### PR TITLE
#277 Deliver .dmg files as single .zip file

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -57,25 +57,19 @@ jobs:
           hdiutil create -fs HFS+ -srcfolder src/app/seamly2d/bin/Seamly2D.app -volname "Seamly2D" Seamly2D.dmg
           hdiutil create -fs HFS+ -srcfolder src/app/seamlyme/bin/seamlyme.app -volname "SeamlyME" SeamlyME.dmg
 
-      - name: upload Seamly2D.dmg
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: ./Seamly2D.dmg
-          asset_name: Seamly2D.dmg
-          asset_content_type: application/x-apple-diskimage
+      - name: pack package files into .zip
+        run: |
+          zip Seamly2D.zip Seamly2D.dmg SeamlyME.dmg
 
-      - name: upload SeamlyME.dmg
+      - name: upload Seamly2D.zip
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: ./SeamlyME.dmg
-          asset_name: SeamlyME.dmg
-          asset_content_type: application/x-apple-diskimage
+          asset_path: ./Seamly2D.zip
+          asset_name: Seamly2D.zip
+          asset_content_type: application/zip
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/build-weekly-release.yml
+++ b/.github/workflows/build-weekly-release.yml
@@ -84,25 +84,19 @@ jobs:
           hdiutil create -fs HFS+ -srcfolder src/app/seamly2d/bin/Seamly2D.app -volname "Seamly2D" Seamly2D.dmg
           hdiutil create -fs HFS+ -srcfolder src/app/seamlyme/bin/seamlyme.app -volname "SeamlyME" SeamlyME.dmg
 
-      - name: upload Seamly2D.dmg
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: ./Seamly2D.dmg
-          asset_name: Seamly2D.dmg
-          asset_content_type: application/x-apple-diskimage
+      - name: pack package files into .zip
+        run: |
+          zip Seamly2D.zip Seamly2D.dmg SeamlyME.dmg
 
-      - name: upload SeamlyME.dmg
+      - name: upload Seamly2D.zip
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: ./SeamlyME.dmg
-          asset_name: SeamlyME.dmg
-          asset_content_type: application/x-apple-diskimage
+          asset_path: ./Seamly2D.zip
+          asset_name: Seamly2D.zip
+          asset_content_type: application/zip
 
   windows:
     runs-on: windows-latest


### PR DESCRIPTION
It changes pipelines so that the .dmg files for macOS would be delivered as single .zip file.