### PR TITLE
Improved Appveyor Deployment

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,199 +1,143 @@
-
 # Notes:
 #   - Minimal appveyor.yml file is an empty file. All sections are optional.
 #   - Indent each level of configuration with 2 spaces. Do not use tabs!
 #   - All section names are case-sensitive.
 #   - Section names should be unique on each level.
 
-##KimMF workaround VS2017 Build Issues #1761 in Microsoft/visualfsharp 8-6-18 
-##KimMF fixed matrix to deploy only one 
- 
-
 #---------------------------------#
 #      general configuration      #
 #---------------------------------#
 
-# version format
 version: '{build}-{branch}'
+clone_folder: c:\projects\seamly2d
+clone_depth: 3                       # Will clone entire repository history if not defined
+shallow_clone: false
+skip_tags: false
+matrix:
+  fast_finish: false                 # Run all build jobs, even when one fails
 
-# branches to build
-branches:
-  # whitelist
-  only:
-    - develop
-    - release
-    - feature-173
-    - feature-183
-
-# Do not build on tags (GitHub and BitBucket)
-skip_tags: true
 
 #---------------------------------#
 #    environment configuration    #
 #---------------------------------#
 
-# clone directory
-# updated 10/25/2018 slspencer -- replaced vpo2 with seamly2d
-clone_folder: c:\projects\seamly2d
+branches:
+  except:
+    - master    # Builds from master branch are triggered by tags, not commits.
 
-# set clone depth
-clone_depth: 1                       # clone entire repository history if not defined
+image:
+  - Visual Studio 2015
 
-# fetch repository as zip archive
-shallow_clone: false                 # default is "false"
-
-# updated passwords and cert file - slspencer 12/2/2018
 environment:
   PFX_PASSW:
     secure: crIrhNZav7fcHfF6XvKykg==
   PFX7z_PASSW:
     secure: fqZv6LjoFmilkJk7lNfafg==
   PFX_FILE: C:\projects\seamly2d\cert.pfx
-  
-  matrix:
-  
-  - QT5: Qt\5.11\mingw53_32
-    QT_VERSION: Qt5.11
-    QMAKE_GENERATOR: "MinGW Makefiles"
-    MINGW_PATH: C:\Qt\Tools\mingw530_32\bin
-    VSVER: 14  #drop back to workaround VS 2017 changes KMF 11-12-2018
-    PLATFORM: x86
-    DEPLOY: false
-  - QT5: Qt\5.6\mingw49_32
-    QT_VERSION: Qt5.6
-    QMAKE_GENERATOR: "MinGW Makefiles"
-    MINGW_PATH: C:\Qt\Tools\mingw492_32\bin
-    VSVER: 14  #drop back to workaround VS 2017 changes  KMF 11-12-2018
-    PLATFORM: x86
-    DEPLOY: false
-  - QT5: Qt\5.11\msvc2015_64
-    QMAKE_GENERATOR: "NMake Makefiles JOM"
-    VSVER: 14  #drop back to workaround VS 2017 changes  KMF 11-12-2018
-    PLATFORM: x64
-    DEPLOY: false
-  - QT5: Qt\5.11\msvc2015
-    QMAKE_GENERATOR: "NMake Makefiles JOM"
-    VSVER: 14 #drop back to workaround VS 2017 changes  KMF 11-12-2018
-    PLATFORM: x86
-    DEPLOY: false 
-  - QT5: Qt\5.10\mingw53_32
-    QT_VERSION: Qt5.10
-    QMAKE_GENERATOR: "MinGW Makefiles"
-    MINGW_PATH: C:\Qt\Tools\mingw530_32\bin
-    VSVER: 14  #drop back to workaround VS 2017 changes  KMF 11-12-2018
-    PLATFORM: x86
-    DEPLOY: false
-  - QT5: Qt\5.10\msvc2015_64
-    QMAKE_GENERATOR: "NMake Makefiles JOM"
-    VSVER: 14 #drop back to workaround VS 2017 changes KMF 11-12-2018
-    PLATFORM: x64
-    DEPLOY: false
-  - QT5: Qt\5.10\msvc2015
-    QMAKE_GENERATOR: "NMake Makefiles JOM"
-    VSVER: 14  #drop back to workaround VS 2017 changes KMF 11-12-2018
-    PLATFORM: x86
-    DEPLOY: false
-  
-  - QT5: Qt\5.9\mingw53_32
-    QT_VERSION: Qt5.9
-    QMAKE_GENERATOR: "MinGW Makefiles"
-    MINGW_PATH: C:\Qt\Tools\mingw530_32\bin
-    VSVER: 14  #drop back to workaround VS 2017 changes  KMF 11-12-2018
-    PLATFORM: x86
-    DEPLOY: true
-  - QT5: Qt\5.9\msvc2015_64
-    QMAKE_GENERATOR: "NMake Makefiles JOM"
-    VSVER: 14  #drop back to workaround VS 2017 changes  KMF 11-12-2018
-    PLATFORM: x64
-    DEPLOY: false
-  - QT5: Qt\5.9\msvc2015
-    QMAKE_GENERATOR: "NMake Makefiles JOM"
-    VSVER: 14  #drop back to workaround VS 2017 changes  KMF 11-12-2018
-    PLATFORM: x86
-    DEPLOY: false
-    
-  - QT5: Qt\5.6\msvc2015_64
-    QT_VERSION: Qt5.6
-    QMAKE_GENERATOR: "NMake Makefiles JOM"
-    VSVER: 14  #drop back to workaround VS 2017 changes  KMF 11-12-2018
-    PLATFORM: x64
-    DEPLOY: false
-  - QT5: Qt\5.6\msvc2015
-    QT_VERSION: Qt5.6
-    QMAKE_GENERATOR: "NMake Makefiles JOM"
-    VSVER: 14  #drop back to workaround VS 2017 changes KMF 11-12-2018
-    PLATFORM: x86
-    DEPLOY: false
+  DEPLOY: false
 
-# scripts that are called at very beginning, before repo cloning
+  matrix:
+      # Only 1 job should have DEPLOY set to true
+    - QTDIR: C:\Qt\5.9\mingw53_32
+      QT_VERSION: Qt5.9
+      TOOLCHAIN: "GNU"
+      MINGW_PATH: C:\Qt\Tools\mingw530_32\bin
+      DEPLOY: true
+    - QTDIR: C:\Qt\5.9\msvc2015_64
+      QT_VERSION: Qt5.9
+      TOOLCHAIN: "MSVC"
+      PLATFORM: x64
+    - QTDIR: C:\Qt\5.9\msvc2015
+      QT_VERSION: Qt5.9
+      TOOLCHAIN: "MSVC"
+      PLATFORM: x86
+
+    - QTDIR: C:\Qt\5.11\mingw53_32
+      QT_VERSION: Qt5.11
+      TOOLCHAIN: "GNU"
+      MINGW_PATH: C:\Qt\Tools\mingw530_32\bin
+    - QTDIR: C:\Qt\5.11\msvc2015_64
+      QT_VERSION: Qt5.11
+      TOOLCHAIN: "MSVC"
+      PLATFORM: x64
+    - QTDIR: C:\Qt\5.11\msvc2015
+      QT_VERSION: Qt5.11
+      TOOLCHAIN: "MSVC"
+      PLATFORM: x86
+
+
+# Called at the very beginning, before repo cloning.
 init:
-     
-  # Path before 
+  - echo Path before setup:
   - path
-  - set QTDIR=C:\%QT5%
-  
-  ##KMF this is a temporary fix to avoid decryption problems with pull request builds
-  # Prevent pull requests from attempting to sign package.
-  - if NOT "%APPVEYOR_PULL_REQUEST_NUMBER%" == "" set DEPLOY=false
-  
-  - set PATH=C:\ProgramData\chocolatey;%QTDIR%\bin;%QTDIR%\include;C:\Tools\PsTools;C:\Windows\system32;C:\Windows;C:\Windows\System32\WindowsPowerShell\v1.0\
-  - set PATH=%PATH%;C:\Program Files\Git\cmd\
-  - set PATH=%PATH%;C:\Program Files\7-Zip\
-  
-  - ps: $env:VSCOMNTOOLS=(Get-Content ("env:VS" + "$env:VSVER" + "0COMNTOOLS"))
-  - if NOT "%QMAKE_GENERATOR%" == "MinGW Makefiles" echo "Using Visual Studio %VSVER%.0 at %VSCOMNTOOLS%"
-  
-  - if "%QMAKE_GENERATOR%" == "MinGW Makefiles" echo "Using MinGW"
-  # Set VC variables for the platform
-  - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" if %PLATFORM% == x64 call "%VSCOMNTOOLS%\..\..\VC\bin\x86_amd64\vcvarsx86_amd64.bat"
-  - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" if %PLATFORM% == x86 call "%VSCOMNTOOLS%\..\..\VC\bin\vcvars32.bat"
-  - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" if "%PLATFORM%" == "x86" call "%VSCOMNTOOLS%\..\..\VC\vcvarsall.bat"
-  - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" if "%PLATFORM%" == "x64" "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64
-  - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" if "%PLATFORM%" == "x64" call "%VSCOMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64
-  - if "%QMAKE_GENERATOR%" == "MinGW Makefiles" set PATH=%MINGW_PATH%;%PATH%
-  - if "%QMAKE_GENERATOR%" == "NMake Makefiles JOM" set PATH=C:\Qt\Tools\QtCreator\bin;%PATH%
-  # updated 10/25/2018 slspencer -- replaced vpo2 with seamly2d
-  - set PATH=C:\projects\seamly2d\build\src\libs\vpropertyexplorer\bin;C:\projects\seamly2d\build\src\libs\qmuparser\bin;%PATH%
-  # Path after
+
+  - set PATH=%QTDIR%\bin;%QTDIR%\include;C:\Tools\PsTools;C:\Windows\system32;C:\Windows;C:\Program Files\Git\cmd\;C:\Program Files\7-Zip\;C:\Program Files (x86)\Inno Setup 5;C:\projects\seamly2d\build\src\libs\vpropertyexplorer\bin;C:\projects\seamly2d\build\src\libs\qmuparser\bin;
+
+  - if "%TOOLCHAIN%" == "GNU" (echo Using MinGW) else (echo Using %APPVEYOR_BUILD_WORKER_IMAGE%)
+
+  - if "%TOOLCHAIN%" == "MSVC" if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" if "%PLATFORM%" == "x86" call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat"
+  - if "%TOOLCHAIN%" == "MSVC" if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" if "%PLATFORM%" == "x64" call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64
+
+  - if "%TOOLCHAIN%" == "MSVC" if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" if "%PLATFORM%" == "x86" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
+  - if "%TOOLCHAIN%" == "MSVC" if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" if "%PLATFORM%" == "x64" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=amd64
+
+  - if "%TOOLCHAIN%" == "GNU" set PATH=%MINGW_PATH%;%PATH%
+  - if "%TOOLCHAIN%" == "MSVC" set PATH=C:\Qt\Tools\QtCreator\bin;%PATH%
+
+  - echo Path after setup:
   - path
+
   - qmake -v
- 
-install:
-  - choco install -y InnoSetup  
-  
-  
+
+
 #---------------------------------#
 #       build configuration       #
 #---------------------------------#
-#updated 10/25/2018 slspencer -- replaced vpo2 with seamly2d
+
 before_build:
-  - 7z x C:\projects\seamly2d\cert.7z -p%PFX7z_PASSW%
-  - cd c:\projects\seamly2d
-  - md build
+    # TODO: Read version from some other file.
 
-# to run your custom scripts instead of automatic MSBuild
 build_script:
+  - md build
   - cd build
-  - if "%DEPLOY%" == "true" (qmake ..\Seamly2D.pro -r CONFIG+=no_ccache CONFIG+=checkWarnings) else (qmake ..\Seamly2D.pro -r CONFIG+=noDebugSymbols CONFIG+=no_ccache CONFIG+=checkWarnings)
-  - if not "%QMAKE_GENERATOR%" == "MinGW Makefiles" (nmake -s) else (mingw32-make -j%NUMBER_OF_PROCESSORS%)
+  # Only strip debug symbols for production code
+  - if "%APPVEYOR_REPO_TAG%" == "true" (qmake ..\Seamly2D.pro -r CONFIG+=noDebugSymbols CONFIG+=checkWarnings) else (qmake ..\Seamly2D.pro -r CONFIG+=checkWarnings)
+  - if "%TOOLCHAIN%" == "GNU" (mingw32-make -j%NUMBER_OF_PROCESSORS%) else (jom -j %NUMBER_OF_PROCESSORS%) 
 
-# to run your custom scripts instead of automatic tests
+for:
+  -
+    matrix:
+      only:
+        - DEPLOY: true
+
+    after_build:
+      - set DAILY_OR_MASTER=false
+      - if "%APPVEYOR_REPO_TAG%" == "true" set DAILY_OR_MASTER=true
+      - if "%APPVEYOR_SCHEDULED_BUILD%" == "True" set DAILY_OR_MASTER=true
+
+      - if "%TOOLCHAIN%" == "GNU" (mingw32-make install) else (jom install)
+
+      # Only sign code from master (via tag) or develop (via scheduled build)
+      - if "%DAILY_OR_MASTER%" == "true" 7z x C:\projects\seamly2d\cert.7z -p%PFX7z_PASSW%
+      - if "%DAILY_OR_MASTER%" == "true" "C:\Program Files (x86)\Windows Kits\8.1\bin\x86\signtool" sign /f %PFX_FILE% /p %PFX_PASSW%  /t http://timestamp.comodoca.com /v c:/projects/seamly2d/build/package/seamly2d_*.exe
+      - if "%DAILY_OR_MASTER%" == "true" "C:\Program Files (x86)\Windows Kits\8.1\bin\x86\signtool" sign /f %PFX_FILE% /p %PFX_PASSW% /fd sha256 /tr http://timestamp.comodoca.com/?td=sha256 /td sha256 /as /v c:/projects/seamly2d/build/package/seamly2d_*.exe
+
+      - for %%I in (c:\projects\seamly2d\build\package\seamly2d_*.exe) do set artifactName=%%~nI
+      - 7z a -tzip -mx1 c:\projects\seamly2d\build\package\%artifactName%.zip c:\projects\seamly2d\build\package\seamly2d_*.exe
+
+    artifacts:
+      - path: build/package/seamly2d_*.zip
+        name: seamly2d-win-$(QT_VERSION)-$(APPVEYOR_REPO_COMMIT)
+
 test_script:
-  - if "%QMAKE_GENERATOR%" == "MinGW Makefiles" (mingw32-make -s check TESTARGS="-silent")
+  - if "%TOOLCHAIN%" == "GNU" (mingw32-make -s check TESTARGS="-silent")
 
-# to disable automatic tests 
-#test: off
-
-matrix:
-  fast_finish: false
 
 #---------------------------------#
 #         notifications           #
 #---------------------------------#
-  
+
 notifications:
-# Email
-# updated 10/25/2018 -- replaced dvajdual@gmail.com with susan.spencer@gmail.com
   - provider: Email
     to:
       - susan.spencer@gmail.com
@@ -202,51 +146,38 @@ notifications:
     on_build_failure: true
     on_build_status_changed: true
 
+
 #---------------------------------#
 #         deployment              #
 #---------------------------------#
 
-# prepare to deploy
-# updated 10/25/2018 slspencer -- replaced vpo2 with seamly2d
-after_test:
-  - if "%DEPLOY%" == "true" (mingw32-make install)
-  - if "%DEPLOY%" == "true" cd "C:\Program Files (x86)\Windows Kits\8.1\bin\x86"  
-  - if "%DEPLOY%" == "true" signtool sign /f %PFX_FILE% /p %PFX_PASSW%  /t http://timestamp.comodoca.com /v c:/projects/seamly2d/build/package/seamly2d_*.exe
-  - if "%DEPLOY%" == "true" signtool sign /f %PFX_FILE% /p %PFX_PASSW% /fd sha256 /tr http://timestamp.comodoca.com/?td=sha256 /td sha256 /as /v c:/projects/seamly2d/build/package/seamly2d_*.exe  
-  - if "%DEPLOY%" == "true" for %%I in (c:\projects\seamly2d\build\package\seamly2d_*.exe) do set artifactName=%%~nI
-  - if "%DEPLOY%" == "true" 7z a -tzip -mx1 c:\projects\seamly2d\build\package\%artifactName%.zip c:\projects\seamly2d\build\package\seamly2d_*.exe
-
-artifacts:
-  - path: build/package/seamly2d_*.zip
-    name: seamly2d-win-$(QT_VERSION)-$(APPVEYOR_REPO_COMMIT)
-
 deploy:
-- provider: BinTray
-  username: slspencer
-  api_key:
-    secure: xnl+xCbtLd5ACm3NM9wJylajIGRJ59JvmZSz5M4bLn2Elw9d6H2sTa8XXGZTgZw+
-  subject: fashionfreedom
-  repo: Seamly2D
-  package: Seamly2D-win_auto-upload
-  publish: true
-  override: true
-  version: 0.6.0.1
-  on:
-    DEPLOY: true
-    branch: develop
-  artifact: seamly2d-win-$(QT_VERSION)-$(APPVEYOR_REPO_COMMIT)
-  
-- provider: BinTray
-  username: slspencer
-  api_key:
-    secure: xnl+xCbtLd5ACm3NM9wJylajIGRJ59JvmZSz5M4bLn2Elw9d6H2sTa8XXGZTgZw+
-  subject: fashionfreedom
-  repo: Seamly2D
-  package: Seamly2D-win_release
-  publish: true
-  override: true
-  version: 0.6.0.1
-  on:
-    DEPLOY: true
-    branch: master
-  artifact: seamly2d-win-$(QT_VERSION)-$(APPVEYOR_REPO_COMMIT)  
+  - provider: BinTray
+    username: slspencer
+    api_key:
+      secure: xnl+xCbtLd5ACm3NM9wJylajIGRJ59JvmZSz5M4bLn2Elw9d6H2sTa8XXGZTgZw+
+    subject: fashionfreedom
+    repo: Seamly2D
+    package: Seamly2D-win_auto-upload
+    publish: true
+    override: true
+    version: 0.6.0.1
+    on:
+      DEPLOY: true
+      APPVEYOR_SCHEDULED_BUILD: True
+    artifact: seamly2d-win-$(QT_VERSION)-$(APPVEYOR_REPO_COMMIT)
+
+  - provider: BinTray
+    username: slspencer
+    api_key:
+      secure: xnl+xCbtLd5ACm3NM9wJylajIGRJ59JvmZSz5M4bLn2Elw9d6H2sTa8XXGZTgZw+
+    subject: fashionfreedom
+    repo: Seamly2D
+    package: Seamly2D-win_release
+    publish: true
+    override: true
+    version: 0.6.0.1
+    on:
+      DEPLOY: true
+      APPVEYOR_REPO_TAG: true
+    artifact: seamly2d-win-$(QT_VERSION)-$(APPVEYOR_REPO_COMMIT)


### PR DESCRIPTION
This version will build commits to all branches except for master.  The master branch is instead built and deployed by pushing a new tag.  The develop branch will build each commit but will only deploy during scheduled daily builds, which must be configured using the Appveyor GUI.  The feature is available for free accounts, but is disabled by default.  Susan will need to reach out to Appveyor support in order to have it enabled if she has not done so already.  I'd suggest not configuring the daily builds until they are set up on Travis CI, too. 

