### PR TITLE
Update settings to show Point Names on new install

### DIFF
--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -1140,7 +1140,7 @@ void VCommonSettings::setPointNameFont(const QFont &f)
 //---------------------------------------------------------------------------------------------------------------------
 bool VCommonSettings::getHidePointNames() const
 {
-    return value(settingGraphicsViewHidePointNames, false).toBool();
+    return value(settingGraphicsViewHidePointNames, true).toBool();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1152,7 +1152,7 @@ void VCommonSettings::setHidePointNames(bool value)
 //---------------------------------------------------------------------------------------------------------------------
 bool VCommonSettings::getShowAxisOrigin() const
 {
-    return value(settingGraphicsViewShowAxisOrigin, false).toBool();
+    return value(settingGraphicsViewShowAxisOrigin, true).toBool();
 }
 
 //---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This changes the preference setting to show instead of hiding the point names on a new or updated install.