### PR TITLE
Continuous appimage

### DIFF
--- a/.github/workflows/build-continuous-linux.yml
+++ b/.github/workflows/build-continuous-linux.yml
@@ -1,7 +1,6 @@
 name: Build weekly release
 
-on:
-  push: 
+on: [push]
 
 jobs:
   linux:
@@ -10,19 +9,20 @@ jobs:
       - uses: actions/checkout@v2.3.4
       - name: Install Qt5
         run: |
-          sudo apt-get install -y build-essential gettext git qttools5-dev libqt5svg5-dev libqt5xmlpatterns5-dev
+          # register kde neon repository
+          echo 'deb http://archive.neon.kde.org/user focal main' | sudo tee /etc/apt/sources.list.d/neon.list
+          curl https://origin.archive.neon.kde.org/public.key -o - | sudo apt-key add -
+          
+          # install build dependencies
+          sudo apt-get update
+          sudo apt-get install -y build-essential gettext git qt5-default qttools5-dev libqt5svg5-dev libqt5xmlpatterns5-dev
       - name: build
         run: |
           sudo wget -q https://github.com/AppImageCrafters/appimage-builder/releases/download/v0.8.8/appimage-builder-0.8.8-4e7c15f-x86_64.AppImage -O /usr/local/bin/appimage-builder
           sudo chmod +x /usr/local/bin/appimage-builder
           appimage-builder --recipe dist/appimage-builder-recipe.yml --skip-test
-
-      - name: upload Seamly2D.AppImage
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v2
         with:
-          upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: ./*.AppImage*
-          asset_name: Seamly2D.AppImage
-          asset_content_type: application/octet-stream
+          name: AppImage
+          path: './*.AppImage*'
+

--- a/.github/workflows/build-continuous-linux.yml
+++ b/.github/workflows/build-continuous-linux.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
       - name: Install Qt5
         run: |
-          sudo apt-get install -y build-essential gettext qttools5-dev libqt5svg5-dev libqt5xmlpatterns5-dev
+          sudo apt-get install -y build-essential gettext git qttools5-dev libqt5svg5-dev libqt5xmlpatterns5-dev
       - name: build
         run: |
           sudo wget -q https://github.com/AppImageCrafters/appimage-builder/releases/download/v0.8.8/appimage-builder-0.8.8-4e7c15f-x86_64.AppImage -O /usr/local/bin/appimage-builder

--- a/dist/appimage-builder-recipe.yml
+++ b/dist/appimage-builder-recipe.yml
@@ -3,7 +3,9 @@ version: 1
 script:
   - rm -rf AppDir || true
   - qmake PREFIX=/usr Seamly2D.pro -r CONFIG+=no_ccache CONFIG+=noDebugSymbols
+  - make -j$(nproc)
   - INSTALL_ROOT=$PWD/AppDir make install
+
   # place the icon in the right path
   - mkdir -p AppDir/usr/share/icons/hicolor/64x64/apps/
   - cp AppDir/usr/share/pixmaps/seamly2d.png AppDir/usr/share/icons/hicolor/64x64/apps/
@@ -11,7 +13,7 @@ script:
 AppDir:
   path: ./AppDir
   app_info:
-    id: net.seamly.seamly2d
+    id: seamly2d
     name: Seamly2D
     icon: seamly2d
     version: latest
@@ -19,11 +21,14 @@ AppDir:
     exec_args: $@
   apt:
     arch: amd64
-    allow_unauthenticated: true
     sources:
     - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
     - sourceline: deb http://security.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
     - sourceline: deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
+      key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3b4fe6acc0b21f32'
+    - sourceline: deb http://archive.neon.kde.org/user focal main
+      key_url: https://origin.archive.neon.kde.org/public.key
+
     include:
     - libqt5svg5
     - libqt5xml5


### PR DESCRIPTION
This PR, creates an AppImage on every push. KDE Neon repositories are used to install Qt 5.15.2.

The resulting AppImage can be found in the [job artifacts](https://github.com/AppImageCrafters/Seamly2D/actions/runs/833093250). Please help testing it and report any issues found here before proceeding to merge.