### PR TITLE
Continuous appimage

### DIFF
--- a/.github/workflows/build-continuous-linux.yml
+++ b/.github/workflows/build-continuous-linux.yml
@@ -1,0 +1,38 @@
+name: Build weekly release
+
+on:
+  push: 
+
+env:
+  QT_SELECT: 5
+
+  # See https://wiki.qt.io/Qt_5.13_Release
+  # The project is currently incompatible with Qt-5.15/5.14.2
+  # When chaning the version information in this file be sure to change it in
+  # pull-request.yml as well
+  QT_VERSION: '5.13.2' # quotes required or YAML parser will interpret as float
+
+jobs:
+  linux:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: jurplel/install-qt-action@v2.13.0
+        with:
+          version: ${{ env.QT_VERSION }}
+
+      - name: build
+        run: |
+          sudo wget https://github.com/AppImageCrafters/appimage-builder/releases/download/v0.8.8/appimage-builder-0.8.8-4e7c15f-x86_64.AppImage -O /usr/local/bin/appimage-builder
+          sudo chmod +x /usr/local/bin/appimage-builder
+          appimage-builder --recipe dist/appimage-builder-recipe.yml --skip-test
+
+      - name: upload Seamly2D.AppImage
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ env.UPLOAD_URL }}
+          asset_path: ./*.AppImage*
+          asset_name: Seamly2D.AppImage
+          asset_content_type: application/octet-stream

--- a/.github/workflows/build-continuous-linux.yml
+++ b/.github/workflows/build-continuous-linux.yml
@@ -3,27 +3,17 @@ name: Build weekly release
 on:
   push: 
 
-env:
-  QT_SELECT: 5
-
-  # See https://wiki.qt.io/Qt_5.13_Release
-  # The project is currently incompatible with Qt-5.15/5.14.2
-  # When chaning the version information in this file be sure to change it in
-  # pull-request.yml as well
-  QT_VERSION: '5.13.2' # quotes required or YAML parser will interpret as float
-
 jobs:
   linux:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2.3.4
-      - uses: jurplel/install-qt-action@v2.13.0
-        with:
-          version: ${{ env.QT_VERSION }}
-
+      - name: Install Qt5
+        run: |
+          sudo apt-get install -y build-essential gettext qttools5-dev libqt5svg5-dev libqt5xmlpatterns5-dev
       - name: build
         run: |
-          sudo wget https://github.com/AppImageCrafters/appimage-builder/releases/download/v0.8.8/appimage-builder-0.8.8-4e7c15f-x86_64.AppImage -O /usr/local/bin/appimage-builder
+          sudo wget -q https://github.com/AppImageCrafters/appimage-builder/releases/download/v0.8.8/appimage-builder-0.8.8-4e7c15f-x86_64.AppImage -O /usr/local/bin/appimage-builder
           sudo chmod +x /usr/local/bin/appimage-builder
           appimage-builder --recipe dist/appimage-builder-recipe.yml --skip-test
 

--- a/dist/appimage-builder-recipe.yml
+++ b/dist/appimage-builder-recipe.yml
@@ -1,0 +1,92 @@
+# appimage-builder recipe see https://appimage-builder.readthedocs.io for details
+version: 1
+script:
+  - rm -rf AppDir || true
+  - qmake PREFIX=/usr Seamly2D.pro -r CONFIG+=no_ccache CONFIG+=noDebugSymbols
+  - INSTALL_ROOT=$PWD/AppDir make install -j$(nproc)
+  # place the icon in the right path
+  - mkdir -p AppDir/usr/share/icons/hicolor/64x64/apps/
+  - cp AppDir/usr/share/pixmaps/seamly2d.png AppDir/usr/share/icons/hicolor/64x64/apps/
+
+AppDir:
+  path: ./AppDir
+  app_info:
+    id: net.seamly.seamly2d
+    name: Seamly2D
+    icon: seamly2d
+    version: latest
+    exec: usr/bin/seamly2d
+    exec_args: $@
+  apt:
+    arch: amd64
+    allow_unauthenticated: true
+    sources:
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
+    - sourceline: deb http://security.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
+    - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
+    include:
+    - libqt5svg5
+    - libqt5xml5
+    - liblz4-1
+    - libxshmfence1
+    - libxrender1
+    - qt5-image-formats-plugins
+    - libxcb-render-util0
+    - qttranslations5-l10n
+    - libxcb-sync1
+    - libxcb-xkb1
+    - qt5-gtk-platformtheme
+    - kimageformat-plugins
+    - libxau6
+    - qtwayland5
+    - libgcrypt20
+    - libxext6
+    - libpoppler97
+    - libxxf86vm1
+    - libjpeg-turbo8
+    - libxfixes3
+    - libsm6
+    - libxdmcp6
+    - libqt5xmlpatterns5
+    - libxcb-xinerama0
+    exclude:
+    - dbus
+    - ubuntu-mono
+    - humanity-icon-theme
+    - adwaita-icon-theme
+    - hicolor-icon-theme
+    - fonts-hack
+    - dbus-user-session
+    - dconf-service
+  files:
+    exclude:
+    - usr/share/man
+    - usr/share/doc/**/README.*
+    - usr/share/doc/**/changelog.*
+    - usr/share/doc/**/NEWS.*
+    - usr/share/doc/**/TODO.*
+  test:
+    fedora:
+      image: appimagecrafters/tests-env:fedora-30
+      command: ./AppRun
+      use_host_x: true
+    debian:
+      image: appimagecrafters/tests-env:debian-stable
+      command: ./AppRun
+      use_host_x: true
+    arch:
+      image: appimagecrafters/tests-env:archlinux-latest
+      command: ./AppRun
+      use_host_x: true
+    centos:
+      image: appimagecrafters/tests-env:centos-7
+      command: ./AppRun
+      use_host_x: true
+    ubuntu:
+      image: appimagecrafters/tests-env:ubuntu-xenial
+      command: ./AppRun
+      use_host_x: true
+AppImage:
+  arch: x86_64
+  update-information: guess
+  sign-key: None

--- a/dist/appimage-builder-recipe.yml
+++ b/dist/appimage-builder-recipe.yml
@@ -3,7 +3,7 @@ version: 1
 script:
   - rm -rf AppDir || true
   - qmake PREFIX=/usr Seamly2D.pro -r CONFIG+=no_ccache CONFIG+=noDebugSymbols
-  - INSTALL_ROOT=$PWD/AppDir make install -j$(nproc)
+  - INSTALL_ROOT=$PWD/AppDir make install
   # place the icon in the right path
   - mkdir -p AppDir/usr/share/icons/hicolor/64x64/apps/
   - cp AppDir/usr/share/pixmaps/seamly2d.png AppDir/usr/share/icons/hicolor/64x64/apps/


### PR DESCRIPTION
This PR adds continuous builds on every push to easy testing. `appimage-builder` is used to create the AppImage instead of linuxdeploy this will allow us to build in a modern system while keeping the backward compatibility.

I was able to build the AppImage locally but it seems that I'm missing some dependencies on the Github Actions workflow. Could you please take a look into it? Here is the link to the [error msg](https://github.com/AppImageCrafters/Seamly2D/runs/2558333845?check_suite_focus=true#step:4:358)

Reference:

- [appimage-builder documentation](appimage-builder.readthedocs.io/)