### PR TITLE
don't automate the VC++ redistributable install

### DIFF
--- a/dist/seamly2d-installer.nsi
+++ b/dist/seamly2d-installer.nsi
@@ -30,9 +30,9 @@ Section "Seamly2D"
 
   !include "x64.nsh"
   ${If} ${RunningX64}
-    ExecWait '"$INSTDIR\VC_redist.x64.exe"  /passive /norestart'
+    ExecWait '"$INSTDIR\VC_redist.x64.exe"  /norestart'
   ${Else}
-    ExecWait '"$INSTDIR\VC_redist.x86.exe"  /passive /norestart'
+    ExecWait '"$INSTDIR\VC_redist.x86.exe"  /norestart'
   ${EndIf}
 
   ; relative to the location of this .nsi file, copy all the files/directories recursively


### PR DESCRIPTION
Allow the user to answer any prompts shown by the VC++ redistributable
installer