### PR TITLE
ci: actions linux runners downgrade to ubuntu-18.04

### DIFF
--- a/.github/workflows/build-release-assets.yml
+++ b/.github/workflows/build-release-assets.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: jurplel/install-qt-action@v2.10.0

--- a/.github/workflows/build-weekly-release.yml
+++ b/.github/workflows/build-weekly-release.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   create-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     outputs:
       upload_url: ${{ steps.create-release.outputs.upload_url }}
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   build-test:
     name: 'Build & Test'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: jurplel/install-qt-action@v2.10.0


### PR DESCRIPTION
Just happened to notice that the last weekly release failed with GLIBC version error.

Initially, I thought it might just be related to linuxdeployqt, however, it just seems that the seamly2d is linked against some version of `libm.so.6` that requires a newer version of Glibc on ubuntu-latest (which would likely be Ubuntu 20.04 at this point).

Forked repo build without the change, and with the https://github.com/mhitza/Seamly2D/runs/1964694740?check_suite_focus=true https://github.com/mhitza/Seamly2D/runs/1964868715?check_suite_focus=true.

Personally, I'm not sure why this error happens. As a linked library is looked up by linuxdeployqt within the docker container, which should not contain dynamic libraries that link to Glibc versions that are not packaged within the container itself :thinking: 

But somehow this downgrade fixes the build...