### PR TITLE
fix: disable ok-apply with before or after allowance error

### DIFF
--- a/src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp
@@ -606,7 +606,7 @@ void DialogInternalPath::notchSubTypeChanged(int id)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void DialogInternalPath::EvalWidth()
+void DialogInternalPath::evaluateDefaultWidth()
 {
     labelEditFormula = ui->widthEdit_Label;
     const QString postfix = UnitsToStr(qApp->patternUnit(), true);
@@ -620,13 +620,13 @@ void DialogInternalPath::EvalWidth()
                                                                   QString().setNum(m_saWidth), true,
                                                                   tr("Current seam aloowance")));
 
-        EvalWidthBefore();
-        EvalWidthAfter();
+        evaluateBeforeWidth();
+        evaluateAfterWidth();
     }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void DialogInternalPath::EvalWidthBefore()
+void DialogInternalPath::evaluateBeforeWidth()
 {
     labelEditFormula = ui->beforeWidthEdit_Label;
     const QString postfix = UnitsToStr(qApp->patternUnit(), true);
@@ -644,7 +644,7 @@ void DialogInternalPath::EvalWidthBefore()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void DialogInternalPath::EvalWidthAfter()
+void DialogInternalPath::evaluateAfterWidth()
 {
     labelEditFormula = ui->afterWidthEdit_Label;
     const QString postfix = UnitsToStr(qApp->patternUnit(), true);
@@ -707,7 +707,7 @@ void DialogInternalPath::FXWidthAfter()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void DialogInternalPath::WidthChanged()
+void DialogInternalPath::defaultWidthChanged()
 {
     labelEditFormula = ui->widthEdit_Label;
     labelResultCalculation = ui->widthResult_Label;
@@ -716,7 +716,7 @@ void DialogInternalPath::WidthChanged()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void DialogInternalPath::WidthBeforeChanged()
+void DialogInternalPath::beforeWidthChanged()
 {
     labelEditFormula = ui->beforeWidthEdit_Label;
     labelResultCalculation = ui->beforeWidthResult_Label;
@@ -726,7 +726,7 @@ void DialogInternalPath::WidthBeforeChanged()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void DialogInternalPath::WidthAfterChanged()
+void DialogInternalPath::afterWidthChanged()
 {
     labelEditFormula = ui->afterWidthEdit_Label;
     labelResultCalculation = ui->afterWidthResult_Label;
@@ -794,13 +794,13 @@ void DialogInternalPath::InitSeamAllowanceTab()
     ui->afterWidthFormula_PlainTextEdit->installEventFilter(this);
 
     m_timerWidth = new QTimer(this);
-    connect(m_timerWidth, &QTimer::timeout, this, &DialogInternalPath::EvalWidth);
+    connect(m_timerWidth, &QTimer::timeout, this, &DialogInternalPath::evaluateDefaultWidth);
 
     m_timerWidthBefore = new QTimer(this);
-    connect(m_timerWidthBefore, &QTimer::timeout, this, &DialogInternalPath::EvalWidthBefore);
+    connect(m_timerWidthBefore, &QTimer::timeout, this, &DialogInternalPath::evaluateBeforeWidth);
 
     m_timerWidthAfter = new QTimer(this);
-    connect(m_timerWidthAfter, &QTimer::timeout, this, &DialogInternalPath::EvalWidthAfter);
+    connect(m_timerWidthAfter, &QTimer::timeout, this, &DialogInternalPath::evaluateAfterWidth);
 
     // Default value for seam allowence is 1 cm. But pattern have different units, so just set 1 in dialog not enough.
     m_saWidth = UnitConvertor(1, Unit::Cm, qApp->patternUnit());
@@ -821,11 +821,11 @@ void DialogInternalPath::InitSeamAllowanceTab()
     connect(ui->beforeExpr_ToolButton, &QPushButton::clicked, this, &DialogInternalPath::FXWidthBefore);
     connect(ui->afterExpr_ToolButton, &QPushButton::clicked, this, &DialogInternalPath::FXWidthAfter);
 
-    connect(ui->widthFormula_PlainTextEdit, &QPlainTextEdit::textChanged, this, &DialogInternalPath::WidthChanged);
+    connect(ui->widthFormula_PlainTextEdit, &QPlainTextEdit::textChanged, this, &DialogInternalPath::defaultWidthChanged);
     connect(ui->beforeWidthFormula_PlainTextEdit, &QPlainTextEdit::textChanged, this,
-            &DialogInternalPath::WidthBeforeChanged);
+            &DialogInternalPath::beforeWidthChanged);
     connect(ui->afterWidthFormula_PlainTextEdit, &QPlainTextEdit::textChanged, this,
-            &DialogInternalPath::WidthAfterChanged);
+            &DialogInternalPath::afterWidthChanged);
 
     connect(ui->widthGrow_PushButton, &QPushButton::clicked, this, &DialogInternalPath::DeployWidthFormulaTextEdit);
     connect(ui->beforeWidthGrow_PushButton, &QPushButton::clicked,

--- a/src/libs/vtools/dialogs/tools/piece/dialoginternalpath.h
+++ b/src/libs/vtools/dialogs/tools/piece/dialoginternalpath.h
@@ -99,17 +99,17 @@ private slots:
     void                    notchTypeChanged(int id);
     void                    notchSubTypeChanged(int id);
 
-    void                    EvalWidth();
-    void                    EvalWidthBefore();
-    void                    EvalWidthAfter();
+    void                    evaluateDefaultWidth();
+    void                    evaluateBeforeWidth();
+    void                    evaluateAfterWidth();
 
     void                    FXWidth();
     void                    FXWidthBefore();
     void                    FXWidthAfter();
 
-    void                    WidthChanged();
-    void                    WidthBeforeChanged();
-    void                    WidthAfterChanged();
+    void                    defaultWidthChanged();
+    void                    beforeWidthChanged();
+    void                    afterWidthChanged();
 
     void                    DeployWidthFormulaTextEdit();
     void                    DeployWidthBeforeFormulaTextEdit();

--- a/src/libs/vtools/dialogs/tools/piece/dialogseamallowance.h
+++ b/src/libs/vtools/dialogs/tools/piece/dialogseamallowance.h
@@ -158,17 +158,17 @@ private slots:
     void                        EnabledDetailLabel();
     void                        EnabledPatternLabel();
 
-    void                        EvalWidth();
-    void                        EvalWidthBefore();
-    void                        EvalWidthAfter();
+    void                        evaluateDefaultWidth();
+    void                        evaluateBeforeWidth();
+    void                        evaluateAfterWidth();
 
     void                        FXWidth();
     void                        FXWidthBefore();
     void                        FXWidthAfter();
 
-    void                        WidthChanged();
-    void                        WidthBeforeChanged();
-    void                        WidthAfterChanged();
+    void                        defaultWidthChanged();
+    void                        beforeWidthChanged();
+    void                        afterWidthChanged();
 
     void                        DeployWidthFormulaTextEdit();
     void                        DeployWidthBeforeFormulaTextEdit();
@@ -182,6 +182,8 @@ private slots:
 
 private:
     Q_DISABLE_COPY(DialogSeamAllowance)
+
+
 
     Ui::DialogSeamAllowance    *ui;
     Ui::PathsTab               *uiPathsTab;
@@ -207,6 +209,9 @@ private:
     bool                        flagDLFormulas;
     bool                        flagPLAngle;
     bool                        flagPLFormulas;
+    bool                        flagBeforeFormula;
+    bool                        flagAfterFormula;
+
     bool                        m_bAddMode;
     qreal                       m_mx;
     qreal                       m_my;

--- a/src/libs/vtools/dialogs/tools/piece/tabs/tabpaths.ui
+++ b/src/libs/vtools/dialogs/tools/piece/tabs/tabpaths.ui
@@ -117,7 +117,7 @@
                 <string>...</string>
                </property>
                <property name="icon">
-                <iconset resource="../../../../../vmisc/share/resources/icon.qrc">
+                <iconset resource="../../../../../vmisc/share/resources/theme.qrc">
                  <normaloff>:/icons/win.icon.theme/16x16/actions/go-top.png</normaloff>:/icons/win.icon.theme/16x16/actions/go-top.png</iconset>
                </property>
               </widget>
@@ -131,7 +131,7 @@
                 <string>...</string>
                </property>
                <property name="icon">
-                <iconset resource="../../../../../vmisc/share/resources/icon.qrc">
+                <iconset resource="../../../../../vmisc/share/resources/theme.qrc">
                  <normaloff>:/icons/win.icon.theme/16x16/actions/go-up.png</normaloff>:/icons/win.icon.theme/16x16/actions/go-up.png</iconset>
                </property>
               </widget>
@@ -145,7 +145,7 @@
                 <string>...</string>
                </property>
                <property name="icon">
-                <iconset resource="../../../../../vmisc/share/resources/icon.qrc">
+                <iconset resource="../../../../../vmisc/share/resources/theme.qrc">
                  <normaloff>:/icons/win.icon.theme/16x16/actions/go-down.png</normaloff>:/icons/win.icon.theme/16x16/actions/go-down.png</iconset>
                </property>
               </widget>
@@ -159,7 +159,7 @@
                 <string>...</string>
                </property>
                <property name="icon">
-                <iconset resource="../../../../../vmisc/share/resources/icon.qrc">
+                <iconset resource="../../../../../vmisc/share/resources/theme.qrc">
                  <normaloff>:/icons/win.icon.theme/16x16/actions/go-bottom.png</normaloff>:/icons/win.icon.theme/16x16/actions/go-bottom.png</iconset>
                </property>
               </widget>
@@ -318,7 +318,7 @@
                    </palette>
                   </property>
                   <property name="text">
-                   <string>Width:</string>
+                   <string>Default width:</string>
                   </property>
                  </widget>
                 </item>
@@ -1039,8 +1039,8 @@
   </layout>
  </widget>
  <resources>
-  <include location="../../../../../vmisc/share/resources/theme.qrc"/>
   <include location="../../../../../vmisc/share/resources/icon.qrc"/>
+  <include location="../../../../../vmisc/share/resources/theme.qrc"/>
  </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
*Add flags to check error state to disable ok-apply with an error in the before or after allowance fields.

*Clarify the term "width" in the Seam Allowance dialog by using the label "Default width". 

Closes #597