### PR TITLE
Switch magnifier cursor pointer type to a QSharedPointer

### DIFF
--- a/src/libs/vwidgets/vmaingraphicsview.h
+++ b/src/libs/vwidgets/vmaingraphicsview.h
@@ -64,6 +64,7 @@
 #include <QRubberBand>
 #include <QColor>
 #include <Qt>
+#include <QSharedPointer>
 
 /*!
  * This class adds ability to zoom QGraphicsView using mouse wheel. The point under cursor
@@ -203,7 +204,7 @@ protected:
     virtual void          mouseReleaseEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
     virtual void          mouseDoubleClickEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
 
-    std::unique_ptr<QCursor> curMagnifier;
+    QSharedPointer<QCursor> curMagnifier;
 
 private:
     Q_DISABLE_COPY(VMainGraphicsView)


### PR DESCRIPTION
#
## Description

Switch magnifier cursor pointer type to a QSharedPointer which should squash any compiler warnings. 

## CHANGELOG

* [CHANGED] Switch magnifier cursor pointer type to a QSharedPointer

closes #387 and #388
