### PR TITLE
remove xpdf dependency

### DIFF
--- a/dist/debian/control
+++ b/dist/debian/control
@@ -16,7 +16,7 @@ Vcs-Browser: https://github.com/fashionfreedom/seamly2d
 
 Package: seamly2d
 Architecture: i386 amd64
-Depends: libc6 (>= 2.4), libgcc1 (>= 1:4.1.1), libqt5core5a (>= 5.2.0) | libqt5core5 (>= 5.2.0), libqt5gui5 (>= 5.2.0) | libqt5gui5-gles (>= 5.2.0), libqt5printsupport5 (>= 5.2.0), libqt5svg5 (>= 5.2.0), libqt5widgets5 (>= 5.2.0), libqt5xml5 (>= 5.2.0), libqt5xmlpatterns5 (>= 5.2.0), libstdc++6 (>= 4.6), xpdf
+Depends: libc6 (>= 2.4), libgcc1 (>= 1:4.1.1), libqt5core5a (>= 5.2.0) | libqt5core5 (>= 5.2.0), libqt5gui5 (>= 5.2.0) | libqt5gui5-gles (>= 5.2.0), libqt5printsupport5 (>= 5.2.0), libqt5svg5 (>= 5.2.0), libqt5widgets5 (>= 5.2.0), libqt5xml5 (>= 5.2.0), libqt5xmlpatterns5 (>= 5.2.0), libstdc++6 (>= 4.6)
 Description: Pattern making program.
  Seamly2D is a free and opensource patternmaking program for Windows, Mac, and 
  Linux. Seamly2D enables creative parametric patterns which conform to an


### PR DESCRIPTION
Update dist/debian/control to remove xpdf dependency.  This primarily is an issue in the build performed on launchpad and affects users of FOCAL (Ubuntu 20.04 LTS).  This will probably not show up as an issue once appimage version is created, nor will it affect users of releases of Ubuntu earlier than 18.10