### PR TITLE
Issue #534 incorrect line weights

### DIFF
--- a/src/libs/vlayout/vlayoutpiece.cpp
+++ b/src/libs/vlayout/vlayoutpiece.cpp
@@ -1037,7 +1037,7 @@ void VLayoutPiece::createInternalPathItem(int i, QGraphicsItem *parent) const
     SCASSERT(parent != nullptr)
     QColor  color      = QColor(qApp->Settings()->getDefaultInternalColor());
     QString lineType   = qApp->Settings()->getDefaultInternalLinetype();
-    qreal   lineWeight = qApp->Settings()->getDefaultInternalLineweight();
+    qreal   lineWeight = ToPixel(qApp->Settings()->getDefaultInternalLineweight(), Unit::Mm);
 
     QGraphicsPathItem* item = new QGraphicsPathItem(parent);
     item->setPath(d->transform.map(d->m_internalPaths.at(i).GetPainterPath()));
@@ -1050,7 +1050,7 @@ void VLayoutPiece::createCutoutPathItem(int i, QGraphicsItem *parent) const
     SCASSERT(parent != nullptr)
     QColor  color      = QColor(qApp->Settings()->getDefaultCutoutColor());
     QString lineType   = qApp->Settings()->getDefaultCutoutLinetype();
-    qreal   lineWeight = qApp->Settings()->getDefaultCutoutLineweight();
+    qreal   lineWeight = ToPixel(qApp->Settings()->getDefaultCutoutLineweight(), Unit::Mm);
 
     QGraphicsPathItem* item = new QGraphicsPathItem(parent);
     item->setPath(d->transform.map(d->m_cutoutPaths.at(i).GetPainterPath()));
@@ -1239,13 +1239,13 @@ QGraphicsPathItem *VLayoutPiece::createMainItem() const
     {
         color      = QColor(qApp->Settings()->getDefaultSeamColor());
         lineType   = qApp->Settings()->getDefaultSeamLinetype();
-        lineWeight = qApp->Settings()->getDefaultSeamLineweight();
+        lineWeight = ToPixel(qApp->Settings()->getDefaultSeamLineweight(), Unit::Mm);
     }
     else
     {
         color      = QColor(qApp->Settings()->getDefaultCutColor());
         lineType   = qApp->Settings()->getDefaultCutLinetype();
-        lineWeight = qApp->Settings()->getDefaultCutLineweight();
+        lineWeight = ToPixel(qApp->Settings()->getDefaultCutLineweight(), Unit::Mm);
     }
     QGraphicsPathItem *item = new QGraphicsPathItem();
     item->setPath(createMainPath());
@@ -1258,7 +1258,7 @@ void VLayoutPiece::createAllowanceItem(QGraphicsItem *parent) const
 {
     QColor  color      = QColor(qApp->Settings()->getDefaultCutColor());
     QString lineType   = qApp->Settings()->getDefaultCutLinetype();
-    qreal   lineWeight = qApp->Settings()->getDefaultCutLineweight();
+    qreal   lineWeight = ToPixel(qApp->Settings()->getDefaultCutLineweight(), Unit::Mm);
 
     QGraphicsPathItem *item = new QGraphicsPathItem(parent);
     item->setPath(createAllowancePath());

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -64,6 +64,7 @@
 #include <QTextCodec>
 #include <QFont>
 
+#include "../ifc/ifcdef.h"
 #include "../vmisc/def.h"
 #include "../vmisc/vmath.h"
 #include "../vpatterndb/pmsystems.h"
@@ -1142,7 +1143,7 @@ void VCommonSettings::setDefaultSeamColor(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 QString VCommonSettings::getDefaultSeamLinetype() const
 {
-   return value(settingDefaultSeamLinetype, "solid").toString();
+   return value(settingDefaultSeamLinetype, "solidLine").toString();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1154,7 +1155,7 @@ void VCommonSettings::setDefaultSeamLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultSeamLineweight() const
 {
-   return value(settingDefaultSeamLineweight, 0.18).toReal();
+   return value(settingDefaultSeamLineweight, 1.20).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1178,7 +1179,7 @@ void VCommonSettings::setDefaultCutColor(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 QString VCommonSettings::getDefaultCutLinetype() const
 {
-   return value(settingDefaultCutLinetype, "solid").toString();
+   return value(settingDefaultCutLinetype, "solidLine").toString();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1190,7 +1191,7 @@ void VCommonSettings::setDefaultCutLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultCutLineweight() const
 {
-   return value(settingDefaultCutLineweight, 0.18).toReal();
+   return value(settingDefaultCutLineweight, 1.20).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1214,7 +1215,7 @@ void VCommonSettings::setDefaultInternalColor(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 QString VCommonSettings::getDefaultInternalLinetype() const
 {
-   return value(settingDefaultInternalLinetype, "solid").toString();
+   return value(settingDefaultInternalLinetype, "solidLine").toString();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1226,7 +1227,7 @@ void VCommonSettings::setDefaultInternalLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultInternalLineweight() const
 {
-   return value(settingDefaultInternalLineweight, 0.18).toReal();
+   return value(settingDefaultInternalLineweight, 1.20).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1250,7 +1251,7 @@ void VCommonSettings::setDefaultCutoutColor(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 QString VCommonSettings::getDefaultCutoutLinetype() const
 {
-   return value(settingDefaultCutoutLinetype, "solid").toString();
+   return value(settingDefaultCutoutLinetype, "solidLine").toString();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1262,7 +1263,7 @@ void VCommonSettings::setDefaultCutoutLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultCutoutLineweight() const
 {
-   return value(settingDefaultCutoutLineweight, 0.18).toReal();
+   return value(settingDefaultCutoutLineweight, 1.20).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/tools/nodeDetails/vtoolinternalpath.cpp
+++ b/src/libs/vtools/tools/nodeDetails/vtoolinternalpath.cpp
@@ -54,6 +54,7 @@
 #include "../vpatterndb/vpiecepath.h"
 #include "../vpatterndb/vpiecenode.h"
 #include "../../undocommands/savepieceoptions.h"
+#include "../vmisc/vcommonsettings.h"
 #include "../vtoolseamallowance.h"
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -138,17 +139,10 @@ QString VToolInternalPath::getTagName() const
 //---------------------------------------------------------------------------------------------------------------------
 void VToolInternalPath::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
-    qreal width = widthHairLine;
-
-    const qreal scale = sceneScale(scene());
-    if (scale > 1)
-    {
-        width = qMax(1., width/scale);
-    }
+    qreal lineWeight = ToPixel(qApp->Settings()->getDefaultInternalLineweight(), Unit::Mm);
 
     QPen toolPen = pen();
-    toolPen.setWidthF(width);
-
+    toolPen.setWidthF(scaleWidth(lineWeight, sceneScale(scene())));
     setPen(toolPen);
 
     QGraphicsPathItem::paint(painter, option, widget);

--- a/src/libs/vtools/tools/vtoolseamallowance.cpp
+++ b/src/libs/vtools/tools/vtoolseamallowance.cpp
@@ -817,7 +817,8 @@ void VToolSeamAllowance::paint(QPainter *painter, const QStyleOptionGraphicsItem
     //set cutline pen
     color      = QColor(qApp->Settings()->getDefaultCutColor());
     lineType   = qApp->Settings()->getDefaultCutLinetype();
-    lineWeight = qApp->Settings()->getDefaultCutLineweight();
+    lineWeight = ToPixel(qApp->Settings()->getDefaultCutLineweight(), Unit::Mm);
+
     m_cutLine->setPen(QPen(color, scaleWidth(lineWeight, sceneScale(scene())),
                             lineTypeToPenStyle(lineType), Qt::RoundCap, Qt::RoundJoin));
     m_cutLine->setZValue(-10);
@@ -829,13 +830,13 @@ void VToolSeamAllowance::paint(QPainter *painter, const QStyleOptionGraphicsItem
     {
         color      = QColor(qApp->Settings()->getDefaultSeamColor());
         lineType   = qApp->Settings()->getDefaultSeamLinetype();
-        lineWeight = qApp->Settings()->getDefaultSeamLineweight();
+        lineWeight = ToPixel(qApp->Settings()->getDefaultSeamLineweight(), Unit::Mm);
     }
     else
     {
         color      = QColor(qApp->Settings()->getDefaultCutColor());
         lineType   = qApp->Settings()->getDefaultCutLinetype();
-        lineWeight = qApp->Settings()->getDefaultCutLineweight();
+        lineWeight = ToPixel(qApp->Settings()->getDefaultCutLineweight(), Unit::Mm);
     }
 
     this->setPen(QPen(color, scaleWidth(lineWeight, sceneScale(scene())),
@@ -1574,14 +1575,13 @@ void VToolSeamAllowance::InitInternalPaths(const VPiece &piece)
             color = QColor(qApp->Settings()->getDefaultInternalColor());
         }
         Qt::PenStyle lineType   = path.GetPenType();
-        qreal   lineWeight = qApp->Settings()->getDefaultInternalLineweight();
-
+        qreal   lineWeight = ToPixel(qApp->Settings()->getDefaultInternalLineweight(), Unit::Mm);
 
         auto *tool = qobject_cast<VToolInternalPath*>(VAbstractPattern::getTool(pathIds.at(i)));
         SCASSERT(tool != nullptr);
         tool->setParentItem(this);
         tool->SetParentType(ParentType::Item);
-        tool->setPen(QPen(color, lineWeight, lineType, Qt::RoundCap, Qt::RoundJoin));
+        tool->setPen(QPen(color, scaleWidth(lineWeight, sceneScale(scene())), lineType, Qt::RoundCap, Qt::RoundJoin));
         tool->show();
         doc->IncrementReferens(piece.GetInternalPaths().at(i));
     }

--- a/src/libs/vwidgets/lineweight_combobox.cpp
+++ b/src/libs/vwidgets/lineweight_combobox.cpp
@@ -101,6 +101,7 @@ void LineWeightComboBox::init()
     addItem(createIcon(7.00), "1.58mm",       1.58);
     addItem(createIcon(8.00), "2.00mm (ISO)", 2.00);
     addItem(createIcon(8.00), "2.11mm",       2.11);
+    setMaxVisibleItems(24);
 
     this->blockSignals(false);
 		connect(this, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &LineWeightComboBox::updateLineWeight);


### PR DESCRIPTION
#
## Description

This fixes the incorrect display of the line weights in piece & layout mode.  Need to convert to pixels for QPen. 

## CHANGELOG

* [#534] Fix line weight display in piece and layout mode.

closes $534