### PR TITLE
Fix piece label rotation

### DIFF
--- a/src/libs/vtools/tools/vtoolseamallowance.cpp
+++ b/src/libs/vtools/tools/vtoolseamallowance.cpp
@@ -694,7 +694,7 @@ void VToolSeamAllowance::SaveRotationDetail(qreal dRot)
     // Tranform angle to anticlockwise
     QLineF line(0, 0, 100, 0);
     line.setAngle(-dRot);
-    newDet.GetPatternPieceData().SetRotationWay(QString().setNum(line.angle()));
+    newDet.GetPatternPieceData().SetRotation(QString().setNum(line.angle()));
 
     SavePieceOptions* rotateCommand = new SavePieceOptions(oldDet, newDet, doc, m_id);
     rotateCommand->setText(tr("rotate pattern piece label"));


### PR DESCRIPTION
#
## Description

This fixes the interactive rotation of pattern piece labels. 

## CHANGELOG

* [CHANGED] Fixes Issue #537 Pattern piece label is not interactively rotatable
