### PR TITLE
Appimage fix

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -62,7 +62,7 @@ jobs:
 
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
           --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-          -v /home/user/local:/app/usr \
+          -v /home/runner/local:/app/usr \
           --rm lucaszanella/linuxdeployqt /bin/bash builder.sh "-executable=/app/usr/bin/seamlyme"
 
           mv /home/runner/local/Seamly2D*.AppImage Seamly2D.AppImage
@@ -73,7 +73,7 @@ jobs:
 
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
           --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-          -v /home/user/local:/app/usr \
+          -v /home/runner/local:/app/usr \
           --rm lucaszanella/linuxdeployqt /bin/bash builder.sh
 
           mv /home/runner/local/SeamlyMe*.AppImage SeamlyMe.AppImage

--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -62,8 +62,6 @@ jobs:
 
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
             --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-            --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-            -v /home/runner/local:/app/usr \
             -v /home/runner/local:/app/usr \
             -e EXTRA_BINARIES="seamlyme" \
             --rm mhitza/linuxdeployqt:5.13.2
@@ -76,8 +74,6 @@ jobs:
 
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
             --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-            --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-            -v /home/runner/local:/app/usr \
             -v /home/runner/local:/app/usr \
             --rm mhitza/linuxdeployqt:5.13.2
 

--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -55,28 +55,28 @@ jobs:
 
       - name: AppImages
         run: |
-        mkdir -p /home/runner/local/share/applications /home/runner/local/share/icons/hicolor/256x256
+          mkdir -p /home/runner/local/share/applications /home/runner/local/share/icons/hicolor/256x256
 
-        cp dist/seamly2d.desktop /home/runner/local/share/applications/
-        cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamly2d.png
+          cp dist/seamly2d.desktop /home/runner/local/share/applications/
+          cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamly2d.png
 
-        docker run --cap-add SYS_ADMIN --device /dev/fuse \
-        --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-        -v /home/user/local:/app/usr \
-        --rm lucaszanella/linuxdeployqt /bin/bash builder.sh "-executable=/app/usr/bin/seamlyme"
+          docker run --cap-add SYS_ADMIN --device /dev/fuse \
+          --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
+          -v /home/user/local:/app/usr \
+          --rm lucaszanella/linuxdeployqt /bin/bash builder.sh "-executable=/app/usr/bin/seamlyme"
 
-        mv /home/runner/local/Seamly2D*.AppImage Seamly2D.AppImage
-        cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamlyme.png
+          mv /home/runner/local/Seamly2D*.AppImage Seamly2D.AppImage
+          cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamlyme.png
 
-        rm /home/runner/local/share/applications/seamly2d.desktop
-        cp dist/seamlyme.desktop /home/runner/local/share/applications
+          rm /home/runner/local/share/applications/seamly2d.desktop
+          cp dist/seamlyme.desktop /home/runner/local/share/applications
 
-        docker run --cap-add SYS_ADMIN --device /dev/fuse \
-        --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-        -v /home/user/local:/app/usr \
-        --rm lucaszanella/linuxdeployqt /bin/bash builder.sh
+          docker run --cap-add SYS_ADMIN --device /dev/fuse \
+          --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
+          -v /home/user/local:/app/usr \
+          --rm lucaszanella/linuxdeployqt /bin/bash builder.sh
 
-        mv /home/runner/local/SeamlyMe*.AppImage SeamlyMe.AppImage
+          mv /home/runner/local/SeamlyMe*.AppImage SeamlyMe.AppImage
 
       - name: upload Seamly2D.AppImage
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -63,7 +63,7 @@ jobs:
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
             --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
             -v /home/runner/local:/app/usr \
-            --rm mhitza/linuxdeployqt:5.13.2
+            --rm lucaszanella/linuxdeployqt /bin/bash make_seamly2d_appimage.sh
 
           mv /home/runner/local/Seamly2D*.AppImage Seamly2D.AppImage
           cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamlyme.png
@@ -74,7 +74,7 @@ jobs:
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
             --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
             -v /home/runner/local:/app/usr \
-            --rm mhitza/linuxdeployqt:5.13.2
+            --rm lucaszanella/linuxdeployqt /bin/bash make_seamlyme_appimage.sh
 
           mv /home/runner/local/SeamlyMe*.AppImage SeamlyMe.AppImage
 

--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -61,9 +61,12 @@ jobs:
           cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamly2d.png
 
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
-          --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-          -v /home/runner/local:/app/usr \
-          --rm lucaszanella/linuxdeployqt /bin/bash builder.sh "-executable=/app/usr/bin/seamlyme"
+            --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
+            --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
+            -v /home/runner/local:/app/usr \
+            -v /home/runner/local:/app/usr \
+            -e EXTRA_BINARIES="seamlyme" \
+            --rm mhitza/linuxdeployqt:5.13.2
 
           mv /home/runner/local/Seamly2D*.AppImage Seamly2D.AppImage
           cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamlyme.png
@@ -72,9 +75,11 @@ jobs:
           cp dist/seamlyme.desktop /home/runner/local/share/applications
 
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
-          --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-          -v /home/runner/local:/app/usr \
-          --rm lucaszanella/linuxdeployqt /bin/bash builder.sh
+            --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
+            --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
+            -v /home/runner/local:/app/usr \
+            -v /home/runner/local:/app/usr \
+            --rm mhitza/linuxdeployqt:5.13.2
 
           mv /home/runner/local/SeamlyMe*.AppImage SeamlyMe.AppImage
 

--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -55,28 +55,28 @@ jobs:
 
       - name: AppImages
         run: |
-          mkdir -p /home/runner/local/share/applications /home/runner/local/share/icons/hicolor/256x256
+        mkdir -p /home/runner/local/share/applications /home/runner/local/share/icons/hicolor/256x256
 
-          cp dist/seamly2d.desktop /home/runner/local/share/applications/
-          cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamly2d.png
+        cp dist/seamly2d.desktop /home/runner/local/share/applications/
+        cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamly2d.png
 
-          docker run --cap-add SYS_ADMIN --device /dev/fuse \
-          --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-          -v /home/user/local:/app/usr \
-          --rm linuxdeployqt /bin/bash builder.sh "-executable=/app/usr/bin/seamlyme"
+        docker run --cap-add SYS_ADMIN --device /dev/fuse \
+        --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
+        -v /home/user/local:/app/usr \
+        --rm lucaszanella/linuxdeployqt /bin/bash builder.sh "-executable=/app/usr/bin/seamlyme"
 
-          mv /home/runner/local/Seamly2D*.AppImage Seamly2D.AppImage
-          cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamlyme.png
+        mv /home/runner/local/Seamly2D*.AppImage Seamly2D.AppImage
+        cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamlyme.png
 
-          rm /home/runner/local/share/applications/seamly2d.desktop
-          cp dist/seamlyme.desktop /home/runner/local/share/applications
+        rm /home/runner/local/share/applications/seamly2d.desktop
+        cp dist/seamlyme.desktop /home/runner/local/share/applications
 
-          docker run --cap-add SYS_ADMIN --device /dev/fuse \
-          --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-          -v /home/user/local:/app/usr \
-          --rm linuxdeployqt /bin/bash builder.sh
+        docker run --cap-add SYS_ADMIN --device /dev/fuse \
+        --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
+        -v /home/user/local:/app/usr \
+        --rm lucaszanella/linuxdeployqt /bin/bash builder.sh
 
-          mv /home/runner/local/SeamlyMe*.AppImage SeamlyMe.AppImage
+        mv /home/runner/local/SeamlyMe*.AppImage SeamlyMe.AppImage
 
       - name: upload Seamly2D.AppImage
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -61,9 +61,9 @@ jobs:
           cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamly2d.png
 
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
-            --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-            -v /home/runner/local:/app/usr \
-            --rm lucaszanella/linuxdeployqt /bin/bash make_seamly2d_appimage.sh
+          --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
+          -v /home/user/local:/app/usr \
+          --rm linuxdeployqt /bin/bash builder.sh "-executable=/app/usr/bin/seamlyme"
 
           mv /home/runner/local/Seamly2D*.AppImage Seamly2D.AppImage
           cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamlyme.png
@@ -72,9 +72,9 @@ jobs:
           cp dist/seamlyme.desktop /home/runner/local/share/applications
 
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
-            --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-            -v /home/runner/local:/app/usr \
-            --rm lucaszanella/linuxdeployqt /bin/bash make_seamlyme_appimage.sh
+          --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
+          -v /home/user/local:/app/usr \
+          --rm linuxdeployqt /bin/bash builder.sh
 
           mv /home/runner/local/SeamlyMe*.AppImage SeamlyMe.AppImage
 

--- a/.github/workflows/build-weekly-release.yml
+++ b/.github/workflows/build-weekly-release.yml
@@ -87,7 +87,7 @@ jobs:
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
           --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
           -v /home/user/local:/app/usr \
-          --rm linuxdeployqt /bin/bash builder.sh "-executable=/app/usr/bin/seamlyme"
+          --rm lucaszanella/linuxdeployqt /bin/bash builder.sh "-executable=/app/usr/bin/seamlyme"
 
           mv /home/runner/local/Seamly2D*.AppImage Seamly2D.AppImage
           cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamlyme.png
@@ -98,7 +98,7 @@ jobs:
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
           --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
           -v /home/user/local:/app/usr \
-          --rm linuxdeployqt /bin/bash builder.sh
+          --rm lucaszanella/linuxdeployqt /bin/bash builder.sh
 
           mv /home/runner/local/SeamlyMe*.AppImage SeamlyMe.AppImage
 

--- a/.github/workflows/build-weekly-release.yml
+++ b/.github/workflows/build-weekly-release.yml
@@ -85,9 +85,10 @@ jobs:
           cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamly2d.png
 
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
-          --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-          -v /home/runner/local:/app/usr \
-          --rm lucaszanella/linuxdeployqt /bin/bash builder.sh "-executable=/app/usr/bin/seamlyme"
+            --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
+            -v /home/runner/local:/app/usr \
+            -e EXTRA_BINARIES="seamlyme" \
+            --rm mhitza/linuxdeployqt:5.13.2
 
           mv /home/runner/local/Seamly2D*.AppImage Seamly2D.AppImage
           cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamlyme.png
@@ -96,9 +97,9 @@ jobs:
           cp dist/seamlyme.desktop /home/runner/local/share/applications
 
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
-          --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-          -v /home/runner/local:/app/usr \
-          --rm lucaszanella/linuxdeployqt /bin/bash builder.sh
+            --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
+            -v /home/runner/local:/app/usr \
+            --rm mhitza/linuxdeployqt:5.13.2
 
           mv /home/runner/local/SeamlyMe*.AppImage SeamlyMe.AppImage
 

--- a/.github/workflows/build-weekly-release.yml
+++ b/.github/workflows/build-weekly-release.yml
@@ -86,7 +86,7 @@ jobs:
 
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
           --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-          -v /home/user/local:/app/usr \
+          -v /home/runner/local:/app/usr \
           --rm lucaszanella/linuxdeployqt /bin/bash builder.sh "-executable=/app/usr/bin/seamlyme"
 
           mv /home/runner/local/Seamly2D*.AppImage Seamly2D.AppImage
@@ -97,7 +97,7 @@ jobs:
 
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
           --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-          -v /home/user/local:/app/usr \
+          -v /home/runner/local:/app/usr \
           --rm lucaszanella/linuxdeployqt /bin/bash builder.sh
 
           mv /home/runner/local/SeamlyMe*.AppImage SeamlyMe.AppImage

--- a/.github/workflows/build-weekly-release.yml
+++ b/.github/workflows/build-weekly-release.yml
@@ -85,9 +85,9 @@ jobs:
           cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamly2d.png
 
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
-            --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-            -v /home/runner/local:/app/usr \
-            --rm mhitza/linuxdeployqt:5.13.2
+          --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
+          -v /home/user/local:/app/usr \
+          --rm linuxdeployqt /bin/bash builder.sh "-executable=/app/usr/bin/seamlyme"
 
           mv /home/runner/local/Seamly2D*.AppImage Seamly2D.AppImage
           cp share/img/Seamly2D_logo_254x254.png /home/runner/local/share/icons/hicolor/256x256/seamlyme.png
@@ -96,9 +96,9 @@ jobs:
           cp dist/seamlyme.desktop /home/runner/local/share/applications
 
           docker run --cap-add SYS_ADMIN --device /dev/fuse \
-            --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
-            -v /home/runner/local:/app/usr \
-            --rm mhitza/linuxdeployqt:5.13.2
+          --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
+          -v /home/user/local:/app/usr \
+          --rm linuxdeployqt /bin/bash builder.sh
 
           mv /home/runner/local/SeamlyMe*.AppImage SeamlyMe.AppImage
 


### PR DESCRIPTION
AppImage bundler runs ldd on the binary pointed by the .desktop file (in this case, seamly2d). Only those binaries are included in the appimage. Turns out we can pass other binaries with `-executable=path/to/binary`. The docker image docker-linuxdeployqt got changed to accomodate this new option as an environment variable, which is now included in the github workflow