### PR TITLE
Issue 163:  Fix Appveyor settings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,9 @@
-
 # Notes:
 #   - Minimal appveyor.yml file is an empty file. All sections are optional.
 #   - Indent each level of configuration with 2 spaces. Do not use tabs!
 #   - All section names are case-sensitive.
 #   - Section names should be unique on each level.
 
-##KimMF workaround VS2017 Build Issues #1761 in Microsoft/visualfsharp 8-6-18 
- 
 
 #---------------------------------#
 #      general configuration      #
@@ -20,7 +17,6 @@ branches:
   # whitelist
   only:
     - develop
-##KimMF 8-6-18
 ##    - release
 ##    - default
 
@@ -40,6 +36,8 @@ clone_depth: 1                       # clone entire repository history if not de
 # fetch repository as zip archive
 shallow_clone: false                 # default is "false"
 
+image: Visual Studio 2015
+
 environment:
   PFX_PASSW:
     secure: 27oXT3aJ48poktx/j1EJew==
@@ -55,12 +53,10 @@ environment:
     DEPLOY: true
   - QT5: Qt\5.9\msvc2015_64
     QMAKE_GENERATOR: "NMake Makefiles JOM"
-    VSVER: 14
     PLATFORM: x64
     DEPLOY: false
   - QT5: Qt\5.9\msvc2015
     QMAKE_GENERATOR: "NMake Makefiles JOM"
-    VSVER: 14
     PLATFORM: x86
     DEPLOY: false
 
@@ -72,29 +68,26 @@ init:
   - set PATH=C:\ProgramData\chocolatey;%QTDIR%\bin;%QTDIR%\include;C:\Tools\PsTools;C:\Windows\system32;C:\Windows;C:\Windows\System32\WindowsPowerShell\v1.0\
   - set PATH=%PATH%;C:\Program Files\Git\cmd\
   - set PATH=%PATH%;C:\Program Files\7-Zip\
-  
- ##KimMF 8-6-18
-  - ps: $env:VSCOMNTOOLS="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\" 
- ### - ps: $env:VSCOMNTOOLS=(Get-Content ("env:VS" + "$env:VSVER" + "0COMNTOOLS"))
-  - if NOT "%QMAKE_GENERATOR%" == "MinGW Makefiles" echo "Using Visual Studio %VSVER%.0 at %VSCOMNTOOLS%"
+
+  - if NOT "%QMAKE_GENERATOR%" == "MinGW Makefiles" echo "Using Visual Studio 2015 at %VS140COMNTOOLS%"
   - if "%QMAKE_GENERATOR%" == "MinGW Makefiles" echo "Using MinGW"
+
   # Set VC variables for the platform
-  - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" if %PLATFORM% == x64 call "%VSCOMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
-  - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" if %PLATFORM% == x86 call "%VSCOMNTOOLS%\..\..\VC\bin\vcvars32.bat"
-  - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" if "%PLATFORM%" == "x86" call "%VSCOMNTOOLS%\..\..\VC\vcvarsall.bat"
+  - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" if "%PLATFORM%" == "x86" call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat"
   - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" if "%PLATFORM%" == "x64" "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
-  - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" if "%PLATFORM%" == "x64" call "%VSCOMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64
+  - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" if "%PLATFORM%" == "x64" call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64
+
   - if "%QMAKE_GENERATOR%" == "MinGW Makefiles" set PATH=%MINGW_PATH%;%PATH%
   - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" set PATH=C:\Qt\Tools\QtCreator\bin;%PATH%
   - set PATH=C:\projects\vpo2\build\src\libs\vpropertyexplorer\bin;C:\projects\vpo2\build\src\libs\qmuparser\bin;%PATH%
   # Path after
   - path
   - qmake -v
- 
+
 install:
   - choco install -y InnoSetup  
-  
-  
+
+
 #---------------------------------#
 #       build configuration       #
 #---------------------------------#
@@ -123,7 +116,7 @@ matrix:
 #---------------------------------#
 #         notifications           #
 #---------------------------------#
-  
+
 notifications:
 # Email
   - provider: Email
@@ -165,7 +158,7 @@ deploy:
     DEPLOY: true
     branch: develop
   artifact: seamly2d-win-$(QT_VERSION)-$(APPVEYOR_REPO_COMMIT)
-  
+
 - provider: BinTray
   username: slspencer
   api_key:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,6 @@ branches:
   only:
     - develop
 ##    - release
-##    - default
 
 # Do not build on tags (GitHub and BitBucket)
 skip_tags: true
@@ -62,9 +61,13 @@ environment:
 
 # scripts that are called at very beginning, before repo cloning
 init:
-  # Path before 
-  - path
   - set QTDIR=C:\%QT5%
+
+    # Prevent pull requests from attempting to sign package.
+  - if NOT "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" set DEPLOY=false
+
+  - path  # Path before
+
   - set PATH=C:\ProgramData\chocolatey;%QTDIR%\bin;%QTDIR%\include;C:\Tools\PsTools;C:\Windows\system32;C:\Windows;C:\Windows\System32\WindowsPowerShell\v1.0\
   - set PATH=%PATH%;C:\Program Files\Git\cmd\
   - set PATH=%PATH%;C:\Program Files\7-Zip\
@@ -80,25 +83,22 @@ init:
   - if "%QMAKE_GENERATOR%" == "MinGW Makefiles" set PATH=%MINGW_PATH%;%PATH%
   - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" set PATH=C:\Qt\Tools\QtCreator\bin;%PATH%
   - set PATH=C:\projects\vpo2\build\src\libs\vpropertyexplorer\bin;C:\projects\vpo2\build\src\libs\qmuparser\bin;%PATH%
-  # Path after
-  - path
+
+  - path  # Path after
+
   - qmake -v
 
 install:
-  - choco install -y InnoSetup  
+  - choco install -y InnoSetup
 
 
 #---------------------------------#
 #       build configuration       #
 #---------------------------------#
 
-before_build:
-  - 7z x C:\projects\vpo2\seamly.7z -p%PFX7z_PASSW%
-  - cd c:\projects\vpo2 
-  - md build
-
 # to run your custom scripts instead of automatic MSBuild
 build_script:
+  - md build
   - cd build
   - if "%DEPLOY%" == "true" (qmake ..\Seamly2D.pro -r CONFIG+=no_ccache CONFIG+=checkWarnings) else (qmake ..\Seamly2D.pro -r CONFIG+=noDebugSymbols CONFIG+=no_ccache CONFIG+=checkWarnings)
   - if not "%QMAKE_GENERATOR%" == "MinGW Makefiles" (nmake -s) else (mingw32-make -j%NUMBER_OF_PROCESSORS%)
@@ -107,7 +107,7 @@ build_script:
 test_script:
   - if "%QMAKE_GENERATOR%" == "MinGW Makefiles" (mingw32-make -s check TESTARGS="-silent")
 
-# to disable automatic tests 
+# to disable automatic tests
 #test: off
 
 matrix:
@@ -118,7 +118,6 @@ matrix:
 #---------------------------------#
 
 notifications:
-# Email
   - provider: Email
     to:
       - dvajdual@gmail.com
@@ -132,10 +131,11 @@ notifications:
 
 # prepare to deploy
 after_test:
+  - if "%DEPLOY%" == "true" 7z x C:\projects\vpo2\seamly.7z -p%PFX7z_PASSW% -o..\
   - if "%DEPLOY%" == "true" (mingw32-make install)
-  - if "%DEPLOY%" == "true" cd "C:\Program Files (x86)\Windows Kits\8.1\bin\x86"  
+  - if "%DEPLOY%" == "true" cd "C:\Program Files (x86)\Windows Kits\8.1\bin\x86"
   - if "%DEPLOY%" == "true" signtool sign /f %PFX_FILE% /p %PFX_PASSW%  /t http://timestamp.comodoca.com /v c:/projects/vpo2/build/package/seamly2d_*.exe
-  - if "%DEPLOY%" == "true" signtool sign /f %PFX_FILE% /p %PFX_PASSW% /fd sha256 /tr http://timestamp.comodoca.com/?td=sha256 /td sha256 /as /v c:/projects/vpo2/build/package/seamly2d_*.exe  
+  - if "%DEPLOY%" == "true" signtool sign /f %PFX_FILE% /p %PFX_PASSW% /fd sha256 /tr http://timestamp.comodoca.com/?td=sha256 /td sha256 /as /v c:/projects/vpo2/build/package/seamly2d_*.exe
   - if "%DEPLOY%" == "true" for %%I in (c:\projects\vpo2\build\package\seamly2d_*.exe) do set artifactName=%%~nI
   - if "%DEPLOY%" == "true" 7z a -tzip -mx1 c:\projects\vpo2\build\package\%artifactName%.zip c:\projects\vpo2\build\package\seamly2d_*.exe
 
@@ -172,4 +172,4 @@ deploy:
   on:
     DEPLOY: true
     branch: master
-  artifact: seamly2d-win-$(QT_VERSION)-$(APPVEYOR_REPO_COMMIT)  
+  artifact: seamly2d-win-$(QT_VERSION)-$(APPVEYOR_REPO_COMMIT)

--- a/common.pri
+++ b/common.pri
@@ -788,6 +788,7 @@ MSVC_DEBUG_CXXFLAGS += \
     # standard library headers, so it's impractical to leave them on.
     -wd4619 \ # there is no warning number 'XXXX'
     -wd4668 \ # XXX is not defined as a preprocessor macro
+    -wd5045 \ # Possible Spectre vulnerability.  TODO: Check flagged areas & fix or suppress warning.
     # Because Microsoft doesn't provide a way to suppress warnings in headers we will suppress
     # all warnings we meet in headers globally
     -wd4548 \


### PR DESCRIPTION
Switched Appveyor back to using Visual Studio 2015 and temporarily disabled VS warning C5045 (Spectre vulnerability warning).  The code flagged by that warning still needs to be properly addressed, whether that's through fixing flaws or suppressing the warning within the code.  

I tested this appveyor setup on my personal account by stripping out things specific to the Seamly account, like encrypted variables & their uses and the deployment section.  The builds succeed without that stuff, but they will fail again now that I've added it back.  This is due to the fact that there remains an issue with the encrypted seamly.7z file and the code signing certificate.

EDIT:  I was wrong about the seamly.7z file and the certificate.  The problem is actually exclusive to pull request builds, and it is due to the way Appveyor handles its encrypted environment variables.  [Secure variables are not decoded during pull requests](https://www.appveyor.com/docs/build-configuration/#secure-variables), so it's trying to use the passwords in their encrypted form, which isn't right.  I addressed this in my second commit.