### PR TITLE
Linux build error 

### DIFF
--- a/.github/workflows/build-linux-pkg.sh
+++ b/.github/workflows/build-linux-pkg.sh
@@ -27,7 +27,6 @@ docker run --cap-add SYS_ADMIN --device /dev/fuse \
     --security-opt apparmor:unconfined --security-opt seccomp=unconfined \
     -v $buildDirPath:/app/usr \
     -e EXTRA_BINARIES="seamlyme" \
-    --rm mhitza/linuxdeployqt:"$QT_VERSION" \
-    gcc:9.3 gcc
+    --rm mhitza/linuxdeployqt:"$QT_VERSION"
 
 mv $buildDirPath/Seamly2D*.AppImage Seamly2D.AppImage


### PR DESCRIPTION
With the removal of the added gcc line I was able to have the build run and package the AppImage without issues[0]. However, the latest linuxdeployqt docker images have been updated to use the latest version of linuxdeployqt (version 7, while previously it was version 6)

However, I had a hard time following through the failed weekly builds to figure out why an updated version GCC is required within the container that packages the AppImage. One of the errors I noticed at one time within the failed build logs was that libm.so did not find the exact GLIBC version it was looking for. If a newer version of Glibc is necessary *that is problematic*, as linuxdeployqt will just exit when it finds a newer version of Glibc on the system, than the one that ships on Ubuntu 16.04.

[0] the build workflow on my fork https://github.com/mhitza/Seamly2D/runs/2231491561?check_suite_focus=true 