### PR TITLE
#279 Create application's directories on startup in user's home directory

### DIFF
--- a/src/app/seamly2d/core/vapplication.cpp
+++ b/src/app/seamly2d/core/vapplication.cpp
@@ -605,6 +605,15 @@ void VApplication::InitOptions()
         //This does not happen under GNOME or KDE
         QIcon::setThemeName("win.icon.theme");
     }
+
+    OpenSettings();
+    VSettings *settings = Seamly2DSettings();
+    QDir().mkpath(settings->GetDefPathLayout());
+    QDir().mkpath(settings->GetDefPathPattern());
+    QDir().mkpath(settings->GetDefPathIndividualMeasurements());
+    QDir().mkpath(settings->GetDefPathMultisizeMeasurements());
+    QDir().mkpath(settings->GetDefPathTemplate());
+    QDir().mkpath(settings->GetDefPathLabelTemplate());
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/app/seamlyme/mapplication.cpp
+++ b/src/app/seamlyme/mapplication.cpp
@@ -404,6 +404,11 @@ void MApplication::InitOptions()
     qInstallMessageHandler(noisyFailureMsgHandler);
 
     OpenSettings();
+    VSeamlyMeSettings *settings = SeamlyMeSettings();
+    QDir().mkpath(settings->GetDefPathTemplate());
+    QDir().mkpath(settings->GetDefPathIndividualMeasurements());
+    QDir().mkpath(settings->GetDefPathMultisizeMeasurements());
+    QDir().mkpath(settings->GetDefPathLabelTemplate());
 
     qCDebug(mApp, "Version: %s", qUtf8Printable(APP_VERSION_STR));
     qCDebug(mApp, "Build revision: %s", BUILD_REVISION);


### PR DESCRIPTION
It allows to create the following directories on the application start:
```
seamly2d/
seamly2d/layouts/
seamly2d/measurements/
seamly2d/measurements/individual/
seamly2d/measurements/multisize/
seamly2d/patterns/
seamly2d/templates/
seamly2d/label templates/
```