### PR TITLE
Updated the SizeAdjustPolicy of the QAbstractScrollArea (Issue #193)

### DIFF
--- a/src/app/seamly2d/mainwindow.ui
+++ b/src/app/seamly2d/mainwindow.ui
@@ -1625,6 +1625,9 @@
       <property name="horizontalScrollBarPolicy">
        <enum>Qt::ScrollBarAlwaysOn</enum>
       </property>
+      <property name="sizeAdjustPolicy">
+       <enum>QAbstractScrollArea::AdjustToContents</enum>
+      </property>
      </widget>
     </item>
    </layout>


### PR DESCRIPTION
This is my fix for issue #193.  To test, open a larg(ish) pattern and observe the scrolling behaviour when zoomed in close.  It should be noticeably more "comfortable".