### PR TITLE
Revert "Build: Update debian to qt 5.9.5 (bionic) issue #320"

### DIFF
--- a/dist/debian/control
+++ b/dist/debian/control
@@ -3,31 +3,25 @@ Section: graphics
 Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 XSBC-Original-Maintainer: Susan Spencer <susan.spencer@gmail.com>
-Build-Depends: debhelper (>= 11.1.6),
-               build-essential (>= 12.4),
-               g++ (>= 7.3.0-12),
-               libglu1-mesa-dev (>= 9.0.0-2.1)
-               qtbase5-dev (>= 5.9.5),
-               qt5-default (>= 5.9.5),
-               qttools5-dev-tools (>= 5.9.5),
-               qt5-image-formats-plugins (>= 5.9.5),
-               qt5-qmltooling-plugins (>=5.9.5),
-               qtwayland5 (>= 5.9.5),
-               libqt5svg5-dev (>= 5.9.5),
-               libqt5xmlpatterns5-dev (>= 5.9.5),
-               libqt5opengl5-dev (>= 5.9.5)
+Build-Depends: debhelper (>= 9.0.0), 
+               qtbase5-dev (>= 5.2.0), 
+               libqt5svg5-dev (>= 5.2.0), 
+               g++ (>= 4.7.0), 
+               qt5-default (>= 5.2.0), 
+               qttools5-dev-tools (>= 5.2.0), 
+               libqt5xmlpatterns5-dev (>= 5.2.0)
 Standards-Version: 3.9.5
-Homepage: https://seamly.net
+Homepage: https://fashionfreedom.eu/
 Vcs-Browser: https://github.com/fashionfreedom/seamly2d
 
 Package: seamly2d
 Architecture: i386 amd64
-Depends: libc6 (>= 2.14), libgcc1 (>= 1:3.5), libqt5core5a (>= 5.9.5), libqt5gui5 (>= 5.9.5), libqt5printsupport5 (>= 5.9.5), libqt5svg5 (>= 5.9.5), libqt5widgets5 (>= 5.9.5), libqt5xml5 (>= 5.9.5), libqt5xmlpatterns5 (>= 5.9.5), libstdc++6 (>= 8.4.0)
-Description: Custom-fit pattern design program.
- Seamly2D is a free and opensource pattern design program for Windows, Mac, and
+Depends: libc6 (>= 2.4), libgcc1 (>= 1:4.1.1), libqt5core5a (>= 5.2.0) | libqt5core5 (>= 5.2.0), libqt5gui5 (>= 5.2.0) | libqt5gui5-gles (>= 5.2.0), libqt5printsupport5 (>= 5.2.0), libqt5svg5 (>= 5.2.0), libqt5widgets5 (>= 5.2.0), libqt5xml5 (>= 5.2.0), libqt5xmlpatterns5 (>= 5.2.0), libstdc++6 (>= 4.6)
+Description: Pattern making program.
+ Seamly2D is a free and opensource patternmaking program for Windows, Mac, and 
  Linux. Seamly2D enables creative parametric patterns which conform to an
- individual's body measurements and to multiple sizing tables. Seamly2D blends
- new technologies with traditional methods to remove Victorian-era gender,
- ethnic, and size biases from clothing design. Seamly2D is created to
- allow independent patternmakers and designers to profitably scale
+ individual's body measurements and to multiple sizing tables. Seamly2D blends 
+ new technologies with traditional methods to remove Victorian-era gender, 
+ ethnic, and size biases from clothing design. Seamly2D is created to 
+ allow independent patternmakers and designers to profitably scale 
  their small batch clothing production.


### PR DESCRIPTION
Reverts FashionFreedom/Seamly2D#321 
Updates /dist/debian/control file from minimum version Qt 5.2 to minimum Qt 5.9.5 - 
This file only controls the build at launchpad.net for the Ubuntu ppa 