### PR TITLE
Fix: issue #376 elliptical arcs do not mirror

### DIFF
--- a/src/libs/vgeometry/vabstractarc.h
+++ b/src/libs/vgeometry/vabstractarc.h
@@ -94,7 +94,7 @@ public:
     void          SetFormulaF2 (const QString &formula, qreal value);
     virtual qreal GetEndAngle () const Q_DECL_OVERRIDE;
 
-    VPointF GetCenter () const;
+    virtual VPointF GetCenter () const;
     void    SetCenter (const VPointF &point);
 
     QString GetFormulaLength () const;

--- a/src/libs/vgeometry/vellipticalarc.cpp
+++ b/src/libs/vgeometry/vellipticalarc.cpp
@@ -30,6 +30,7 @@
 
 #include <QLineF>
 #include <QPoint>
+#include <QPainterPath>
 
 #include "../vmisc/def.h"
 #include "../vmisc/vmath.h"
@@ -131,59 +132,57 @@ VEllipticalArc &VEllipticalArc::operator =(const VEllipticalArc &arc)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-VEllipticalArc VEllipticalArc::Rotate(const QPointF &originPoint, qreal degrees, const QString &prefix) const
+VEllipticalArc VEllipticalArc::Rotate(QPointF originPoint, qreal degrees, const QString &prefix) const
 {
-    const VPointF center = GetCenter().Rotate(originPoint, degrees);
+    originPoint = d->m_transform.inverted().map(originPoint);
 
-    const QPointF p1 = VPointF::RotatePF(originPoint, GetP1(), degrees);
-    const QPointF p2 = VPointF::RotatePF(originPoint, GetP2(), degrees);
+    QTransform t = d->m_transform;
+    t.translate(originPoint.x(), originPoint.y());
+    t.rotate(-degrees);
+    t.translate(-originPoint.x(), -originPoint.y());
 
-    const qreal f1 = QLineF(static_cast<QPointF>(center), p1).angle() - GetRotationAngle();
-    const qreal f2 = QLineF(static_cast<QPointF>(center), p2).angle() - GetRotationAngle();
-
-    VEllipticalArc elArc(center, GetRadius1(), GetRadius2(), f1, f2, GetRotationAngle());
+    VEllipticalArc elArc(VAbstractArc::GetCenter(), GetRadius1(), GetRadius2(), VAbstractArc::GetStartAngle(),
+                         VAbstractArc::GetEndAngle(), GetRotationAngle());
     elArc.setName(name() + prefix);
     elArc.SetColor(GetColor());
     elArc.SetPenStyle(GetPenStyle());
     elArc.SetFlipped(IsFlipped());
+    elArc.setTransform(t);
     return elArc;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 VEllipticalArc VEllipticalArc::Flip(const QLineF &axis, const QString &prefix) const
 {
-    const VPointF center = GetCenter().Flip(axis);
-
-    const QPointF p1 = VPointF::FlipPF(axis, GetP1());
-    const QPointF p2 = VPointF::FlipPF(axis, GetP2());
-
-    const qreal f1 = QLineF(static_cast<QPointF>(center), p1).angle() - GetRotationAngle();
-    const qreal f2 = QLineF(static_cast<QPointF>(center), p2).angle() - GetRotationAngle();
-
-    VEllipticalArc elArc(center, GetRadius1(), GetRadius2(), f1, f2, GetRotationAngle());
+    VEllipticalArc elArc(VAbstractArc::GetCenter(), GetRadius1(), GetRadius2(), VAbstractArc::GetStartAngle(),
+                         VAbstractArc::GetEndAngle(), GetRotationAngle());
     elArc.setName(name() + prefix);
     elArc.SetColor(GetColor());
     elArc.SetPenStyle(GetPenStyle());
     elArc.SetFlipped(not IsFlipped());
+    elArc.setTransform(d->m_transform * VGObject::flipTransform(d->m_transform.inverted().map(axis)));
     return elArc;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 VEllipticalArc VEllipticalArc::Move(qreal length, qreal angle, const QString &prefix) const
 {
-    const VPointF center = GetCenter().Move(length, angle);
+    const VPointF oldCenter = VAbstractArc::GetCenter();
+    const VPointF center = oldCenter.Move(length, angle);
 
-    const QPointF p1 = VPointF::MovePF(GetP1(), length, angle);
-    const QPointF p2 = VPointF::MovePF(GetP2(), length, angle);
+    const QPointF position = d->m_transform.inverted().map(center.toQPointF()) -
+            d->m_transform.inverted().map(oldCenter.toQPointF());
 
-    const qreal f1 = QLineF(static_cast<QPointF>(center), p1).angle() - GetRotationAngle();
-    const qreal f2 = QLineF(static_cast<QPointF>(center), p2).angle() - GetRotationAngle();
+    QTransform t = d->m_transform;
+    t.translate(position.x(), position.y());
 
-    VEllipticalArc elArc(center, GetRadius1(), GetRadius2(), f1, f2, GetRotationAngle());
+    VEllipticalArc elArc(oldCenter, GetRadius1(), GetRadius2(), VAbstractArc::GetStartAngle(),
+                         VAbstractArc::GetEndAngle(), GetRotationAngle());
     elArc.setName(name() + prefix);
     elArc.SetColor(GetColor());
     elArc.SetPenStyle(GetPenStyle());
     elArc.SetFlipped(IsFlipped());
+    elArc.setTransform(t);
     return elArc;
 }
 
@@ -215,7 +214,7 @@ qreal VEllipticalArc::GetLength() const
  */
 QPointF VEllipticalArc::GetP1() const
 {
-    return GetPoint(GetStartAngle());
+    return getTransform().map(getPoint(VAbstractArc::GetStartAngle()));
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -225,169 +224,53 @@ QPointF VEllipticalArc::GetP1() const
  */
 QPointF VEllipticalArc::GetP2 () const
 {
-    return GetPoint(GetEndAngle());
+    return getTransform().map(getPoint(VAbstractArc::GetEndAngle()));
 }
+
+//---------------------------------------------------------------------------------------------------------------------
+QTransform VEllipticalArc::getTransform() const
+{
+    return d->m_transform;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VEllipticalArc::setTransform(const QTransform &matrix, bool combine)
+{
+    d->m_transform = combine ? d->m_transform * matrix : matrix;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+VPointF VEllipticalArc::GetCenter() const
+{
+    VPointF center = VAbstractArc::GetCenter();
+    const QPointF p = d->m_transform.map(center.toQPointF());
+    center.setX(p.x());
+    center.setY(p.y());
+    return center;
+}
+
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
  * @brief GetPoint return point associated with angle.
  * @return point.
  */
-QPointF VEllipticalArc::GetPoint (qreal angle) const
+ //---------------------------------------------------------------------------------------------------------------------
+QPointF VEllipticalArc::getPoint(qreal angle) const
 {
-    // Original idea http://alex-black.ru/article.php?content=109#head_3
-    if (angle > 360 || angle < 0)
-    {// Filter incorect value of angle
-        QLineF dummy(0, 0, 100, 0);
-        dummy.setAngle(angle);
-        angle = dummy.angle();
-    }
+    QLineF line(0, 0, 100, 0);
+    line.setAngle(angle);
 
-    // p - point without rotation
-    qreal x = 0;
-    qreal y = 0;
+    const qreal a = line.p2().x() / GetRadius1();
+    const qreal b = line.p2().y() / GetRadius2();
+    const qreal k = qSqrt(a*a + b*b);
+    QPointF p(line.p2().x() / k, line.p2().y() / k);
 
-    qreal angleRad = qDegreesToRadians(angle);
-    const int n = GetQuadransRad(angleRad);
-    if (VFuzzyComparePossibleNulls(angleRad, 0) || VFuzzyComparePossibleNulls(angleRad, M_2PI) ||
-        VFuzzyComparePossibleNulls(angleRad, -M_2PI))
-    { // 0 (360, -360) degress
-        x = d->radius1;
-        y = 0;
-    }
-    else if (VFuzzyComparePossibleNulls(angleRad, M_PI_2) || VFuzzyComparePossibleNulls(angleRad, -3 * M_PI_2))
-    { // 90 (-270) degress
-        x = 0;
-        y = d->radius2;
-    }
-    else if (VFuzzyComparePossibleNulls(angleRad, M_PI) || VFuzzyComparePossibleNulls(angleRad, -M_PI))
-    { // 180 (-180) degress
-        x = -d->radius1;
-        y = 0;
-    }
-    else if (VFuzzyComparePossibleNulls(angleRad, 3 * M_PI_2) || VFuzzyComparePossibleNulls(angleRad, -M_PI_2))
-    { // 270 (-90) degress
-        x = 0;
-        y = -d->radius2;
-    }
-    else
-    { // cases between
-        const qreal r1Pow = qPow(d->radius1, 2);
-        const qreal r2Pow = qPow(d->radius2, 2);
-        const qreal angleTan = qTan(angleRad);
-        const qreal angleTan2 = qPow(angleTan, 2);
-        x = qSqrt((r1Pow * r2Pow) / (r1Pow * angleTan2 + r2Pow));
-        y = angleTan * x;
-    }
+    QLineF line2(QPointF(), p);
+    SCASSERT(VFuzzyComparePossibleNulls(line2.angle(), line.angle()))
 
-    switch (n)
-    {
-        case 1:
-            x = +x;
-            y = +y;
-            break;
-        case 2:
-            x = -x;
-            y = +y;
-            break;
-        case 3:
-            x = -x;
-            y = -y;
-            break;
-        case 4:
-            x = +x;
-            y = -y;
-            break;
-        default:
-            break;
-    }
-
-    QPointF p (GetCenter().x() + x, GetCenter().y() + y);
-    // rotation of point
-    QLineF line(static_cast<QPointF>(GetCenter()), p);
-    line.setAngle(line.angle() + GetRotationAngle());
-
-    return line.p2();
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-int VEllipticalArc::GetQuadransRad(qreal &rad)
-{
-    if (rad > M_PI)
-    {
-        rad = rad - M_2PI;
-    }
-
-    if (rad < -M_PI)
-    {
-        rad = rad + M_2PI;
-    }
-
-    int n = 0;
-    if (rad >= 0)
-    {
-        if (rad <= M_PI_2)
-        {
-            n = 1;
-            rad = -rad;
-        }
-        else if (rad > M_PI_2 && rad <= M_PI)
-        {
-            n = 2;
-            rad = M_PI+rad;
-        }
-    }
-    else
-    {
-        if (rad >= -M_PI_2)
-        {
-            n = 4;
-        }
-        else if (rad < -M_PI_2 && rad >= -M_PI)
-        {
-            n = 3;
-            rad = M_PI-rad;
-        }
-    }
-    return n;
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief GetAngles return list of angles needed for drawing arc.
- * @return list of angles
- */
-QVector<qreal> VEllipticalArc::GetAngles() const
-{
-    QVector<qreal> sectionAngle;
-    qreal angle = AngleArc();
-
-    if (qFuzzyIsNull(angle))
-    {// Return the array that includes one angle
-        sectionAngle.append(GetStartAngle());
-        return sectionAngle;
-    }
-
-    if (angle > 360 || angle < 0)
-    {// Filter incorect value of angle
-        QLineF dummy(0,0, 100, 0);
-        dummy.setAngle(angle);
-        angle = dummy.angle();
-    }
-
-    const qreal angleInterpolation = 45; //degree
-    const int sections = qFloor(angle / angleInterpolation);
-    for (int i = 0; i < sections; ++i)
-    {
-        sectionAngle.append(angleInterpolation);
-    }
-
-    const qreal tail = angle - sections * angleInterpolation;
-    if (tail > 0)
-    {
-        sectionAngle.append(tail);
-    }
-    return sectionAngle;
+    line2.setAngle(line2.angle() + GetRotationAngle());
+    return line2.p2() + VAbstractArc::GetCenter().toQPointF();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -397,34 +280,55 @@ QVector<qreal> VEllipticalArc::GetAngles() const
  */
 QVector<QPointF> VEllipticalArc::GetPoints() const
 {
-    QVector<QPointF> points;
-    QVector<qreal> sectionAngle = GetAngles();
+    const QPointF center = VAbstractArc::GetCenter().toQPointF();
+    QRectF box(center.x() - d->radius1, center.y() - d->radius2, d->radius1*2, d->radius2*2);
 
-    qreal currentAngle;
-    IsFlipped() ? currentAngle = GetEndAngle() : currentAngle = GetStartAngle();
-    for (int i = 0; i < sectionAngle.size(); ++i)
+    QLineF startLine(center.x(), center.y(), center.x() + d->radius1, center.y());
+    QLineF endLine = startLine;
+
+    startLine.setAngle(VAbstractArc::GetStartAngle());
+    endLine.setAngle(VAbstractArc::GetEndAngle());
+    qreal sweepAngle = startLine.angleTo(endLine);
+
+    if (qFuzzyIsNull(sweepAngle))
     {
-        QPointF startPoint = GetPoint(currentAngle);
-        QPointF ellipsePoint2 = GetPoint(currentAngle + sectionAngle.at(i)/3);
-        QPointF ellipsePoint3 = GetPoint(currentAngle + 2*sectionAngle.at(i)/3);
-        QPointF lastPoint = GetPoint(currentAngle + sectionAngle.at(i));
-        // four points that are on ellipse
-
-        QPointF bezierPoint1 = ( -5*startPoint + 18*ellipsePoint2 -9*ellipsePoint3 + 2*lastPoint )/6;
-        QPointF bezierPoint2 = ( 2*startPoint - 9*ellipsePoint2 + 18*ellipsePoint3 - 5*lastPoint )/6;
-
-        VSpline spl(VPointF(startPoint), bezierPoint1, bezierPoint2, VPointF(lastPoint), 1.0);
-
-        QVector<QPointF> splPoints = spl.GetPoints();
-
-        if (not splPoints.isEmpty() && i != sectionAngle.size() - 1)
-        {
-            splPoints.removeLast();
-        }
-        points << splPoints;
-        currentAngle += sectionAngle.at(i);
+        sweepAngle = 360;
     }
-    return points;
+
+    QPainterPath path;
+    path.arcTo(box, VAbstractArc::GetStartAngle(), sweepAngle);
+
+    QTransform t = d->m_transform;
+    t.translate(center.x(), center.y());
+    t.rotate(-GetRotationAngle());
+    t.translate(-center.x(), -center.y());
+
+    path = t.map(path);
+
+    QPolygonF polygon;
+    const QList<QPolygonF> subpath = path.toSubpathPolygons();
+    if (not subpath.isEmpty())
+    {
+        polygon = path.toSubpathPolygons().first();
+        if (not polygon.isEmpty())
+        {
+            polygon.removeFirst(); // remove point (0;0)
+        }
+    }
+
+    return std::move(polygon);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+qreal VEllipticalArc::GetStartAngle() const
+{
+    return QLineF(GetCenter().toQPointF(), GetP1()).angle() - GetRotationAngle();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+qreal VEllipticalArc::GetEndAngle() const
+{
+    return QLineF(GetCenter().toQPointF(), GetP2()).angle() - GetRotationAngle();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -514,7 +418,7 @@ void VEllipticalArc::FindF2(qreal length)
     }
     while (length > MaxLength())
     {
-        length = length - MaxLength();
+        length = MaxLength();
     }
 
     // We need to calculate the second angle
@@ -527,7 +431,7 @@ void VEllipticalArc::FindF2(qreal length)
 
     qreal lenBez = GetLength(); // first approximation of length
 
-    const qreal eps = ToPixel(0.1, Unit::Mm);
+    const qreal eps = ToPixel(0.001, Unit::Mm);
 
     while (qAbs(lenBez - length) > eps)
     {

--- a/src/libs/vgeometry/vellipticalarc.h
+++ b/src/libs/vgeometry/vellipticalarc.h
@@ -47,69 +47,85 @@ class VEllipticalArcData;
 class VEllipticalArc : public VAbstractArc
 {
     Q_DECLARE_TR_FUNCTIONS(VEllipticalArc)
+
 public:
     VEllipticalArc();
-    VEllipticalArc (const VPointF &center, qreal radius1, qreal radius2, const QString &formulaRadius1,
-                    const QString &formulaRadius2, qreal f1, const QString &formulaF1, qreal f2,
-                    const QString &formulaF2, qreal rotationAngle, const QString &formulaRotationAngle,
-                    quint32 idObject = 0, Draw mode = Draw::Calculation);
-    VEllipticalArc (const VPointF &center, qreal radius1, qreal radius2, qreal f1, qreal f2, qreal rotationAngle);
-    VEllipticalArc (qreal length, const QString &formulaLength, const VPointF &center, qreal radius1, qreal radius2,
-                    const QString &formulaRadius1, const QString &formulaRadius2, qreal f1, const QString &formulaF1,
-                    qreal rotationAngle, const QString &formulaRotationAngle, quint32 idObject = 0,
-                    Draw mode = Draw::Calculation);
-    VEllipticalArc (qreal length, const VPointF &center, qreal radius1, qreal radius2, qreal f1, qreal rotationAngle);
+    VEllipticalArc(const VPointF &center, qreal radius1, qreal radius2, const QString &formulaRadius1,
+                   const QString &formulaRadius2, qreal f1, const QString &formulaF1, qreal f2,
+                   const QString &formulaF2, qreal rotationAngle, const QString &formulaRotationAngle,
+                   quint32 idObject = 0, Draw mode = Draw::Calculation);
+
+    VEllipticalArc(const VPointF &center, qreal radius1, qreal radius2, qreal f1, qreal f2, qreal rotationAngle);
+
+    VEllipticalArc(qreal length, const QString &formulaLength, const VPointF &center, qreal radius1, qreal radius2,
+                   const QString &formulaRadius1, const QString &formulaRadius2, qreal f1, const QString &formulaF1,
+                   qreal rotationAngle, const QString &formulaRotationAngle, quint32 idObject = 0,
+                   Draw mode = Draw::Calculation);
+
+    VEllipticalArc(qreal length, const VPointF &center, qreal radius1, qreal radius2, qreal f1, qreal rotationAngle);
+
     VEllipticalArc(const VEllipticalArc &arc);
 
-    VEllipticalArc Rotate(const QPointF &originPoint, qreal degrees, const QString &prefix = QString()) const;
-    VEllipticalArc Flip(const QLineF &axis, const QString &prefix = QString()) const;
-    VEllipticalArc Move(qreal length, qreal angle, const QString &prefix = QString()) const;
+    VEllipticalArc  Rotate(QPointF originPoint, qreal degrees, const QString &prefix = QString()) const;
+    VEllipticalArc  Flip(const QLineF &axis, const QString &prefix = QString()) const;
+    VEllipticalArc  Move(qreal length, qreal angle, const QString &prefix = QString()) const;
 
-    virtual ~VEllipticalArc() Q_DECL_OVERRIDE;
+    virtual        ~VEllipticalArc() Q_DECL_OVERRIDE;
 
-    VEllipticalArc& operator= (const VEllipticalArc &arc);
+    VEllipticalArc &operator= (const VEllipticalArc &arc);
+
 #ifdef Q_COMPILER_RVALUE_REFS
 	VEllipticalArc &operator=(VEllipticalArc &&arc) Q_DECL_NOTHROW;
 #endif
 
-	void Swap(VEllipticalArc &arc) Q_DECL_NOTHROW;
+	void            Swap(VEllipticalArc &arc) Q_DECL_NOTHROW;
 
-    QString GetFormulaRotationAngle () const;
-    void    SetFormulaRotationAngle (const QString &formula, qreal value);
-    qreal   GetRotationAngle() const;
+    QString         GetFormulaRotationAngle () const;
+    void            SetFormulaRotationAngle (const QString &formula, qreal value);
+    qreal           GetRotationAngle() const;
 
-    QString GetFormulaRadius1 () const;
-    void    SetFormulaRadius1 (const QString &formula, qreal value);
-    qreal   GetRadius1 () const;
+    QString         GetFormulaRadius1 () const;
+    void            SetFormulaRadius1 (const QString &formula, qreal value);
+    qreal           GetRadius1 () const;
 
-    QString GetFormulaRadius2 () const;
-    void    SetFormulaRadius2 (const QString &formula, qreal value);
-    qreal   GetRadius2 () const;
+    QString         GetFormulaRadius2 () const;
+    void            SetFormulaRadius2 (const QString &formula, qreal value);
+    qreal           GetRadius2 () const;
 
-    virtual qreal GetLength () const Q_DECL_OVERRIDE;
+    virtual qreal   GetLength () const Q_DECL_OVERRIDE;
 
-    QPointF GetP1() const;
-    QPointF GetP2() const;
+    QPointF         GetP1() const;
+    QPointF         GetP2() const;
 
+    QTransform      getTransform() const;
+    void            setTransform(const QTransform &matrix, bool combine = false);
+
+    virtual VPointF GetCenter () const Q_DECL_OVERRIDE;
     virtual QVector<QPointF> GetPoints () const Q_DECL_OVERRIDE;
+    virtual qreal   GetStartAngle () const Q_DECL_OVERRIDE;
+    virtual qreal   GetEndAngle () const Q_DECL_OVERRIDE;
 
-    QPointF CutArc (const qreal &length, VEllipticalArc &arc1, VEllipticalArc &arc2) const;
-    QPointF CutArc (const qreal &length) const;
+    QPointF         CutArc (const qreal &length, VEllipticalArc &arc1, VEllipticalArc &arc2) const;
+    QPointF         CutArc (const qreal &length) const;
+
+    static qreal    normalizeAngle(qreal angle);
+
 protected:
-    virtual void CreateName() Q_DECL_OVERRIDE;
-    virtual void FindF2(qreal length) Q_DECL_OVERRIDE;
+    virtual void    CreateName() Q_DECL_OVERRIDE;
+    virtual void    FindF2(qreal length) Q_DECL_OVERRIDE;
+
 private:
     QSharedDataPointer<VEllipticalArcData> d;
-
-    // cppcheck-suppress unusedPrivateFunction
-    QVector<qreal> GetAngles () const;
-    qreal          MaxLength() const;
-    QPointF        GetPoint (qreal angle) const;
-
-    static int GetQuadransRad(qreal &rad);
+    qreal           MaxLength() const;
+    QPointF         getPoint (qreal angle) const;
 };
 
 Q_DECLARE_METATYPE(VEllipticalArc)
 Q_DECLARE_TYPEINFO(VEllipticalArc, Q_MOVABLE_TYPE);
 
+//---------------------------------------------------------------------------------------------------------------------
+inline qreal VEllipticalArc::normalizeAngle(qreal angle)
+{
+    return angle - 360.*qFloor(angle/360.);
+}
 #endif // VELLIPTICALARC_H

--- a/src/libs/vgeometry/vellipticalarc_p.h
+++ b/src/libs/vgeometry/vellipticalarc_p.h
@@ -33,6 +33,8 @@ public:
     qreal   rotationAngle;
     /** @brief formulaRotationAngle formula for rotationAngle. */
     QString formulaRotationAngle;
+    /** @brief m_transform for elliptical arc */
+    QTransform m_transform;
 
 private:
     VEllipticalArcData &operator=(const VEllipticalArcData &) Q_DECL_EQ_DELETE;
@@ -40,45 +42,49 @@ private:
 
 //---------------------------------------------------------------------------------------------------------------------
 VEllipticalArcData::VEllipticalArcData()
-    : radius1(0),
-      radius2(0),
-      formulaRadius1(),
-      formulaRadius2(),
-      rotationAngle(0),
-      formulaRotationAngle()
+    : radius1(0)
+    , radius2(0)
+    , formulaRadius1()
+    , formulaRadius2()
+    , rotationAngle(0)
+    , formulaRotationAngle()
+    , m_transform()
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
 VEllipticalArcData::VEllipticalArcData(qreal radius1, qreal radius2, const QString &formulaRadius1,
                                        const QString &formulaRadius2, qreal rotationAngle,
                                        const QString &formulaRotationAngle)
-    : radius1(radius1),
-      radius2(radius2),
-      formulaRadius1(formulaRadius1),
-      formulaRadius2(formulaRadius2),
-      rotationAngle(rotationAngle),
-      formulaRotationAngle(formulaRotationAngle)
+    : radius1(radius1)
+    , radius2(radius2)
+    , formulaRadius1(formulaRadius1)
+    , formulaRadius2(formulaRadius2)
+    , rotationAngle(rotationAngle)
+    , formulaRotationAngle(formulaRotationAngle)
+    , m_transform()
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
 VEllipticalArcData::VEllipticalArcData(qreal radius1, qreal radius2, qreal rotationAngle)
-    : radius1(radius1),
-      radius2(radius2),
-      formulaRadius1(QString().number(qApp->fromPixel(radius1))),
-      formulaRadius2(QString().number(qApp->fromPixel(radius2))),
-      rotationAngle(rotationAngle),
-      formulaRotationAngle(QString().number(qApp->fromPixel(rotationAngle)))
+    : radius1(radius1)
+    , radius2(radius2)
+    , formulaRadius1(QString().number(qApp->fromPixel(radius1)))
+    , formulaRadius2(QString().number(qApp->fromPixel(radius2)))
+    , rotationAngle(rotationAngle)
+    , formulaRotationAngle(QString().number(qApp->fromPixel(rotationAngle)))
+    , m_transform()
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
 VEllipticalArcData::VEllipticalArcData(const VEllipticalArcData &arc)
-    : QSharedData(arc),
-      radius1(arc.radius1),
-      radius2(arc.radius2),
-      formulaRadius1(arc.formulaRadius1),
-      formulaRadius2(arc.formulaRadius2),
-      rotationAngle(arc.rotationAngle),
-      formulaRotationAngle(arc.formulaRotationAngle)
+    : QSharedData(arc)
+    , radius1(arc.radius1)
+    , radius2(arc.radius2)
+    , formulaRadius1(arc.formulaRadius1)
+    , formulaRadius2(arc.formulaRadius2)
+    , rotationAngle(arc.rotationAngle)
+    , formulaRotationAngle(arc.formulaRotationAngle)
+    , m_transform(arc.m_transform)
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -88,4 +94,3 @@ VEllipticalArcData::~VEllipticalArcData()
 QT_WARNING_POP
 
 #endif // VELLIPTICALARC_P
-

--- a/src/libs/vgeometry/vgobject.cpp
+++ b/src/libs/vgeometry/vgobject.cpp
@@ -63,7 +63,7 @@
 #include "../ifc/ifcdef.h"
 #include "vgobject_p.h"
 
-const double VGObject::accuracyPointOnLine = (0.12/*mm*/ / 25.4) * PrintDPI;
+const double VGObject::accuracyPointOnLine = (0.1555/*mm*/ / 25.4) * 96.0;
 
 #ifdef Q_COMPILER_RVALUE_REFS
 VGObject &VGObject::operator=(VGObject &&obj) Q_DECL_NOTHROW { Swap(obj); return *this; }

--- a/src/libs/vmisc/def.h
+++ b/src/libs/vmisc/def.h
@@ -53,11 +53,12 @@
 #define DEF_H
 
 #include <qcompilerdetection.h>
-#include <QPrinter>
+#include <QLineF>
 #include <QString>
 #include <QStringList>
 #include <Qt>
 #include <QtGlobal>
+#include <QPrinter>
 #include <csignal>
 #ifdef Q_OS_WIN
     #include <windows.h>
@@ -452,6 +453,16 @@ QMarginsF GetPrinterFields(const QSharedPointer<QPrinter> &printer);
 Q_REQUIRED_RESULT QPixmap darkenPixmap(const QPixmap &pixmap);
 
 void ShowInGraphicalShell(const QString &filePath);
+
+constexpr qreal accuracyPointOnLine = (0.1555/*mm*/ / 25.4) * 96.0;
+
+Q_REQUIRED_RESULT static inline bool VFuzzyComparePoints(const QPointF &p1, const QPointF &p2,
+                                                         qreal accuracy = accuracyPointOnLine);
+
+static inline bool VFuzzyComparePoints(const QPointF &p1, const QPointF &p2, qreal accuracy)
+{
+    return QLineF(p1, p2).length() <= accuracy;
+}
 
 Q_REQUIRED_RESULT static inline bool VFuzzyComparePossibleNulls(double p1, double p2);
 static inline bool VFuzzyComparePossibleNulls(double p1, double p2)

--- a/src/libs/vtest/abstracttest.cpp
+++ b/src/libs/vtest/abstracttest.cpp
@@ -2,7 +2,7 @@
  *                                                                         *
  *   Copyright (C) 2017  Seamly, LLC                                       *
  *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
+ *   https://github.com/fashionfreedom/seamly2d                            *
  *                                                                         *
  ***************************************************************************
  **
@@ -68,10 +68,19 @@
 #include <QStringList>
 #include <QVector>
 #include <QtGlobal>
+#include <QLineF>
 
 #include "logging.h"
 #include "vsysexits.h"
+#include "../vgeometry/vgeometrydef.h"
 #include "../vgeometry/vgobject.h"
+#include "../vgeometry/vpointf.h"
+#include "../vgeometry/vspline.h"
+#include "../vgeometry/vsplinepath.h"
+#include "../vlayout/vabstractpiece.h"
+#include "../vpatterndb/vcontainer.h"
+#include "../vpatterndb/vpiece.h"
+#include "../vpatterndb/vpiecenode.h"
 
 //---------------------------------------------------------------------------------------------------------------------
 AbstractTest::AbstractTest(QObject *parent) :
@@ -84,17 +93,22 @@ void AbstractTest::Comparison(const QVector<QPointF> &ekv, const QVector<QPointF
 {
     // Begin comparison
     QCOMPARE(ekv.size(), ekvOrig.size());// First check if sizes equal
+    const qreal testAccuracy = (1.0/*mm*/ / 25.4) * PrintDPI;
 
     for (int i=0; i < ekv.size(); i++)
     {
-        const QPointF p1 = ekv.at(i);
-        const QPointF p2 = ekvOrig.at(i);
-        const QString msg = QString("Index: %1. Got '%2;%3', Expected '%4;%5'.")
-                .arg(i).arg(p1.x()).arg(p1.y()).arg(p2.x()).arg(p2.y());
-        // Check each point. Don't use comparison float values
-        QVERIFY2((qAbs(p1.x() - p2.x()) <= VGObject::accuracyPointOnLine)
-                 && (qAbs(p1.y() - p2.y()) <= VGObject::accuracyPointOnLine), qUtf8Printable(msg));
+        Comparison(ekv.at(i), ekvOrig.at(i), testAccuracy);
     }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void AbstractTest::Comparison(const QPointF &result, const QPointF &expected, qreal testAccuracy) const
+{
+    const QString msg = QStringLiteral("Actual '%2;%3', Expected '%4;%5'. Distance between points %6 mm.")
+            .arg(result.x()).arg(result.y()).arg(expected.x()).arg(expected.y())
+            .arg(UnitConvertor(QLineF(result, expected).length(), Unit::Px, Unit::Mm));
+    // Check each point. Don't use comparison float values
+    QVERIFY2(VFuzzyComparePoints(result, expected, testAccuracy), qUtf8Printable(msg));
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtest/abstracttest.h
+++ b/src/libs/vtest/abstracttest.h
@@ -86,6 +86,7 @@ public:
 
 protected:
     void Comparison(const QVector<QPointF> &ekv, const QVector<QPointF> &ekvOrig) const;
+    void Comparison(const QPointF &result, const QPointF &expected, qreal testAccuracy) const;
 
     QString Seamly2DPath() const;
     QString SeamlyMePath() const;

--- a/src/libs/vtest/vtest.pro
+++ b/src/libs/vtest/vtest.pro
@@ -8,7 +8,7 @@
 message("Entering vtest.pro")
 include(../../../common.pri)
 
-QT += testlib widgets
+QT += testlib widgets printsupport
 
 # Name of library
 TARGET = vtest

--- a/src/test/Seamly2DTest/tst_vellipticalarc.h
+++ b/src/test/Seamly2DTest/tst_vellipticalarc.h
@@ -29,9 +29,9 @@
 #ifndef TST_VELLIPTICALARC_H
 #define TST_VELLIPTICALARC_H
 
-#include <QObject>
+#include "../vtest/abstracttest.h"
 
-class TST_VEllipticalArc : public QObject
+class TST_VEllipticalArc : public AbstractTest
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
- Fix issue#376 Elliptical arcs do not mirror correctly
- Fix elliptical arc tests

This fixes the transform to get the proper start and end angles when mirroring elliptical arcs.

closes #376