### PR TITLE
Add default export file format preference setting

### DIFF
--- a/src/app/seamly2d/core/vcmdexport.cpp
+++ b/src/app/seamly2d/core/vcmdexport.cpp
@@ -28,7 +28,7 @@
 
 #include "vcmdexport.h"
 #include "../dialogs/dialoglayoutsettings.h"
-#include "../dialogs/dialogsavelayout.h"
+#include "../vwidgets/export_format_combobox.h"
 #include "../ifc/xml/vdomdocument.h"
 #include "../vformat/vmeasurements.h"
 #include "../vmisc/commandoptions.h"
@@ -97,7 +97,7 @@ void VCommandLine::InitOptions(VCommandLineOptions &options, QMap<QString, int> 
     options.append(new QCommandLineOption(QStringList() << SINGLE_OPTION_EXP2FORMAT << LONG_OPTION_EXP2FORMAT,
                                           translate("VCommandLine", "Number corresponding to output format (default = "
                                                                     "0, export mode):") +
-                                                                    DialogSaveLayout::MakeHelpFormatList(),
+                                                                    ExportFormatCombobox::makeHelpFormatList(),
                                           translate("VCommandLine", "Format number"), "0"));
 
     optionsIndex.insert(LONG_OPTION_BINARYDXF, index++);

--- a/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp
@@ -113,7 +113,7 @@ PreferencesConfigurationPage::PreferencesConfigurationPage(QWidget *parent)
         ui->systemCombo->setCurrentIndex(index);
     }
 
-    // Default opertsions suffixes
+    // Default operations suffixes
     ui->moveSuffix_ComboBox->addItem(tr("None"), "");
     ui->moveSuffix_ComboBox->addItem(tr("_M"), "_M");
     ui->moveSuffix_ComboBox->addItem(tr("_MOV"), "_MOV");
@@ -181,7 +181,7 @@ PreferencesConfigurationPage::PreferencesConfigurationPage(QWidget *parent)
     {
         m_defaultExportFormatChanged = true;
     });
-
+I 
     // Language
     InitLanguages(ui->langCombo);
     connect(ui->langCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, [this]()

--- a/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp
@@ -181,7 +181,7 @@ PreferencesConfigurationPage::PreferencesConfigurationPage(QWidget *parent)
     {
         m_defaultExportFormatChanged = true;
     });
-I 
+ 
     // Language
     InitLanguages(ui->langCombo);
     connect(ui->langCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, [this]()

--- a/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.h
+++ b/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.h
@@ -2,7 +2,7 @@
  *                                                                         *
  *   Copyright (C) 2017  Seamly, LLC                                       *
  *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
+ *   https://github.com/fashionfreedom/seamly2d                            *
  *                                                                         *
  ***************************************************************************
  **
@@ -81,6 +81,7 @@ private:
     bool m_rotateSuffixChanged;
     bool m_mirrorByAxisSuffixChanged;
     bool m_mirrorByLineSuffixChanged;
+    bool m_defaultExportFormatChanged;
 
     void SetLabelComboBox(const QStringList &list);
     void InitUnits();

--- a/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui
@@ -18,708 +18,1159 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>493</width>
+    <width>600</width>
     <height>570</height>
    </size>
   </property>
   <property name="windowTitle">
    <string notr="true">Configuration</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <property name="topMargin">
-    <number>8</number>
-   </property>
-   <property name="rightMargin">
-    <number>8</number>
-   </property>
-   <property name="bottomMargin">
-    <number>8</number>
-   </property>
+  <property name="styleSheet">
+   <string notr="true">background-color: rgb(240, 240, 240);</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
    <item row="0" column="0">
-    <widget class="QGroupBox" name="save_GroupBox">
+    <widget class="QTabWidget" name="tabWidget">
      <property name="minimumSize">
       <size>
-       <width>465</width>
-       <height>80</height>
+       <width>470</width>
+       <height>0</height>
       </size>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>465</width>
-       <height>16777215</height>
-      </size>
+     <property name="palette">
+      <palette>
+       <active>
+        <colorrole role="Button">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>240</red>
+           <green>240</green>
+           <blue>240</blue>
+          </color>
+         </brush>
+        </colorrole>
+        <colorrole role="Base">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>240</red>
+           <green>240</green>
+           <blue>240</blue>
+          </color>
+         </brush>
+        </colorrole>
+        <colorrole role="Window">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>240</red>
+           <green>240</green>
+           <blue>240</blue>
+          </color>
+         </brush>
+        </colorrole>
+       </active>
+       <inactive>
+        <colorrole role="Button">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>240</red>
+           <green>240</green>
+           <blue>240</blue>
+          </color>
+         </brush>
+        </colorrole>
+        <colorrole role="Base">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>240</red>
+           <green>240</green>
+           <blue>240</blue>
+          </color>
+         </brush>
+        </colorrole>
+        <colorrole role="Window">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>240</red>
+           <green>240</green>
+           <blue>240</blue>
+          </color>
+         </brush>
+        </colorrole>
+       </inactive>
+       <disabled>
+        <colorrole role="Button">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>240</red>
+           <green>240</green>
+           <blue>240</blue>
+          </color>
+         </brush>
+        </colorrole>
+        <colorrole role="Base">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>240</red>
+           <green>240</green>
+           <blue>240</blue>
+          </color>
+         </brush>
+        </colorrole>
+        <colorrole role="Window">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>240</red>
+           <green>240</green>
+           <blue>240</blue>
+          </color>
+         </brush>
+        </colorrole>
+       </disabled>
+      </palette>
      </property>
      <property name="font">
       <font>
-       <family>MS Shell Dlg 2 UI</family>
-       <pointsize>9</pointsize>
-       <weight>50</weight>
-       <bold>false</bold>
-      </font>
-     </property>
-     <property name="title">
-      <string>Save</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_6" columnminimumwidth="140,0,0">
-      <item row="0" column="0" colspan="2">
-       <widget class="QCheckBox" name="autoSaveCheck">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-          <weight>50</weight>
-          <bold>false</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>Auto-save modified pattern</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="autoTime">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>80</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-          <weight>50</weight>
-          <bold>false</bold>
-         </font>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-        <property name="suffix">
-         <string> min</string>
-        </property>
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>60</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label">
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-          <weight>50</weight>
-          <bold>false</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>Interval:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="patternMakingSytem_GroupBox">
-     <property name="minimumSize">
-      <size>
-       <width>465</width>
-       <height>170</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>465</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <family>MS Shell Dlg 2 UI</family>
        <pointsize>9</pointsize>
       </font>
      </property>
-     <property name="title">
-      <string>Pattern making system</string>
+     <property name="autoFillBackground">
+      <bool>false</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout_3" columnminimumwidth="140,0,0">
-      <item row="0" column="1">
-       <widget class="QComboBox" name="systemCombo">
-        <property name="minimumSize">
-         <size>
-          <width>280</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QPlainTextEdit" name="systemBookValueLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>280</width>
-          <height>50</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>280</width>
-          <height>100</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>System:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_7">
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>Author:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_9">
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>Book:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="systemAuthorValueLabel">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>20</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string notr="true">author</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <spacer name="horizontalSpacer_4">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QGroupBox" name="language_GroupBox">
-     <property name="minimumSize">
-      <size>
-       <width>465</width>
-       <height>130</height>
-      </size>
+     <property name="tabPosition">
+      <enum>QTabWidget::West</enum>
      </property>
-     <property name="maximumSize">
-      <size>
-       <width>465</width>
-       <height>16777215</height>
-      </size>
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <property name="font">
-      <font>
-       <family>MS Shell Dlg 2 UI</family>
-       <pointsize>9</pointsize>
-      </font>
-     </property>
-     <property name="title">
-      <string>Language</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2" columnminimumwidth="140,0,0">
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>Decimal separator:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="osOptionCheck">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string notr="true">&lt; With OS options &gt;</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="langCombo">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>GUI language:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QComboBox" name="labelCombo">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>Label language:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>Default unit:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QComboBox" name="unitCombo">
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <family>MS Shell Dlg 2 UI</family>
-          <pointsize>9</pointsize>
-         </font>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QGroupBox" name="patternEditing_GroupBox">
-     <property name="minimumSize">
-      <size>
-       <width>465</width>
-       <height>150</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>465</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <family>MS Shell Dlg 2 UI</family>
-       <pointsize>9</pointsize>
-      </font>
-     </property>
-     <property name="title">
-      <string>Pattern editing</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <widget class="QLabel" name="label_11">
-          <property name="minimumSize">
-           <size>
-            <width>140</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Mirror by axis suffix:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="mirrorByAxisSuffix_ComboBox">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_7">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_5">
-        <item>
-         <widget class="QLabel" name="label_12">
-          <property name="minimumSize">
-           <size>
-            <width>140</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Mirror by line suffix:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="mirrorByLineSuffix_ComboBox">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_8">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QLabel" name="label_8">
-          <property name="minimumSize">
-           <size>
-            <width>140</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Move suffix:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="moveSuffix_ComboBox">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QLabel" name="label_10">
-          <property name="minimumSize">
-           <size>
-            <width>140</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Rotate suffix:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="rotateSuffix_ComboBox">
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_6">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
-        <item>
-         <widget class="QPushButton" name="resetWarningsButton">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="font">
-           <font>
-            <family>MS Shell Dlg 2 UI</family>
-            <pointsize>9</pointsize>
-           </font>
-          </property>
-          <property name="text">
-           <string>Reset warnings</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-     </layout>
+     <widget class="QWidget" name="general_Tab">
+      <attribute name="title">
+       <string>Editing</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_9">
+       <item>
+        <widget class="QGroupBox" name="undo_GroupBox">
+         <property name="minimumSize">
+          <size>
+           <width>420</width>
+           <height>60</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>420</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <family>MS Shell Dlg 2</family>
+           <pointsize>9</pointsize>
+          </font>
+         </property>
+         <property name="title">
+          <string>Undo</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
+             <widget class="QLabel" name="undoCount_Label">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <family>MS Shell Dlg 2</family>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string>Count step:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="undoCount_SpinBox">
+              <property name="minimumSize">
+               <size>
+                <width>80</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <family>MS Shell Dlg 2</family>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">background-color: rgb(255, 255, 255);</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_10">
+              <property name="font">
+               <font>
+                <family>MS Shell Dlg 2</family>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string> (0 - no limit)</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="patternEditing_GroupBox">
+         <property name="minimumSize">
+          <size>
+           <width>420</width>
+           <height>90</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>420</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <family>MS Shell Dlg 2</family>
+           <pointsize>9</pointsize>
+          </font>
+         </property>
+         <property name="title">
+          <string>Pattern Editing Warnings</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_7">
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_8">
+            <item>
+             <widget class="QCheckBox" name="confirmItemDelete_CheckBox">
+              <property name="text">
+               <string>Confirm Item Delete</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="confirmFormatRewriting_CheckBox">
+              <property name="text">
+               <string>Confirm Format Rewriting</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="patternMakingSytem_GroupBox">
+         <property name="minimumSize">
+          <size>
+           <width>420</width>
+           <height>170</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>420</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <family>MS Shell Dlg 2 UI</family>
+           <pointsize>9</pointsize>
+          </font>
+         </property>
+         <property name="title">
+          <string>Pattern making system</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_15">
+            <property name="minimumSize">
+             <size>
+              <width>140</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <family>MS Shell Dlg 2 UI</family>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>System:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="systemCombo">
+            <property name="minimumSize">
+             <size>
+              <width>250</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <family>MS Shell Dlg 2 UI</family>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_16">
+            <property name="minimumSize">
+             <size>
+              <width>140</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <family>MS Shell Dlg 2 UI</family>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Author:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="systemAuthorValueLabel">
+            <property name="minimumSize">
+             <size>
+              <width>200</width>
+              <height>20</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <family>MS Shell Dlg 2 UI</family>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string notr="true">author</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_17">
+            <property name="minimumSize">
+             <size>
+              <width>140</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <family>MS Shell Dlg 2 UI</family>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Book:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTop|Qt::AlignTrailing</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPlainTextEdit" name="systemBookValueLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>250</width>
+              <height>50</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>280</width>
+              <height>100</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <family>MS Shell Dlg 2 UI</family>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">background-color: rgb(255, 255, 255);</string>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="suffix_GroupBox">
+         <property name="minimumSize">
+          <size>
+           <width>420</width>
+           <height>150</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>465</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <family>MS Shell Dlg 2 UI</family>
+           <pointsize>9</pointsize>
+          </font>
+         </property>
+         <property name="title">
+          <string>Operations Default Suffix</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QLabel" name="label_11">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Mirror by axis suffix:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="mirrorByAxisSuffix_ComboBox">
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_7">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <item>
+             <widget class="QLabel" name="label_12">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Mirror by line suffix:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="mirrorByLineSuffix_ComboBox">
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_8">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QLabel" name="label_13">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Move suffix:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="moveSuffix_ComboBox">
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_9">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="label_14">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Rotate suffix:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="rotateSuffix_ComboBox">
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_10">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="fileHandling_Tab">
+      <attribute name="title">
+       <string>File Handling</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_6">
+       <item>
+        <widget class="QGroupBox" name="autoSave_CheckBox">
+         <property name="minimumSize">
+          <size>
+           <width>420</width>
+           <height>60</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>420</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <family>MS Shell Dlg 2</family>
+           <pointsize>9</pointsize>
+           <weight>50</weight>
+           <bold>false</bold>
+          </font>
+         </property>
+         <property name="title">
+          <string>Enable Autosave</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QLabel" name="interval_Label">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <family>MS Shell Dlg 2 UI</family>
+                <pointsize>9</pointsize>
+                <weight>50</weight>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="text">
+               <string>Interval:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="autoInterval_Spinbox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>120</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <family>MS Shell Dlg 2</family>
+                <pointsize>9</pointsize>
+                <weight>50</weight>
+                <bold>false</bold>
+               </font>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">background-color: rgb(255, 255, 255);</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+              <property name="suffix">
+               <string> min</string>
+              </property>
+              <property name="prefix">
+               <string>Every </string>
+              </property>
+              <property name="minimum">
+               <number>1</number>
+              </property>
+              <property name="maximum">
+               <number>60</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="exportFormat_GroupBox">
+         <property name="minimumSize">
+          <size>
+           <width>420</width>
+           <height>100</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>420</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="title">
+          <string>Export Format</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <widget class="QCheckBox" name="uselastExportFormat_CheckBox">
+            <property name="text">
+             <string>Save last used</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QLabel" name="defaultExportFormat_Label">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Default:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="ExportFormatCombobox" name="defaultExportFormat_ComboBox">
+              <property name="minimumSize">
+               <size>
+                <width>250</width>
+                <height>0</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>353</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="language_Tab">
+      <attribute name="title">
+       <string>Language</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_10">
+       <item>
+        <widget class="QGroupBox" name="language_GroupBox">
+         <property name="minimumSize">
+          <size>
+           <width>420</width>
+           <height>140</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>420</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <family>MS Shell Dlg 2</family>
+           <pointsize>9</pointsize>
+          </font>
+         </property>
+         <property name="title">
+          <string>Language</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_11">
+            <item>
+             <widget class="QLabel" name="label_6">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <family>MS Shell Dlg 2</family>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string>GUI language:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="langCombo">
+              <property name="minimumSize">
+               <size>
+                <width>245</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <family>MS Shell Dlg 2</family>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_12">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_12">
+            <item>
+             <widget class="QLabel" name="label_7">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <family>MS Shell Dlg 2</family>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string>Decimal separator:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="osOptionCheck">
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <family>MS Shell Dlg 2</family>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string notr="true">&lt; With OS options &gt;</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_13">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_13">
+            <item>
+             <widget class="QLabel" name="label_8">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <family>MS Shell Dlg 2</family>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string>Default unit:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="unitCombo">
+              <property name="minimumSize">
+               <size>
+                <width>245</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <family>MS Shell Dlg 2</family>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_14">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_14">
+            <item>
+             <widget class="QLabel" name="label_9">
+              <property name="minimumSize">
+               <size>
+                <width>140</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <family>MS Shell Dlg 2</family>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string>Label language:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="labelCombo">
+              <property name="minimumSize">
+               <size>
+                <width>245</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <family>MS Shell Dlg 2</family>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_15">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ExportFormatCombobox</class>
+   <extends>QComboBox</extends>
+   <header>export_format_combobox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
@@ -407,6 +407,9 @@
                 <pointsize>8</pointsize>
                </font>
               </property>
+              <property name="styleSheet">
+               <string notr="true">background-color: rgb(255, 255, 255);</string>
+              </property>
              </widget>
             </item>
             <item row="1" column="0">
@@ -666,6 +669,9 @@
                 <pointsize>9</pointsize>
                </font>
               </property>
+              <property name="styleSheet">
+               <string notr="true">background-color: rgb(255, 255, 255);</string>
+              </property>
              </widget>
             </item>
             <item row="1" column="0">
@@ -924,6 +930,9 @@
                 <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">background-color: rgb(255, 255, 255);</string>
               </property>
              </widget>
             </item>
@@ -1940,6 +1949,9 @@
               <property name="toolTip">
                <string>Scrolling animation duration</string>
               </property>
+              <property name="styleSheet">
+               <string notr="true">background-color: rgb(255, 255, 255);</string>
+              </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
               </property>
@@ -1995,6 +2007,9 @@
               </property>
               <property name="toolTip">
                <string>Time in milliseconds between each animation update</string>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">background-color: rgb(255, 255, 255);</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp
@@ -89,7 +89,6 @@ PreferencesPatternPage::PreferencesPatternPage(QWidget *parent)
     initNotches();
     initGrainlines();
 
-    ui->undoCount_SpinBox->setValue(qApp->Seamly2DSettings()->GetUndoCount());
     ui->forbidFlipping_CheckBox->setChecked(qApp->Seamly2DSettings()->GetForbidWorkpieceFlipping());
     ui->showSecondNotch_CheckBox->setChecked(qApp->Seamly2DSettings()->showSecondNotch());
     ui->hideMainPath_CheckBox->setChecked(qApp->Seamly2DSettings()->IsHideMainPath());
@@ -105,11 +104,6 @@ PreferencesPatternPage::~PreferencesPatternPage()
 void PreferencesPatternPage::Apply()
 {
     VSettings *settings = qApp->Seamly2DSettings();
-
-    /* Maximum number of commands in undo stack may only be set when the undo stack is empty, since setting it on a
-     * non-empty stack might delete the command at the current index. Calling setUndoLimit() on a non-empty stack
-     * prints a warning and does nothing.*/
-    settings->SetUndoCount(ui->undoCount_SpinBox->value());
 
     settings->SetDefaultSeamAllowance(ui->defaultSeamAllowance_DoubleSpinBox->value());
     settings->setDefaultSeamColor(ui->defaultSeamColor_ComboBox->currentData().toString());

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
@@ -58,135 +58,8 @@
     <enum>QTabWidget::West</enum>
    </property>
    <property name="currentIndex">
-    <number>0</number>
+    <number>4</number>
    </property>
-   <widget class="QWidget" name="tab_3">
-    <attribute name="title">
-     <string>Undo</string>
-    </attribute>
-    <layout class="QVBoxLayout" name="verticalLayout_14">
-     <item>
-      <widget class="QGroupBox" name="undo_GroupBox">
-       <property name="minimumSize">
-        <size>
-         <width>420</width>
-         <height>50</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>420</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <family>MS Shell Dlg 2</family>
-         <pointsize>9</pointsize>
-        </font>
-       </property>
-       <property name="title">
-        <string>Undo</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_8">
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_8">
-          <item>
-           <widget class="QLabel" name="undoCount_Label">
-            <property name="minimumSize">
-             <size>
-              <width>70</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <family>MS Shell Dlg 2</family>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Count step:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="undoCount_SpinBox">
-            <property name="minimumSize">
-             <size>
-              <width>50</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <family>MS Shell Dlg 2</family>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">background-color: rgb(255, 255, 255);</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="label">
-            <property name="font">
-             <font>
-              <family>MS Shell Dlg 2</family>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string> (0 - no limit)</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>462</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </widget>
    <widget class="QWidget" name="tab_4">
     <attribute name="title">
      <string>Pattern Piece</string>
@@ -1048,7 +921,7 @@
        </font>
       </property>
       <property name="currentIndex">
-       <number>3</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="tab">
        <attribute name="title">

--- a/src/app/seamly2d/dialogs/dialogpreferences.ui
+++ b/src/app/seamly2d/dialogs/dialogpreferences.ui
@@ -75,7 +75,7 @@
        </property>
        <item>
         <property name="text">
-         <string>Configuration</string>
+         <string>General</string>
         </property>
         <property name="textAlignment">
          <set>AlignCenter</set>
@@ -179,8 +179,8 @@
   </layout>
  </widget>
  <resources>
-  <include location="../../../libs/vmisc/share/resources/icon.qrc"/>
   <include location="../../../libs/vmisc/share/resources/theme.qrc"/>
+  <include location="../../../libs/vmisc/share/resources/icon.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/src/app/seamly2d/dialogs/dialogsavelayout.cpp
+++ b/src/app/seamly2d/dialogs/dialogsavelayout.cpp
@@ -2,7 +2,7 @@
  *                                                                         *
  *   Copyright (C) 2017  Seamly, LLC                                       *
  *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
+ *   https://github.com/fashionfreedom/seamly2d                            *
  *                                                                         *
  ***************************************************************************
  **
@@ -55,6 +55,7 @@
 #include "../core/vapplication.h"
 #include "../vmisc/vsettings.h"
 #include "../ifc/exception/vexception.h"
+#include "../vwidgets/export_format_combobox.h"
 
 #include <QDir>
 #include <QFileDialog>
@@ -66,18 +67,16 @@
 
 const QString baseFilenameRegExp = QStringLiteral("^[\\p{L}\\p{Nd}\\-. _]+$");
 
-bool DialogSaveLayout::havePdf = false;
-bool DialogSaveLayout::tested  = false;
-
 //---------------------------------------------------------------------------------------------------------------------
 DialogSaveLayout::DialogSaveLayout(int count, Draw mode, const QString &fileName, QWidget *parent)
-    :  VAbstractLayoutDialog(parent),
-      ui(new Ui::DialogSaveLAyout),
-      count(count),
-      isInitialized(false),
-      m_mode(mode)
+    : VAbstractLayoutDialog(parent)
+    , ui(new Ui::DialogSaveLAyout)
+    , count(count)
+    , isInitialized(false)
+    , m_mode(mode)
 {
     ui->setupUi(this);
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
     ui->lineEditPath->setClearButtonEnabled(true);
     ui->lineEditFileName->setClearButtonEnabled(true);
@@ -108,17 +107,46 @@ DialogSaveLayout::DialogSaveLayout(int count, Draw mode, const QString &fileName
         }
     }
 
-    foreach (auto& v, InitFormats())
+    if (m_mode == Draw::Calculation)
     {
-        ui->comboBoxFormat->addItem(v.first, QVariant(static_cast<int>(v.second)));
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1006_Flat);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1009_Flat);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1012_Flat);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1014_Flat);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1015_Flat);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1018_Flat);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1021_Flat);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1024_Flat);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1027_Flat);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1006_AAMA);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1009_AAMA);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1012_AAMA);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1014_AAMA);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1015_AAMA);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1018_AAMA);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1021_AAMA);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1024_AAMA);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1027_AAMA);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1006_ASTM);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1009_ASTM);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1012_ASTM);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1014_ASTM);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1015_ASTM);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1018_ASTM);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1021_ASTM);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1024_ASTM);
+        RemoveFormatFromList(LayoutExportFormat::DXF_AC1027_ASTM);
+        //RemoveFormatFromList(LayoutExportFormat::PS);
+        //RemoveFormatFromList(LayoutExportFormat::PDF);
+        //RemoveFormatFromList(LayoutExportFormat::EPS);
     }
 #ifdef V_NO_ASSERT // Temporarily unavailable
-    RemoveFormatFromList(LayoutExportFormats::OBJ);
+    RemoveFormatFromList(LayoutExportFormat::OBJ);
 #endif
 
     if (m_mode != Draw::Layout)
     {
-        RemoveFormatFromList(LayoutExportFormats::PDFTiled);
+        RemoveFormatFromList(LayoutExportFormat::PDFTiled);
     }
     else
     {
@@ -161,27 +189,6 @@ DialogSaveLayout::DialogSaveLayout(int count, Draw mode, const QString &fileName
     InitTemplates(ui->comboBoxTemplates);
 
     ReadSettings();
-
-    // connect for the template drop down box of the tiled pds
-    connect(ui->comboBoxTemplates, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-            this, &DialogSaveLayout::WriteSettings);
-
-    // connects for the margins of the tiled pdf
-    connect(ui->doubleSpinBoxLeftField, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
-            this, &DialogSaveLayout::WriteSettings);
-    connect(ui->doubleSpinBoxTopField, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
-            this, &DialogSaveLayout::WriteSettings);
-    connect(ui->doubleSpinBoxRightField, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
-            this, &DialogSaveLayout::WriteSettings);
-    connect(ui->doubleSpinBoxBottomField, static_cast<void (QDoubleSpinBox::*)(double)>(&QDoubleSpinBox::valueChanged),
-            this, &DialogSaveLayout::WriteSettings);
-
-    // connects for the orientation buttons for the tiled pdf
-    connect(ui->toolButtonPortrait, &QToolButton::toggled, this, &DialogSaveLayout::WriteSettings);
-    connect(ui->toolButtonLandscape, &QToolButton::toggled, this, &DialogSaveLayout::WriteSettings);
-
-    connect(ui->exportQuality_Slider, &QSlider::valueChanged, this, &DialogSaveLayout::WriteSettings);
-
     ShowExample();//Show example for current format.
 }
 
@@ -198,9 +205,9 @@ void DialogSaveLayout::InitTemplates(QComboBox *comboBoxTemplates)
 
 //---------------------------------------------------------------------------------------------------------------------
 
-void DialogSaveLayout::SelectFormat(LayoutExportFormats format)
+void DialogSaveLayout::SelectFormat(LayoutExportFormat format)
 {
-    if (static_cast<int>(format) < 0 || format >= LayoutExportFormats::COUNT)
+    if (static_cast<int>(format) < 0 || format >= LayoutExportFormat::COUNT)
     {
         VException e(tr("Tried to use out of range format number."));
         throw e;
@@ -220,45 +227,46 @@ void DialogSaveLayout::SetBinaryDXFFormat(bool binary)
 {
     switch(Format())
     {
-        case LayoutExportFormats::DXF_AC1006_Flat:
-        case LayoutExportFormats::DXF_AC1009_Flat:
-        case LayoutExportFormats::DXF_AC1012_Flat:
-        case LayoutExportFormats::DXF_AC1014_Flat:
-        case LayoutExportFormats::DXF_AC1015_Flat:
-        case LayoutExportFormats::DXF_AC1018_Flat:
-        case LayoutExportFormats::DXF_AC1021_Flat:
-        case LayoutExportFormats::DXF_AC1024_Flat:
-        case LayoutExportFormats::DXF_AC1027_Flat:
-        case LayoutExportFormats::DXF_AC1006_AAMA:
-        case LayoutExportFormats::DXF_AC1009_AAMA:
-        case LayoutExportFormats::DXF_AC1012_AAMA:
-        case LayoutExportFormats::DXF_AC1014_AAMA:
-        case LayoutExportFormats::DXF_AC1015_AAMA:
-        case LayoutExportFormats::DXF_AC1018_AAMA:
-        case LayoutExportFormats::DXF_AC1021_AAMA:
-        case LayoutExportFormats::DXF_AC1024_AAMA:
-        case LayoutExportFormats::DXF_AC1027_AAMA:
-        case LayoutExportFormats::DXF_AC1006_ASTM:
-        case LayoutExportFormats::DXF_AC1009_ASTM:
-        case LayoutExportFormats::DXF_AC1012_ASTM:
-        case LayoutExportFormats::DXF_AC1014_ASTM:
-        case LayoutExportFormats::DXF_AC1015_ASTM:
-        case LayoutExportFormats::DXF_AC1018_ASTM:
-        case LayoutExportFormats::DXF_AC1021_ASTM:
-        case LayoutExportFormats::DXF_AC1024_ASTM:
-        case LayoutExportFormats::DXF_AC1027_ASTM:
+        case LayoutExportFormat::DXF_AC1006_Flat:
+        case LayoutExportFormat::DXF_AC1009_Flat:
+        case LayoutExportFormat::DXF_AC1012_Flat:
+        case LayoutExportFormat::DXF_AC1014_Flat:
+        case LayoutExportFormat::DXF_AC1015_Flat:
+        case LayoutExportFormat::DXF_AC1018_Flat:
+        case LayoutExportFormat::DXF_AC1021_Flat:
+        case LayoutExportFormat::DXF_AC1024_Flat:
+        case LayoutExportFormat::DXF_AC1027_Flat:
+        case LayoutExportFormat::DXF_AC1006_AAMA:
+        case LayoutExportFormat::DXF_AC1009_AAMA:
+        case LayoutExportFormat::DXF_AC1012_AAMA:
+        case LayoutExportFormat::DXF_AC1014_AAMA:
+        case LayoutExportFormat::DXF_AC1015_AAMA:
+        case LayoutExportFormat::DXF_AC1018_AAMA:
+        case LayoutExportFormat::DXF_AC1021_AAMA:
+        case LayoutExportFormat::DXF_AC1024_AAMA:
+        case LayoutExportFormat::DXF_AC1027_AAMA:
+        case LayoutExportFormat::DXF_AC1006_ASTM:
+        case LayoutExportFormat::DXF_AC1009_ASTM:
+        case LayoutExportFormat::DXF_AC1012_ASTM:
+        case LayoutExportFormat::DXF_AC1014_ASTM:
+        case LayoutExportFormat::DXF_AC1015_ASTM:
+        case LayoutExportFormat::DXF_AC1018_ASTM:
+        case LayoutExportFormat::DXF_AC1021_ASTM:
+        case LayoutExportFormat::DXF_AC1024_ASTM:
+        case LayoutExportFormat::DXF_AC1027_ASTM:
             ui->checkBoxBinaryDXF->setChecked(binary);
             break;
-        case LayoutExportFormats::SVG:
-        case LayoutExportFormats::PDF:
-        case LayoutExportFormats::PDFTiled:
-        case LayoutExportFormats::PNG:
-        case LayoutExportFormats::JPG:
-        case LayoutExportFormats::BMP:
-        case LayoutExportFormats::PPM:
-        case LayoutExportFormats::OBJ:
-        case LayoutExportFormats::PS:
-        case LayoutExportFormats::EPS:
+        case LayoutExportFormat::SVG:
+        case LayoutExportFormat::PDF:
+        case LayoutExportFormat::PDFTiled:
+        case LayoutExportFormat::PNG:
+        case LayoutExportFormat::JPG:
+        case LayoutExportFormat::BMP:
+        case LayoutExportFormat::PPM:
+        case LayoutExportFormat::OBJ:
+        case LayoutExportFormat::PS:
+        case LayoutExportFormat::EPS:
+        case LayoutExportFormat::TIF:
         default:
             ui->checkBoxBinaryDXF->setChecked(false);
             break;
@@ -270,59 +278,48 @@ bool DialogSaveLayout::IsBinaryDXFFormat() const
 {
     switch(Format())
     {
-        case LayoutExportFormats::DXF_AC1006_Flat:
-        case LayoutExportFormats::DXF_AC1009_Flat:
-        case LayoutExportFormats::DXF_AC1012_Flat:
-        case LayoutExportFormats::DXF_AC1014_Flat:
-        case LayoutExportFormats::DXF_AC1015_Flat:
-        case LayoutExportFormats::DXF_AC1018_Flat:
-        case LayoutExportFormats::DXF_AC1021_Flat:
-        case LayoutExportFormats::DXF_AC1024_Flat:
-        case LayoutExportFormats::DXF_AC1027_Flat:
-        case LayoutExportFormats::DXF_AC1006_AAMA:
-        case LayoutExportFormats::DXF_AC1009_AAMA:
-        case LayoutExportFormats::DXF_AC1012_AAMA:
-        case LayoutExportFormats::DXF_AC1014_AAMA:
-        case LayoutExportFormats::DXF_AC1015_AAMA:
-        case LayoutExportFormats::DXF_AC1018_AAMA:
-        case LayoutExportFormats::DXF_AC1021_AAMA:
-        case LayoutExportFormats::DXF_AC1024_AAMA:
-        case LayoutExportFormats::DXF_AC1027_AAMA:
-        case LayoutExportFormats::DXF_AC1006_ASTM:
-        case LayoutExportFormats::DXF_AC1009_ASTM:
-        case LayoutExportFormats::DXF_AC1012_ASTM:
-        case LayoutExportFormats::DXF_AC1014_ASTM:
-        case LayoutExportFormats::DXF_AC1015_ASTM:
-        case LayoutExportFormats::DXF_AC1018_ASTM:
-        case LayoutExportFormats::DXF_AC1021_ASTM:
-        case LayoutExportFormats::DXF_AC1024_ASTM:
-        case LayoutExportFormats::DXF_AC1027_ASTM:
+        case LayoutExportFormat::DXF_AC1006_Flat:
+        case LayoutExportFormat::DXF_AC1009_Flat:
+        case LayoutExportFormat::DXF_AC1012_Flat:
+        case LayoutExportFormat::DXF_AC1014_Flat:
+        case LayoutExportFormat::DXF_AC1015_Flat:
+        case LayoutExportFormat::DXF_AC1018_Flat:
+        case LayoutExportFormat::DXF_AC1021_Flat:
+        case LayoutExportFormat::DXF_AC1024_Flat:
+        case LayoutExportFormat::DXF_AC1027_Flat:
+        case LayoutExportFormat::DXF_AC1006_AAMA:
+        case LayoutExportFormat::DXF_AC1009_AAMA:
+        case LayoutExportFormat::DXF_AC1012_AAMA:
+        case LayoutExportFormat::DXF_AC1014_AAMA:
+        case LayoutExportFormat::DXF_AC1015_AAMA:
+        case LayoutExportFormat::DXF_AC1018_AAMA:
+        case LayoutExportFormat::DXF_AC1021_AAMA:
+        case LayoutExportFormat::DXF_AC1024_AAMA:
+        case LayoutExportFormat::DXF_AC1027_AAMA:
+        case LayoutExportFormat::DXF_AC1006_ASTM:
+        case LayoutExportFormat::DXF_AC1009_ASTM:
+        case LayoutExportFormat::DXF_AC1012_ASTM:
+        case LayoutExportFormat::DXF_AC1014_ASTM:
+        case LayoutExportFormat::DXF_AC1015_ASTM:
+        case LayoutExportFormat::DXF_AC1018_ASTM:
+        case LayoutExportFormat::DXF_AC1021_ASTM:
+        case LayoutExportFormat::DXF_AC1024_ASTM:
+        case LayoutExportFormat::DXF_AC1027_ASTM:
             return ui->checkBoxBinaryDXF->isChecked();
-        case LayoutExportFormats::SVG:
-        case LayoutExportFormats::PDF:
-        case LayoutExportFormats::PDFTiled:
-        case LayoutExportFormats::PNG:
-        case LayoutExportFormats::JPG:
-        case LayoutExportFormats::BMP:
-        case LayoutExportFormats::PPM:
-        case LayoutExportFormats::OBJ:
-        case LayoutExportFormats::PS:
-        case LayoutExportFormats::EPS:
+        case LayoutExportFormat::SVG:
+        case LayoutExportFormat::PDF:
+        case LayoutExportFormat::PDFTiled:
+        case LayoutExportFormat::PNG:
+        case LayoutExportFormat::JPG:
+        case LayoutExportFormat::BMP:
+        case LayoutExportFormat::PPM:
+        case LayoutExportFormat::OBJ:
+        case LayoutExportFormat::PS:
+        case LayoutExportFormat::EPS:
+        case LayoutExportFormat::TIF:
         default:
             return false;
     }
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-QString DialogSaveLayout::MakeHelpFormatList()
-{
-   QString out("\n");
-   foreach(auto& v, InitFormats())
-   {
-       out += QLatin1String("\t") + v.first + QLatin1String(" = ") + QString::number(static_cast<int>(v.second))
-               + QLatin1String("\n");
-   }
-   return out;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -359,144 +356,58 @@ Draw DialogSaveLayout::Mode() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QString DialogSaveLayout::ExportFormatDescription(LayoutExportFormats format)
-{
-    const QString dxfSuffix = QStringLiteral("(*.dxf)");
-    const QString dxfFlatFilesStr = tr("(flat) files");
-    const QString filesStr = tr("files");
-
-    switch(format)
-    {
-        case LayoutExportFormats::SVG:
-            return QString("Svg %1 (*.svg)").arg(filesStr);
-        case LayoutExportFormats::PDF:
-            return QString("PDF %1 (*.pdf)").arg(filesStr);
-        case LayoutExportFormats::PNG:
-            return QString("PNG %1 (*.png)").arg(filesStr);
-        case LayoutExportFormats::JPG:
-            return QString("JPG %1 (*.jpg)").arg(filesStr);
-        case LayoutExportFormats::BMP:
-            return QString("BMP %1 (*.bmp)").arg(filesStr);
-        case LayoutExportFormats::PPM:
-            return QString("PPM %1 (*.ppm)").arg(filesStr);
-        case LayoutExportFormats::OBJ:
-            return "Wavefront OBJ (*.obj)";
-        case LayoutExportFormats::PS:
-            return QString("PS %1 (*.ps)").arg(filesStr);
-        case LayoutExportFormats::EPS:
-            return QString("EPS %1 (*.eps)").arg(filesStr);
-        case LayoutExportFormats::DXF_AC1006_Flat:
-            return QString("AutoCAD DXF R10 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1009_Flat:
-            return QString("AutoCAD DXF R11/12 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1012_Flat:
-            return QString("AutoCAD DXF R13 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1014_Flat:
-            return QString("AutoCAD DXF R14 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1015_Flat:
-            return QString("AutoCAD DXF 2000 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1018_Flat:
-            return QString("AutoCAD DXF 2004 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1021_Flat:
-            return QString("AutoCAD DXF 2007 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1024_Flat:
-            return QString("AutoCAD DXF 2010 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1027_Flat:
-            return QString("AutoCAD DXF 2013 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1006_AAMA:
-            return QString("AutoCAD DXF R10 AAMA %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1009_AAMA:
-            return QString("AutoCAD DXF R11/12 AAMA %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1012_AAMA:
-            return QString("AutoCAD DXF R13 AAMA %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1014_AAMA:
-            return QString("AutoCAD DXF R14 AAMA %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1015_AAMA:
-            return QString("AutoCAD DXF 2000 AAMA %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1018_AAMA:
-            return QString("AutoCAD DXF 2004 AAMA %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1021_AAMA:
-            return QString("AutoCAD DXF 2007 AAMA %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1024_AAMA:
-            return QString("AutoCAD DXF 2010 AAMA %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1027_AAMA:
-            return QString("AutoCAD DXF 2013 AAMA %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1006_ASTM:
-            return QString("AutoCAD DXF R10 ASTM %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1009_ASTM:
-            return QString("AutoCAD DXF R11/12 ASTM %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1012_ASTM:
-            return QString("AutoCAD DXF R13 ASTM %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1014_ASTM:
-            return QString("AutoCAD DXF R14 ASTM %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1015_ASTM:
-            return QString("AutoCAD DXF 2000 ASTM %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1018_ASTM:
-            return QString("AutoCAD DXF 2004 ASTM %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1021_ASTM:
-            return QString("AutoCAD DXF 2007 ASTM %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1024_ASTM:
-            return QString("AutoCAD DXF 2010 ASTM %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::DXF_AC1027_ASTM:
-            return QString("AutoCAD DXF 2013 ASTM %1 %2").arg(filesStr, dxfSuffix);
-        case LayoutExportFormats::PDFTiled:
-            return QString("PDF tiled %1 (*.pdf)").arg(filesStr);
-        default:
-            return QString();
-    }
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-QString DialogSaveLayout::ExportFromatSuffix(LayoutExportFormats format)
+QString DialogSaveLayout::exportFormatSuffix(LayoutExportFormat format)
 {
     switch(format)
     {
-        case LayoutExportFormats::SVG:
+        case LayoutExportFormat::SVG:
             return ".svg";
-        case LayoutExportFormats::PDF:
-        case LayoutExportFormats::PDFTiled:
+        case LayoutExportFormat::PDF:
+        case LayoutExportFormat::PDFTiled:
             return ".pdf";
-        case LayoutExportFormats::PNG:
+        case LayoutExportFormat::PNG:
             return ".png";
-        case LayoutExportFormats::JPG:
+        case LayoutExportFormat::JPG:
             return ".jpg";
-        case LayoutExportFormats::BMP:
+        case LayoutExportFormat::BMP:
             return ".bmp";
-        case LayoutExportFormats::PPM:
+        case LayoutExportFormat::PPM:
             return ".ppm";
-        case LayoutExportFormats::OBJ:
+        case LayoutExportFormat::OBJ:
             return ".obj";
-        case LayoutExportFormats::PS:
+        case LayoutExportFormat::PS:
             return ".ps";
-        case LayoutExportFormats::EPS:
+        case LayoutExportFormat::EPS:
             return ".eps";
-        case LayoutExportFormats::DXF_AC1006_Flat:
-        case LayoutExportFormats::DXF_AC1009_Flat:
-        case LayoutExportFormats::DXF_AC1012_Flat:
-        case LayoutExportFormats::DXF_AC1014_Flat:
-        case LayoutExportFormats::DXF_AC1015_Flat:
-        case LayoutExportFormats::DXF_AC1018_Flat:
-        case LayoutExportFormats::DXF_AC1021_Flat:
-        case LayoutExportFormats::DXF_AC1024_Flat:
-        case LayoutExportFormats::DXF_AC1027_Flat:
-        case LayoutExportFormats::DXF_AC1006_AAMA:
-        case LayoutExportFormats::DXF_AC1009_AAMA:
-        case LayoutExportFormats::DXF_AC1012_AAMA:
-        case LayoutExportFormats::DXF_AC1014_AAMA:
-        case LayoutExportFormats::DXF_AC1015_AAMA:
-        case LayoutExportFormats::DXF_AC1018_AAMA:
-        case LayoutExportFormats::DXF_AC1021_AAMA:
-        case LayoutExportFormats::DXF_AC1024_AAMA:
-        case LayoutExportFormats::DXF_AC1027_AAMA:
-        case LayoutExportFormats::DXF_AC1006_ASTM:
-        case LayoutExportFormats::DXF_AC1009_ASTM:
-        case LayoutExportFormats::DXF_AC1012_ASTM:
-        case LayoutExportFormats::DXF_AC1014_ASTM:
-        case LayoutExportFormats::DXF_AC1015_ASTM:
-        case LayoutExportFormats::DXF_AC1018_ASTM:
-        case LayoutExportFormats::DXF_AC1021_ASTM:
-        case LayoutExportFormats::DXF_AC1024_ASTM:
-        case LayoutExportFormats::DXF_AC1027_ASTM:
+        case LayoutExportFormat::TIF:
+            return ".tif";
+        case LayoutExportFormat::DXF_AC1006_Flat:
+        case LayoutExportFormat::DXF_AC1009_Flat:
+        case LayoutExportFormat::DXF_AC1012_Flat:
+        case LayoutExportFormat::DXF_AC1014_Flat:
+        case LayoutExportFormat::DXF_AC1015_Flat:
+        case LayoutExportFormat::DXF_AC1018_Flat:
+        case LayoutExportFormat::DXF_AC1021_Flat:
+        case LayoutExportFormat::DXF_AC1024_Flat:
+        case LayoutExportFormat::DXF_AC1027_Flat:
+        case LayoutExportFormat::DXF_AC1006_AAMA:
+        case LayoutExportFormat::DXF_AC1009_AAMA:
+        case LayoutExportFormat::DXF_AC1012_AAMA:
+        case LayoutExportFormat::DXF_AC1014_AAMA:
+        case LayoutExportFormat::DXF_AC1015_AAMA:
+        case LayoutExportFormat::DXF_AC1018_AAMA:
+        case LayoutExportFormat::DXF_AC1021_AAMA:
+        case LayoutExportFormat::DXF_AC1024_AAMA:
+        case LayoutExportFormat::DXF_AC1027_AAMA:
+        case LayoutExportFormat::DXF_AC1006_ASTM:
+        case LayoutExportFormat::DXF_AC1009_ASTM:
+        case LayoutExportFormat::DXF_AC1012_ASTM:
+        case LayoutExportFormat::DXF_AC1014_ASTM:
+        case LayoutExportFormat::DXF_AC1015_ASTM:
+        case LayoutExportFormat::DXF_AC1018_ASTM:
+        case LayoutExportFormat::DXF_AC1021_ASTM:
+        case LayoutExportFormat::DXF_AC1024_ASTM:
+        case LayoutExportFormat::DXF_AC1027_ASTM:
             return ".dxf";
         default:
             return QString();
@@ -522,9 +433,15 @@ QString DialogSaveLayout::FileName() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-LayoutExportFormats DialogSaveLayout::Format() const
+LayoutExportFormat DialogSaveLayout::Format() const
 {
-    return static_cast<LayoutExportFormats>(ui->comboBoxFormat->currentData().toInt());
+    return static_cast<LayoutExportFormat>(ui->comboBoxFormat->currentData().toInt());
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QString DialogSaveLayout::formatText() const
+{
+    return ui->comboBoxFormat->currentText();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -532,11 +449,11 @@ void DialogSaveLayout::Save()
 {
     for (int i=0; i < count; ++i)
     {
-        const QString name = Path()+QLatin1String("/")+FileName()+QString::number(i+1)+ExportFromatSuffix(Format());
+        const QString name = Path()+QLatin1String("/")+FileName()+QString::number(i+1)+exportFormatSuffix(Format());
         if (QFile::exists(name))
         {
             QMessageBox::StandardButton res = QMessageBox::question(this, tr("Name conflict"),
-                                  tr("Folder already contain file with name %1. Rewrite all conflict file names?")
+                                  tr("Folder already contains file with name %1. Rewrite all conflict file names?")
                                   .arg(name), QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
             if (res == QMessageBox::No)
             {
@@ -549,6 +466,7 @@ void DialogSaveLayout::Save()
             }
         }
     }
+    WriteSettings();
     accept();
 }
 
@@ -579,78 +497,66 @@ void DialogSaveLayout::PathChanged(const QString &text)
 //---------------------------------------------------------------------------------------------------------------------
 void DialogSaveLayout::ShowExample()
 {
-    const LayoutExportFormats currentFormat = Format();
-    ui->labelExample->setText(FileName() + QLatin1String("1") + ExportFromatSuffix(currentFormat));
-
-    //ui->lineEditFileName->setText(FileName() + QLatin1String("1") + ExportFromatSuffix(currentFormat));
-
+    const LayoutExportFormat currentFormat = Format();
+    ui->checkBoxTextAsPaths->setEnabled(true);
+    ui->exportQuality_Slider->setEnabled(false);
+    ui->groupBoxPaperFormat->setEnabled(false);
+    ui->groupBoxMargins->setEnabled(false);
+    ui->labelExample->setText(FileName() + QLatin1String("1") + exportFormatSuffix(currentFormat));
 
     switch(currentFormat)
     {
-        case LayoutExportFormats::DXF_AC1006_Flat:
-        case LayoutExportFormats::DXF_AC1009_Flat:
-        case LayoutExportFormats::DXF_AC1012_Flat:
-        case LayoutExportFormats::DXF_AC1014_Flat:
-        case LayoutExportFormats::DXF_AC1015_Flat:
-        case LayoutExportFormats::DXF_AC1018_Flat:
-        case LayoutExportFormats::DXF_AC1021_Flat:
-        case LayoutExportFormats::DXF_AC1024_Flat:
-        case LayoutExportFormats::DXF_AC1027_Flat:
-        case LayoutExportFormats::DXF_AC1006_AAMA:
-        case LayoutExportFormats::DXF_AC1009_AAMA:
-        case LayoutExportFormats::DXF_AC1012_AAMA:
-        case LayoutExportFormats::DXF_AC1014_AAMA:
-        case LayoutExportFormats::DXF_AC1015_AAMA:
-        case LayoutExportFormats::DXF_AC1018_AAMA:
-        case LayoutExportFormats::DXF_AC1021_AAMA:
-        case LayoutExportFormats::DXF_AC1024_AAMA:
-        case LayoutExportFormats::DXF_AC1027_AAMA:
-        case LayoutExportFormats::DXF_AC1006_ASTM:
-        case LayoutExportFormats::DXF_AC1009_ASTM:
-        case LayoutExportFormats::DXF_AC1012_ASTM:
-        case LayoutExportFormats::DXF_AC1014_ASTM:
-        case LayoutExportFormats::DXF_AC1015_ASTM:
-        case LayoutExportFormats::DXF_AC1018_ASTM:
-        case LayoutExportFormats::DXF_AC1021_ASTM:
-        case LayoutExportFormats::DXF_AC1024_ASTM:
-        case LayoutExportFormats::DXF_AC1027_ASTM:
+        case LayoutExportFormat::DXF_AC1006_Flat:
+        case LayoutExportFormat::DXF_AC1009_Flat:
+        case LayoutExportFormat::DXF_AC1012_Flat:
+        case LayoutExportFormat::DXF_AC1014_Flat:
+        case LayoutExportFormat::DXF_AC1015_Flat:
+        case LayoutExportFormat::DXF_AC1018_Flat:
+        case LayoutExportFormat::DXF_AC1021_Flat:
+        case LayoutExportFormat::DXF_AC1024_Flat:
+        case LayoutExportFormat::DXF_AC1027_Flat:
+        case LayoutExportFormat::DXF_AC1006_AAMA:
+        case LayoutExportFormat::DXF_AC1009_AAMA:
+        case LayoutExportFormat::DXF_AC1012_AAMA:
+        case LayoutExportFormat::DXF_AC1014_AAMA:
+        case LayoutExportFormat::DXF_AC1015_AAMA:
+        case LayoutExportFormat::DXF_AC1018_AAMA:
+        case LayoutExportFormat::DXF_AC1021_AAMA:
+        case LayoutExportFormat::DXF_AC1024_AAMA:
+        case LayoutExportFormat::DXF_AC1027_AAMA:
+        case LayoutExportFormat::DXF_AC1006_ASTM:
+        case LayoutExportFormat::DXF_AC1009_ASTM:
+        case LayoutExportFormat::DXF_AC1012_ASTM:
+        case LayoutExportFormat::DXF_AC1014_ASTM:
+        case LayoutExportFormat::DXF_AC1015_ASTM:
+        case LayoutExportFormat::DXF_AC1018_ASTM:
+        case LayoutExportFormat::DXF_AC1021_ASTM:
+        case LayoutExportFormat::DXF_AC1024_ASTM:
+        case LayoutExportFormat::DXF_AC1027_ASTM:
             ui->checkBoxBinaryDXF->setEnabled(true);
             break;
-        case LayoutExportFormats::SVG:
-        case LayoutExportFormats::PDF:
-        case LayoutExportFormats::PDFTiled:
-        case LayoutExportFormats::PNG:
-        case LayoutExportFormats::JPG:
-        case LayoutExportFormats::BMP:
-        case LayoutExportFormats::PPM:
-        case LayoutExportFormats::OBJ:
-        case LayoutExportFormats::PS:
-        case LayoutExportFormats::EPS:
+        case LayoutExportFormat::PDFTiled:
+            ui->groupBoxPaperFormat->setEnabled(true);
+            ui->groupBoxMargins->setEnabled(true);
+            break;
+        case LayoutExportFormat::PNG:
+            ui->exportQuality_Slider->setEnabled(true);
+            break;
+        case LayoutExportFormat::JPG:
+            ui->exportQuality_Slider->setEnabled(true);
+            break;
+        case LayoutExportFormat::PDF:
+        case LayoutExportFormat::SVG:
+        case LayoutExportFormat::BMP:
+        case LayoutExportFormat::PPM:
+        case LayoutExportFormat::OBJ:
+        case LayoutExportFormat::PS:
+        case LayoutExportFormat::EPS:
+        case LayoutExportFormat::TIF:
         default:
             ui->checkBoxBinaryDXF->setEnabled(false);
             break;
     }
-
-    // enable or disable the settings specific for tiled pdf
-    switch(currentFormat)
-    {
-        case LayoutExportFormats::PNG:
-            ui->exportQuality_Slider->setEnabled(true);
-            break;
-        case LayoutExportFormats::JPG:
-            ui->exportQuality_Slider->setEnabled(true);
-            break;
-        case LayoutExportFormats::PDFTiled:
-            ui->groupBoxPaperFormat->setEnabled(true);
-            ui->groupBoxMargins->setEnabled(true);
-            break;
-        default:
-            ui->exportQuality_Slider->setEnabled(false);
-            ui->groupBoxPaperFormat->setEnabled(false);
-            ui->groupBoxMargins->setEnabled(false);
-            break;
-    }
-
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -693,102 +599,13 @@ void DialogSaveLayout::showEvent(QShowEvent *event)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-bool DialogSaveLayout::SupportPSTest()
-{
-    if (!tested)
-    {
-        havePdf = TestPdf();
-        tested = true;
-    }
-    return havePdf;
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-bool DialogSaveLayout::TestPdf()
-{
-    bool res = false;
-
-    QProcess proc;
-    QStringList args;
-#if defined(Q_OS_WIN) || defined(Q_OS_OSX)
-    // Seek pdftops in app bundle or near valentin.exe
-    proc.start(qApp->applicationDirPath() + QLatin1String("/")+ PDFTOPS, QStringList());
-#else
-    proc.start(PDFTOPS, QStringList()); // Seek pdftops in standard path
-#endif
-    if (proc.waitForStarted(15000) && (proc.waitForFinished(15000) || proc.state() == QProcess::NotRunning))
-    {
-        res = true;
-    }
-    else
-    {
-        qDebug()<<PDFTOPS<<"error"<<proc.error()<<proc.errorString();
-    }
-    return res;
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-QVector<std::pair<QString, LayoutExportFormats> > DialogSaveLayout::InitFormats()
-{
-    QVector<std::pair<QString, LayoutExportFormats>> list;
-
-    auto InitFormat = [&list](LayoutExportFormats format)
-    {
-        list.append(std::make_pair(ExportFormatDescription(format), format));
-    };
-
-    InitFormat(LayoutExportFormats::SVG);
-    InitFormat(LayoutExportFormats::PDF);
-    InitFormat(LayoutExportFormats::PDFTiled);
-    InitFormat(LayoutExportFormats::PNG);
-    InitFormat(LayoutExportFormats::JPG);
-    InitFormat(LayoutExportFormats::BMP);
-    InitFormat(LayoutExportFormats::PPM);
-    InitFormat(LayoutExportFormats::OBJ);
-    if (SupportPSTest())
-    {
-        InitFormat(LayoutExportFormats::PS);
-        InitFormat(LayoutExportFormats::EPS);
-    }
-    InitFormat(LayoutExportFormats::DXF_AC1006_Flat);
-    InitFormat(LayoutExportFormats::DXF_AC1009_Flat);
-    InitFormat(LayoutExportFormats::DXF_AC1012_Flat);
-    InitFormat(LayoutExportFormats::DXF_AC1014_Flat);
-    InitFormat(LayoutExportFormats::DXF_AC1015_Flat);
-    InitFormat(LayoutExportFormats::DXF_AC1018_Flat);
-    InitFormat(LayoutExportFormats::DXF_AC1021_Flat);
-    InitFormat(LayoutExportFormats::DXF_AC1024_Flat);
-    InitFormat(LayoutExportFormats::DXF_AC1027_Flat);
-    InitFormat(LayoutExportFormats::DXF_AC1006_AAMA);
-    InitFormat(LayoutExportFormats::DXF_AC1009_AAMA);
-    InitFormat(LayoutExportFormats::DXF_AC1012_AAMA);
-    InitFormat(LayoutExportFormats::DXF_AC1014_AAMA);
-    InitFormat(LayoutExportFormats::DXF_AC1015_AAMA);
-    InitFormat(LayoutExportFormats::DXF_AC1018_AAMA);
-    InitFormat(LayoutExportFormats::DXF_AC1021_AAMA);
-    InitFormat(LayoutExportFormats::DXF_AC1024_AAMA);
-    InitFormat(LayoutExportFormats::DXF_AC1027_AAMA);
-    // We will support them anyway
-//    InitFormat(LayoutExportFormats::DXF_AC1006_ASTM);
-//    InitFormat(LayoutExportFormats::DXF_AC1009_ASTM);
-//    InitFormat(LayoutExportFormats::DXF_AC1012_ASTM);
-//    InitFormat(LayoutExportFormats::DXF_AC1014_ASTM);
-//    InitFormat(LayoutExportFormats::DXF_AC1015_ASTM);
-//    InitFormat(LayoutExportFormats::DXF_AC1018_ASTM);
-//    InitFormat(LayoutExportFormats::DXF_AC1021_ASTM);
-//    InitFormat(LayoutExportFormats::DXF_AC1024_ASTM);
-//    InitFormat(LayoutExportFormats::DXF_AC1027_ASTM);
-
-    return list;
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-void DialogSaveLayout::RemoveFormatFromList(LayoutExportFormats format)
+void DialogSaveLayout::RemoveFormatFromList(LayoutExportFormat format)
 {
     const int index = ui->comboBoxFormat->findData(static_cast<int>(format));
     if (index != -1)
     {
         ui->comboBoxFormat->removeItem(index);
+        ui->comboBoxFormat->setCurrentToDefault();
     }
 }
 
@@ -879,5 +696,11 @@ void DialogSaveLayout::WriteSettings() const
     else
     {
         settings->SetTiledPDFOrientation(PageOrientation::Landscape);
+    }
+
+    //Export Format
+    if (qApp->Settings()->useLastExportFormat())
+    {
+        qApp->Settings()->setExportFormat(formatText());
     }
 }

--- a/src/app/seamly2d/dialogs/dialogsavelayout.h
+++ b/src/app/seamly2d/dialogs/dialogsavelayout.h
@@ -56,60 +56,14 @@
 #include <QMarginsF>
 
 #include "../vgeometry/vgeometrydef.h"
+#include "../vmisc/def.h"
 #include "vabstractlayoutdialog.h"
-
-#ifdef Q_OS_WIN
-#   define PDFTOPS "pdftops.exe"
-#else
-#   define PDFTOPS "pdftops"
-#endif
 
 namespace Ui
 {
     class DialogSaveLAyout;
 }
 
-enum class LayoutExportFormats : char
-{
-    SVG = 0,
-    PDF = 1,
-    PDFTiled = 2,
-    PNG = 3,
-    JPG = 4,
-    BMP = 5,
-    PPM = 6,
-    OBJ = 7,              /* Wavefront OBJ*/
-    PS  = 8,
-    EPS = 9,
-    DXF_AC1006_Flat = 10,  /* R10. */
-    DXF_AC1009_Flat = 11,  /* R11 & R12. */
-    DXF_AC1012_Flat = 12,  /* R13. */
-    DXF_AC1014_Flat = 13,  /* R14. */
-    DXF_AC1015_Flat = 14, /* ACAD 2000. */
-    DXF_AC1018_Flat = 15, /* ACAD 2004. */
-    DXF_AC1021_Flat = 16, /* ACAD 2007. */
-    DXF_AC1024_Flat = 17, /* ACAD 2010. */
-    DXF_AC1027_Flat = 18, /* ACAD 2013. */
-    DXF_AC1006_AAMA = 19, /* R10. */
-    DXF_AC1009_AAMA = 20, /* R11 & R12. */
-    DXF_AC1012_AAMA = 21, /* R13. */
-    DXF_AC1014_AAMA = 22, /* R14. */
-    DXF_AC1015_AAMA = 23, /* ACAD 2000. */
-    DXF_AC1018_AAMA = 24, /* ACAD 2004. */
-    DXF_AC1021_AAMA = 25, /* ACAD 2007. */
-    DXF_AC1024_AAMA = 26, /* ACAD 2010. */
-    DXF_AC1027_AAMA = 27, /* ACAD 2013. */
-    DXF_AC1006_ASTM = 28, /* R10. */
-    DXF_AC1009_ASTM = 29, /* R11 & R12. */
-    DXF_AC1012_ASTM = 30, /* R13. */
-    DXF_AC1014_ASTM = 31, /* R14. */
-    DXF_AC1015_ASTM = 32, /* ACAD 2000. */
-    DXF_AC1018_ASTM = 33, /* ACAD 2004. */
-    DXF_AC1021_ASTM = 34, /* ACAD 2007. */
-    DXF_AC1024_ASTM = 35, /* ACAD 2010. */
-    DXF_AC1027_ASTM = 36, /* ACAD 2013. */
-    COUNT                 /*Use only for validation*/
-};
 
 class DialogSaveLayout : public  VAbstractLayoutDialog
 {
@@ -120,22 +74,23 @@ public:
                               QWidget *parent = nullptr);
     virtual ~DialogSaveLayout();
 
-    QString Path() const;
-    QString FileName() const;
+    QString            Path() const;
+    QString            FileName() const;
 
-    LayoutExportFormats Format() const;
-    void                SelectFormat(LayoutExportFormats format);
+    LayoutExportFormat Format() const;
+    QString            formatText() const;
+    void               SelectFormat(LayoutExportFormat format);
 
-    void SetBinaryDXFFormat(bool binary);
-    bool IsBinaryDXFFormat() const;
+    void               SetBinaryDXFFormat(bool binary);
+    bool               IsBinaryDXFFormat() const;
 
-    static QString MakeHelpFormatList();
-    void   SetDestinationPath(const QString& cmdDestinationPath);
 
-    Draw Mode() const;
+    void               SetDestinationPath(const QString& cmdDestinationPath);
 
-    static QString ExportFormatDescription(LayoutExportFormats format);
-    static QString ExportFromatSuffix(LayoutExportFormats format);
+    Draw               Mode() const;
+
+
+    static QString exportFormatSuffix(LayoutExportFormat format);
 
     bool IsTextAsPaths() const;
     void SetTextAsPaths(bool textAsPaths);
@@ -157,13 +112,7 @@ private:
     bool isInitialized;
     Draw m_mode;
 
-    static bool havePdf;
-    static bool tested;
-    static bool SupportPSTest();
-    static bool TestPdf();
-    static QVector<std::pair<QString, LayoutExportFormats> > InitFormats();
-
-    void RemoveFormatFromList(LayoutExportFormats format);
+    void RemoveFormatFromList(LayoutExportFormat format);
 
     void ReadSettings();
     void WriteSettings() const;

--- a/src/app/seamly2d/dialogs/dialogsavelayout.ui
+++ b/src/app/seamly2d/dialogs/dialogsavelayout.ui
@@ -51,7 +51,7 @@
      <item row="0" column="0">
       <widget class="QGroupBox" name="groupBoxMargins">
        <property name="enabled">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="minimumSize">
         <size>
@@ -131,7 +131,7 @@
      <item row="0" column="1">
       <widget class="QGroupBox" name="groupBoxPaperFormat">
        <property name="enabled">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="minimumSize">
         <size>
@@ -292,7 +292,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="comboBoxFormat">
+        <widget class="ExportFormatCombobox" name="comboBoxFormat">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -568,6 +568,13 @@ border-radius: 4px;
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ExportFormatCombobox</class>
+   <extends>QComboBox</extends>
+   <header>export_format_combobox.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>lineEditPath</tabstop>
   <tabstop>pushButtonBrowse</tabstop>

--- a/src/app/seamly2d/mainwindow.ui
+++ b/src/app/seamly2d/mainwindow.ui
@@ -71,17 +71,27 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
-    <widget class="QMenu" name="layout_Menu">
+    <widget class="QMenu" name="print_Menu">
      <property name="title">
-      <string>Layout</string>
+      <string>Print</string>
+     </property>
+     <property name="icon">
+      <iconset resource="../../libs/vmisc/share/resources/theme.qrc">
+       <normaloff>:/icons/win.icon.theme/32x32/actions/document-print.png</normaloff>:/icons/win.icon.theme/32x32/actions/document-print.png</iconset>
+     </property>
+     <addaction name="print_Action"/>
+     <addaction name="printTiled_Action"/>
+    </widget>
+    <widget class="QMenu" name="preview_Menu">
+     <property name="title">
+      <string>Preview</string>
+     </property>
+     <property name="icon">
+      <iconset resource="../../libs/vmisc/share/resources/theme.qrc">
+       <normaloff>:/icons/win.icon.theme/32x32/actions/document-print-preview.png</normaloff>:/icons/win.icon.theme/32x32/actions/document-print-preview.png</iconset>
      </property>
      <addaction name="printPreview_Action"/>
-     <addaction name="print_Action"/>
-     <addaction name="separator"/>
      <addaction name="printPreviewTiled_Action"/>
-     <addaction name="printTiled_Action"/>
-     <addaction name="separator"/>
-     <addaction name="exportAs_Action"/>
     </widget>
     <addaction name="actionNew"/>
     <addaction name="actionOpen"/>
@@ -89,7 +99,10 @@
     <addaction name="save_Action"/>
     <addaction name="saveAs_Action"/>
     <addaction name="separator"/>
-    <addaction name="layout_Menu"/>
+    <addaction name="print_Menu"/>
+    <addaction name="preview_Menu"/>
+    <addaction name="separator"/>
+    <addaction name="exportAs_Action"/>
     <addaction name="separator"/>
     <addaction name="appPreferences_Action"/>
     <addaction name="patternPreferences_Action"/>
@@ -2563,8 +2576,8 @@
   </widget>
   <action name="actionNew">
    <property name="icon">
-    <iconset theme="document-new">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset resource="../../libs/vmisc/share/resources/theme.qrc">
+     <normaloff>:/icons/win.icon.theme/32x32/actions/document-new.png</normaloff>:/icons/win.icon.theme/32x32/actions/document-new.png</iconset>
    </property>
    <property name="text">
     <string>New</string>
@@ -2584,8 +2597,8 @@
   </action>
   <action name="actionOpen">
    <property name="icon">
-    <iconset theme="document-open">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset resource="../../libs/vmisc/share/resources/theme.qrc">
+     <normaloff>:/icons/win.icon.theme/32x32/actions/document-open.png</normaloff>:/icons/win.icon.theme/32x32/actions/document-open.png</iconset>
    </property>
    <property name="text">
     <string>Open</string>
@@ -2608,8 +2621,8 @@
     <bool>false</bool>
    </property>
    <property name="icon">
-    <iconset theme="document-save">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset resource="../../libs/vmisc/share/resources/theme.qrc">
+     <normaloff>:/icons/win.icon.theme/32x32/actions/document-save.png</normaloff>:/icons/win.icon.theme/32x32/actions/document-save.png</iconset>
    </property>
    <property name="text">
     <string>Save</string>
@@ -3522,8 +3535,8 @@
   </action>
   <action name="exit_Action">
    <property name="icon">
-    <iconset theme="application-exit">
-     <normaloff>.</normaloff>.</iconset>
+    <iconset resource="../../libs/vmisc/share/resources/theme.qrc">
+     <normaloff>:/icons/win.icon.theme/32x32/actions/application-exit.png</normaloff>:/icons/win.icon.theme/32x32/actions/application-exit.png</iconset>
    </property>
    <property name="text">
     <string>E&amp;xit</string>
@@ -3821,13 +3834,13 @@
    </property>
    <property name="icon">
     <iconset resource="share/resources/toolicon.qrc">
-     <normaloff>:/toolicon/32x32/export_to_picture_document.png</normaloff>:/toolicon/32x32/export_to_picture_document.png</iconset>
+     <normaloff>:/toolicon/32x32/export.png</normaloff>:/toolicon/32x32/export.png</iconset>
    </property>
    <property name="text">
     <string>Export As...</string>
    </property>
    <property name="toolTip">
-    <string>Export Layout (XL)</string>
+    <string>Export Layout (EL)</string>
    </property>
    <property name="shortcut">
     <string notr="true"/>
@@ -4564,6 +4577,11 @@
    </property>
    <property name="shortcut">
     <string>E, D</string>
+   </property>
+  </action>
+  <action name="actionExport">
+   <property name="text">
+    <string>Export</string>
    </property>
   </action>
  </widget>

--- a/src/app/seamly2d/mainwindowsnogui.h
+++ b/src/app/seamly2d/mainwindowsnogui.h
@@ -81,11 +81,18 @@ public slots:
     void PrintTiled();
     void RefreshDetailsLabel();
     void refreshGrainLines();
-    void svgFile(const QString &name, QGraphicsRectItem *paper, QGraphicsScene *scene)const;
-    void pngFile(const QString &name, QGraphicsScene *scene)const;
-    void jpgFile(const QString &name, QGraphicsScene *scene)const;
-    void bmpFile(const QString &name, QGraphicsScene *scene)const;
-    void ppmFile(const QString &name, QGraphicsScene *scene)const;
+    void exportSVG(const QString &name, QGraphicsRectItem *paper, QGraphicsScene *scene)const;
+    void exportPNG(const QString &name, QGraphicsScene *scene)const;
+    void exportTIF(const QString &name, QGraphicsScene *scene)const;
+    void exportJPG(const QString &name, QGraphicsScene *scene)const;
+    void exportBMP(const QString &name, QGraphicsScene *scene)const;
+    void exportPPM(const QString &name, QGraphicsScene *scene)const;
+    void exportPDF(const QString &name, QGraphicsRectItem *paper, QGraphicsScene *scene, bool ignoreMargins,
+                 const QMarginsF &margins)const;
+    void exportEPS(const QString &name, QGraphicsRectItem *paper, QGraphicsScene *scene, bool ignoreMargins,
+                 const QMarginsF &margins)const;
+    void exportPS(const QString &name, QGraphicsRectItem *paper, QGraphicsScene *scene, bool ignoreMargins,
+                const QMarginsF &margins)const;
 
 protected:
     QVector<VLayoutPiece> listDetails;
@@ -117,7 +124,7 @@ protected:
 
     bool isNoScaling;
     bool isLayoutStale;
-    bool ignorePrinterFields;
+    bool ignoreMargins;
     QMarginsF margins;
     QSizeF paperSize;
 
@@ -151,14 +158,10 @@ private:
                                                 const QList<QList<QGraphicsItem *> > &details);
 
 
-    void PdfFile(const QString &name, QGraphicsRectItem *paper, QGraphicsScene *scene, bool ignorePrinterFields,
-                 const QMarginsF &margins)const;
+
     void PdfTiledFile(const QString &name);
-    void EpsFile(const QString &name, QGraphicsRectItem *paper, QGraphicsScene *scene, bool ignorePrinterFields,
-                 const QMarginsF &margins)const;
-    void PsFile(const QString &name, QGraphicsRectItem *paper, QGraphicsScene *scene, bool ignorePrinterFields,
-                const QMarginsF &margins)const;
-    void PdfToPs(const QStringList &params)const;
+
+    void convertPdfToPs(const QStringList &params)const;
     void ObjFile(const QString &name, QGraphicsRectItem *paper, QGraphicsScene *scene)const;
     void FlatDxfFile(const QString &name, int version, bool binary, QGraphicsRectItem *paper, QGraphicsScene *scene,
                  const QList<QList<QGraphicsItem *> > &details)const;
@@ -188,7 +191,7 @@ private:
                      const QList<QGraphicsItem *> &papers,
                      const QList<QGraphicsItem *> &shadows,
                      const QList<QList<QGraphicsItem *> > &details,
-                     bool ignorePrinterFields, const QMarginsF &margins) const;
+                     bool ignoreMargins, const QMarginsF &margins) const;
 
     void ExportApparelLayout(const DialogSaveLayout &dialog, const QVector<VLayoutPiece> &details, const QString &name,
                              const QSize &size) const;
@@ -200,7 +203,7 @@ private:
                           const QList<QGraphicsItem *> &papers,
                           const QList<QGraphicsItem *> &shadows,
                           const QList<QList<QGraphicsItem *> > &details,
-                          bool ignorePrinterFields, const QMarginsF &margins);
+                          bool ignoreMargins, const QMarginsF &margins);
 
     void ExportDetailsAsFlatLayout(const DialogSaveLayout &dialog, const QVector<VLayoutPiece> &listDetails);
 };

--- a/src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp
+++ b/src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.cpp
@@ -102,7 +102,7 @@ SeamlyMePreferencesConfigurationPage::SeamlyMePreferencesConfigurationPage(QWidg
     {
         VSeamlyMeSettings *settings = qApp->SeamlyMeSettings();
 
-        settings->SetConfirmFormatRewriting(true);
+        settings->setConfirmFormatRewriting(true);
     });
 
     //----------------------- Toolbar

--- a/src/libs/ifc/xml/vabstractpattern.cpp
+++ b/src/libs/ifc/xml/vabstractpattern.cpp
@@ -249,14 +249,15 @@ void ReadExpressionAttribute(QVector<VFormulaField> &expressions, const QDomElem
 
 //---------------------------------------------------------------------------------------------------------------------
 VAbstractPattern::VAbstractPattern(QObject *parent)
-    : QObject(parent),
-      VDomDocument(),
-      activeDraftBlock(QString()),
-      cursor(0),
-      toolsOnRemove(QVector<VDataTool*>()),
-      history(QVector<VToolRecord>()),
-      patternPieces(QStringList()),
-      modified(false)
+    : QObject(parent)
+    ,  VDomDocument()
+    ,  activeDraftBlock(QString())
+    ,  lastSavedExportFormat(QString())
+    ,  cursor(0)
+    ,  toolsOnRemove(QVector<VDataTool*>())
+    ,  history(QVector<VToolRecord>())
+    ,  patternPieces(QStringList())
+     , modified(false)
 {}
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/ifc/xml/vabstractpattern.h
+++ b/src/libs/ifc/xml/vabstractpattern.h
@@ -110,6 +110,7 @@ public:
 
     void           changeActiveDraftBlock(const QString& name, const Document &parse = Document::FullParse);
     QString        getActiveDraftBlockName() const;
+
     bool           CheckExistNamePP(const QString& name) const;
     int            CountPP() const;
     QDomElement    GetPPElement(const QString &name);
@@ -404,6 +405,8 @@ public slots:
 protected:
     /** @brief nameActivDraw name current pattern peace. */
     QString        activeDraftBlock;
+
+    QString        lastSavedExportFormat;
 
     /** @brief cursor cursor keep id tool after which we will add new tool in file. */
     quint32        cursor;

--- a/src/libs/vdxf/vdxfpaintdevice.cpp
+++ b/src/libs/vdxf/vdxfpaintdevice.cpp
@@ -135,7 +135,7 @@ void VDxfPaintDevice::SetBinaryFormat(bool binary)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-bool VDxfPaintDevice::IsBinaryFromat() const
+bool VDxfPaintDevice::IsBinaryFormat() const
 {
     return engine->IsBinaryFormat();
 }

--- a/src/libs/vdxf/vdxfpaintdevice.h
+++ b/src/libs/vdxf/vdxfpaintdevice.h
@@ -61,7 +61,7 @@ public:
     void         SetVersion(DRW::Version version);
 
     void SetBinaryFormat(bool binary);
-    bool IsBinaryFromat() const;
+    bool IsBinaryFormat() const;
 
     void setMeasurement(const VarMeasurement &var);
     void setInsunits(const VarInsunits &var);

--- a/src/libs/vmisc/def.h
+++ b/src/libs/vmisc/def.h
@@ -79,6 +79,49 @@ class QGraphicsItem;
 
 #define SceneSize 50000
 
+enum class LayoutExportFormat : char
+{
+    SVG = 0,
+    PDF = 1,
+    PDFTiled = 2,
+    PNG = 3,
+    JPG = 4,
+    BMP = 5,
+    PPM = 6,
+    OBJ = 7,              /* Wavefront OBJ*/
+    PS  = 8,
+    EPS = 9,
+    DXF_AC1006_Flat = 10,  /* R10. */
+    DXF_AC1009_Flat = 11,  /* R11 & R12. */
+    DXF_AC1012_Flat = 12,  /* R13. */
+    DXF_AC1014_Flat = 13,  /* R14. */
+    DXF_AC1015_Flat = 14, /* ACAD 2000. */
+    DXF_AC1018_Flat = 15, /* ACAD 2004. */
+    DXF_AC1021_Flat = 16, /* ACAD 2007. */
+    DXF_AC1024_Flat = 17, /* ACAD 2010. */
+    DXF_AC1027_Flat = 18, /* ACAD 2013. */
+    DXF_AC1006_AAMA = 19, /* R10. */
+    DXF_AC1009_AAMA = 20, /* R11 & R12. */
+    DXF_AC1012_AAMA = 21, /* R13. */
+    DXF_AC1014_AAMA = 22, /* R14. */
+    DXF_AC1015_AAMA = 23, /* ACAD 2000. */
+    DXF_AC1018_AAMA = 24, /* ACAD 2004. */
+    DXF_AC1021_AAMA = 25, /* ACAD 2007. */
+    DXF_AC1024_AAMA = 26, /* ACAD 2010. */
+    DXF_AC1027_AAMA = 27, /* ACAD 2013. */
+    DXF_AC1006_ASTM = 28, /* R10. */
+    DXF_AC1009_ASTM = 29, /* R11 & R12. */
+    DXF_AC1012_ASTM = 30, /* R13. */
+    DXF_AC1014_ASTM = 31, /* R14. */
+    DXF_AC1015_ASTM = 32, /* ACAD 2000. */
+    DXF_AC1018_ASTM = 33, /* ACAD 2004. */
+    DXF_AC1021_ASTM = 34, /* ACAD 2007. */
+    DXF_AC1024_ASTM = 35, /* ACAD 2010. */
+    DXF_AC1027_ASTM = 36, /* ACAD 2013. */
+    TIF = 37,             /* TIFF */
+    COUNT                 /*Use only for validation*/
+};
+
 enum class NodeDetail : char { Contour, Modeling };
 enum class SceneObject : char { Point, Line, Spline, Arc, ElArc, SplinePath, Detail, Unknown };
 enum class MeasurementsType : char { Multisize, Individual , Unknown};

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -79,6 +79,10 @@ const QString settingPathsLabelTemplate                  = QStringLiteral("paths
 const QString settingConfigurationOsSeparator            = QStringLiteral("configuration/osSeparator");
 const QString settingConfigurationAutosaveState          = QStringLiteral("configuration/autosave/state");
 const QString settingConfigurationAutosaveTime           = QStringLiteral("configuration/autosave/time");
+
+const QString settingConfigurationUseLastExportFormat    = QStringLiteral("configuration/autosave/useLastExportFormat");
+const QString settingConfigurationExportFormat           = QStringLiteral("configuration/autosave/exportFormat");
+
 const QString settingConfigurationSendReportState        = QStringLiteral("configuration/send_report/state");
 const QString settingConfigurationLocale                 = QStringLiteral("configuration/locale");
 const QString settingPMSystemCode                        = QStringLiteral("configuration/pmscode");
@@ -476,7 +480,7 @@ void VCommonSettings::SetAutosaveState(const bool &value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-int VCommonSettings::GetAutosaveTime() const
+int VCommonSettings::getAutosaveInterval() const
 {
     bool ok = false;
     int val = value(settingConfigurationAutosaveTime, 1).toInt(&ok);
@@ -490,9 +494,33 @@ int VCommonSettings::GetAutosaveTime() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VCommonSettings::SetAutosaveTime(const int &value)
+void VCommonSettings::setAutosaveInterval(const int &value)
 {
     setValue(settingConfigurationAutosaveTime, value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+bool VCommonSettings::useLastExportFormat() const
+{
+    return value(settingConfigurationUseLastExportFormat, true).toBool();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VCommonSettings::setUseLastExportFormat(const bool &value)
+{
+    setValue(settingConfigurationUseLastExportFormat, value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QString VCommonSettings::getExportFormat() const
+{
+    return value(settingConfigurationExportFormat, "SVG").toString();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VCommonSettings::setExportFormat(const QString &value)
+{
+    setValue(settingConfigurationExportFormat, value);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -545,25 +573,25 @@ void VCommonSettings::SetUnit(const QString &value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-bool VCommonSettings::GetConfirmItemDelete() const
+bool VCommonSettings::getConfirmItemDelete() const
 {
     return value(settingConfigurationConfirmItemDeletion, 1).toBool();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VCommonSettings::SetConfirmItemDelete(const bool &value)
+void VCommonSettings::setConfirmItemDelete(const bool &value)
 {
     setValue(settingConfigurationConfirmItemDeletion, value);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-bool VCommonSettings::GetConfirmFormatRewriting() const
+bool VCommonSettings::getConfirmFormatRewriting() const
 {
     return value(settingConfigurationConfirmFormatRewriting, 1).toBool();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VCommonSettings::SetConfirmFormatRewriting(const bool &value)
+void VCommonSettings::setConfirmFormatRewriting(const bool &value)
 {
     setValue(settingConfigurationConfirmFormatRewriting, value);
 }

--- a/src/libs/vmisc/vcommonsettings.h
+++ b/src/libs/vmisc/vcommonsettings.h
@@ -99,8 +99,14 @@ public:
     bool                 GetAutosaveState() const;
     void                 SetAutosaveState(const bool &value);
 
-    int                  GetAutosaveTime() const;
-    void                 SetAutosaveTime(const int &value);
+    int                  getAutosaveInterval() const;
+    void                 setAutosaveInterval(const int &value);
+
+    bool                 useLastExportFormat() const;
+    void                 setUseLastExportFormat(const bool &value);
+
+    QString              getExportFormat() const;
+    void                 setExportFormat(const QString &value);
 
     bool                 GetSendReportState() const;
     void                 SetSendReportState(const bool &value);
@@ -114,11 +120,11 @@ public:
     QString              GetUnit() const;
     void                 SetUnit(const QString &value);
 
-    bool                 GetConfirmItemDelete() const;
-    void                 SetConfirmItemDelete(const bool &value);
+    bool                 getConfirmItemDelete() const;
+    void                 setConfirmItemDelete(const bool &value);
 
-    bool                 GetConfirmFormatRewriting() const;
-    void                 SetConfirmFormatRewriting(const bool &value);
+    bool                 getConfirmFormatRewriting() const;
+    void                 setConfirmFormatRewriting(const bool &value);
 
     QString              getMoveSuffix() const;
     void                 setMoveSuffix(const QString &value);

--- a/src/libs/vtools/tools/vabstracttool.cpp
+++ b/src/libs/vtools/tools/vabstracttool.cpp
@@ -295,7 +295,7 @@ void VAbstractTool::deleteTool(bool ask)
 //---------------------------------------------------------------------------------------------------------------------
 int VAbstractTool::ConfirmDeletion()
 {
-    if (false == qApp->Settings()->GetConfirmItemDelete())
+    if (false == qApp->Settings()->getConfirmItemDelete())
     {
         return QMessageBox::Yes;
     }
@@ -311,7 +311,7 @@ int VAbstractTool::ConfirmDeletion()
 
     if (dialogResult == QDialog::Accepted)
     {
-        qApp->Settings()->SetConfirmItemDelete(not msgBox.isChecked());
+        qApp->Settings()->setConfirmItemDelete(not msgBox.isChecked());
     }
 
     return dialogResult == QDialog::Accepted ? QMessageBox::Yes : QMessageBox::No;

--- a/src/libs/vwidgets/export_format_combobox.cpp
+++ b/src/libs/vwidgets/export_format_combobox.cpp
@@ -1,0 +1,330 @@
+ /******************************************************************************
+  *   @file   export_format_combobox.cpp
+  **  @author DS Caskey
+  **  @date   Mar 15, 2022
+  **
+  **  @brief
+  **  @copyright
+  **
+  **  Seamly2D is free software: you can redistribute it and/or modify
+  **  it under the terms of the GNU General Public License as published by
+  **  the Free Software Foundation, either version 3 of the License, or
+  **  (at your option) any later version.
+  **
+  **  Seamly2D is distributed in the hope that it will be useful,
+  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  **  GNU General Public License for more details.
+  **
+  **  You should have received a copy of the GNU General Public License
+  **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+  **
+  *****************************************************************************/
+
+#include <QAbstractItemView>
+#include <QPen>
+#include <Qt>
+#include <QPainter>
+#include <QPixmap>
+#include <QProcess>
+#include <QDebug>
+#include <QVariant>
+
+#include "export_format_combobox.h"
+#include "../vmisc/vabstractapplication.h"
+#include "../vmisc/vcommonsettings.h"
+
+#ifdef Q_OS_WIN
+#   define PDFTOPS "pdftops.exe"
+#else
+#   define PDFTOPS "pdftops"
+#endif
+
+bool ExportFormatCombobox::havePdf = false;
+bool ExportFormatCombobox::tested  = false;
+
+/**
+ * Constructor with name.
+ */
+ExportFormatCombobox::ExportFormatCombobox(QWidget *parent, const char *name)
+		: QComboBox(parent)
+      	, m_currentFormat()
+{
+		 setObjectName(name);
+		 setEditable ( false );
+		 init();
+}
+
+/**
+ * Destructor
+ */
+ExportFormatCombobox::~ExportFormatCombobox() {}
+
+/**
+ * Initialisation called from constructor or manually but only once.
+ */
+void ExportFormatCombobox::init()
+{
+    this->blockSignals(true);
+
+    int count = 0;
+    foreach (auto& v, initFormats())
+    {
+        addItem(v.first, QVariant(static_cast<int>(v.second)));
+        count++;
+    }
+    setMaxVisibleItems(count);
+
+    this->view()->setTextElideMode(Qt::ElideNone);
+
+    this->blockSignals(false);
+		connect(this, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ExportFormatCombobox::updateExportFormat);
+
+    setCurrentToDefault();
+    updateExportFormat(currentIndex());
+}
+
+LayoutExportFormat ExportFormatCombobox::getExportFormat() const
+{
+    return m_currentFormat;
+}
+
+/**
+ * Sets the currently selected format item to the given format.
+ */
+void ExportFormatCombobox::setExportFormat(LayoutExportFormat &format)
+{
+    m_currentFormat = format;
+
+    setCurrentIndex(findData(QVariant(static_cast<int>(format))));
+
+    if (currentIndex()!= count() -1 )
+    {
+        updateExportFormat(currentIndex());
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QVector<std::pair<QString, LayoutExportFormat>> ExportFormatCombobox::initFormats()
+{
+    QVector<std::pair<QString, LayoutExportFormat>> list;
+
+    auto InitFormat = [&list](LayoutExportFormat format)
+    {
+        list.append(std::make_pair(exportFormatDescription(format), format));
+    };
+
+    InitFormat(LayoutExportFormat::SVG);
+    InitFormat(LayoutExportFormat::PDF);
+    InitFormat(LayoutExportFormat::PDFTiled);
+    InitFormat(LayoutExportFormat::PNG);
+    InitFormat(LayoutExportFormat::JPG);
+    InitFormat(LayoutExportFormat::BMP);
+    InitFormat(LayoutExportFormat::TIF);
+    InitFormat(LayoutExportFormat::PPM);
+    InitFormat(LayoutExportFormat::OBJ);
+    if (supportPSTest())
+    {
+        InitFormat(LayoutExportFormat::PS);
+        InitFormat(LayoutExportFormat::EPS);
+    }
+    InitFormat(LayoutExportFormat::DXF_AC1006_Flat);
+    InitFormat(LayoutExportFormat::DXF_AC1009_Flat);
+    InitFormat(LayoutExportFormat::DXF_AC1012_Flat);
+    InitFormat(LayoutExportFormat::DXF_AC1014_Flat);
+    InitFormat(LayoutExportFormat::DXF_AC1015_Flat);
+    InitFormat(LayoutExportFormat::DXF_AC1018_Flat);
+    InitFormat(LayoutExportFormat::DXF_AC1021_Flat);
+    InitFormat(LayoutExportFormat::DXF_AC1024_Flat);
+    InitFormat(LayoutExportFormat::DXF_AC1027_Flat);
+    InitFormat(LayoutExportFormat::DXF_AC1006_AAMA);
+    InitFormat(LayoutExportFormat::DXF_AC1009_AAMA);
+    InitFormat(LayoutExportFormat::DXF_AC1012_AAMA);
+    InitFormat(LayoutExportFormat::DXF_AC1014_AAMA);
+    InitFormat(LayoutExportFormat::DXF_AC1015_AAMA);
+    InitFormat(LayoutExportFormat::DXF_AC1018_AAMA);
+    InitFormat(LayoutExportFormat::DXF_AC1021_AAMA);
+    InitFormat(LayoutExportFormat::DXF_AC1024_AAMA);
+    InitFormat(LayoutExportFormat::DXF_AC1027_AAMA);
+    // We will support them anyway
+//    InitFormat(LayoutExportFormat::DXF_AC1006_ASTM);
+//    InitFormat(LayoutExportFormat::DXF_AC1009_ASTM);
+//    InitFormat(LayoutExportFormat::DXF_AC1012_ASTM);
+//    InitFormat(LayoutExportFormat::DXF_AC1014_ASTM);
+//    InitFormat(LayoutExportFormat::DXF_AC1015_ASTM);
+//    InitFormat(LayoutExportFormat::DXF_AC1018_ASTM);
+//    InitFormat(LayoutExportFormat::DXF_AC1021_ASTM);
+//    InitFormat(LayoutExportFormat::DXF_AC1024_ASTM);
+//    InitFormat(LayoutExportFormat::DXF_AC1027_ASTM);
+
+    return list;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+bool ExportFormatCombobox::supportPSTest()
+{
+    if (!tested)
+    {
+        havePdf = testPdf();
+        tested = true;
+    }
+    return havePdf;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+bool ExportFormatCombobox::testPdf()
+{
+    bool res = false;
+
+    QProcess proc;
+    QStringList args;
+
+#if defined(Q_OS_WIN) || defined(Q_OS_OSX)
+    // Seek pdftops in app bundle or near valentin.exe
+    proc.start(qApp->applicationDirPath() + QLatin1String("/")+ PDFTOPS, QStringList());
+#else
+    proc.start(PDFTOPS, QStringList()); // Seek pdftops in standard path
+#endif
+
+    if (proc.waitForStarted(15000) && (proc.waitForFinished(15000) || proc.state() == QProcess::NotRunning))
+    {
+        res = true;
+    }
+    else
+    {
+        qDebug()<<PDFTOPS<<"error"<<proc.error()<<proc.errorString();
+    }
+    return res;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QString ExportFormatCombobox::exportFormatDescription(LayoutExportFormat format)
+{
+    const QString dxfSuffix = QStringLiteral("(*.dxf)");
+    const QString dxfFlatFilesStr = tr("(flat) files");
+    const QString filesStr = tr("files");
+
+    switch(format)
+    {
+        case LayoutExportFormat::SVG:
+            return QString("SVG %1 (*.svg)").arg(filesStr);
+        case LayoutExportFormat::PDF:
+            return QString("PDF %1 (*.pdf)").arg(filesStr);
+        case LayoutExportFormat::PNG:
+            return QString("PNG %1 (*.png)").arg(filesStr);
+        case LayoutExportFormat::JPG:
+            return QString("JPG %1 (*.jpg)").arg(filesStr);
+        case LayoutExportFormat::BMP:
+            return QString("BMP %1 (*.bmp)").arg(filesStr);
+        case LayoutExportFormat::TIF:
+            return QString("TIF %1 (*.tif)").arg(filesStr);
+        case LayoutExportFormat::PPM:
+            return QString("PPM %1 (*.ppm)").arg(filesStr);
+        case LayoutExportFormat::OBJ:
+            return "Wavefront OBJ (*.obj)";
+        case LayoutExportFormat::PS:
+            return QString("PS %1 (*.ps)").arg(filesStr);
+        case LayoutExportFormat::EPS:
+            return QString("EPS %1 (*.eps)").arg(filesStr);
+        case LayoutExportFormat::DXF_AC1006_Flat:
+            return QString("AutoCAD DXF R10 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1009_Flat:
+            return QString("AutoCAD DXF R11/12 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1012_Flat:
+            return QString("AutoCAD DXF R13 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1014_Flat:
+            return QString("AutoCAD DXF R14 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1015_Flat:
+            return QString("AutoCAD DXF 2000 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1018_Flat:
+            return QString("AutoCAD DXF 2004 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1021_Flat:
+            return QString("AutoCAD DXF 2007 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1024_Flat:
+            return QString("AutoCAD DXF 2010 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1027_Flat:
+            return QString("AutoCAD DXF 2013 %1 %2").arg(dxfFlatFilesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1006_AAMA:
+            return QString("AutoCAD DXF R10 AAMA %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1009_AAMA:
+            return QString("AutoCAD DXF R11/12 AAMA %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1012_AAMA:
+            return QString("AutoCAD DXF R13 AAMA %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1014_AAMA:
+            return QString("AutoCAD DXF R14 AAMA %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1015_AAMA:
+            return QString("AutoCAD DXF 2000 AAMA %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1018_AAMA:
+            return QString("AutoCAD DXF 2004 AAMA %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1021_AAMA:
+            return QString("AutoCAD DXF 2007 AAMA %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1024_AAMA:
+            return QString("AutoCAD DXF 2010 AAMA %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1027_AAMA:
+            return QString("AutoCAD DXF 2013 AAMA %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1006_ASTM:
+            return QString("AutoCAD DXF R10 ASTM %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1009_ASTM:
+            return QString("AutoCAD DXF R11/12 ASTM %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1012_ASTM:
+            return QString("AutoCAD DXF R13 ASTM %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1014_ASTM:
+            return QString("AutoCAD DXF R14 ASTM %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1015_ASTM:
+            return QString("AutoCAD DXF 2000 ASTM %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1018_ASTM:
+            return QString("AutoCAD DXF 2004 ASTM %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1021_ASTM:
+            return QString("AutoCAD DXF 2007 ASTM %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1024_ASTM:
+            return QString("AutoCAD DXF 2010 ASTM %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::DXF_AC1027_ASTM:
+            return QString("AutoCAD DXF 2013 ASTM %1 %2").arg(filesStr, dxfSuffix);
+        case LayoutExportFormat::PDFTiled:
+            return QString("PDF tiled %1 (*.pdf)").arg(filesStr);
+        default:
+            return QString();
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+QString ExportFormatCombobox::makeHelpFormatList()
+{
+   QString out("\n");
+   foreach(auto& v, initFormats())
+   {
+       out += QLatin1String("\t") + v.first + QLatin1String(" = ") + QString::number(static_cast<int>(v.second))
+               + QLatin1String("\n");
+   }
+   return out;
+}
+
+/**
+ * Called when the width has changed. This method sets the current width to the value chosen or even
+ * offers a dialog to the user that allows him/ her to choose an individual width.
+ */
+void ExportFormatCombobox::updateExportFormat(int index)
+{
+    QVariant format = itemData(index);
+    if(format != QVariant::Invalid )
+    {
+       m_currentFormat = static_cast<LayoutExportFormat>(this->currentData().toInt());
+    }
+
+    emit exportFormatChanged(m_currentFormat);
+}
+
+void ExportFormatCombobox::setCurrentToDefault()
+{
+    QString format = qApp->Settings()->getExportFormat();
+
+    int index = findText(format);
+    if (index != -1)
+    {
+        setCurrentIndex(index);
+    }
+    else
+    {
+        setCurrentIndex(0);
+    }
+}

--- a/src/libs/vwidgets/export_format_combobox.h
+++ b/src/libs/vwidgets/export_format_combobox.h
@@ -1,0 +1,68 @@
+/******************************************************************************
+ *   @file   export_format_combobox.h
+ **  @author DS Caskey
+ **  @date   Mar 15, 2022
+ **
+ **  @brief
+ **  @copyright
+ **
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+ **
+ *****************************************************************************/
+
+
+#ifndef LINEWEIGHT_COMBOBOX_H
+#define LINEWEIGHT_COMBOBOX_H
+
+#include <QComboBox>
+#include <QWidget>
+
+#include "../vmisc/def.h"
+#include "../ifc/xml/vabstractpattern.h"
+
+/**
+ * A comboBox for choosing an export format type.
+ */
+class ExportFormatCombobox: public QComboBox
+{
+    Q_OBJECT
+
+public:
+                        ExportFormatCombobox(QWidget *parent = nullptr, const char *name = nullptr);
+    virtual            ~ExportFormatCombobox();
+
+    void                init();
+
+    LayoutExportFormat getExportFormat() const;
+    void                setExportFormat(LayoutExportFormat &format);
+    static QString      exportFormatDescription(LayoutExportFormat format);
+    static QString      makeHelpFormatList();
+    void                setCurrentToDefault();
+
+private slots:
+    void                updateExportFormat(int index);
+
+signals:
+    void                exportFormatChanged(const LayoutExportFormat &format);
+
+private:
+    static QVector<std::pair<QString, LayoutExportFormat> > initFormats();
+    static bool         supportPSTest();
+    static bool         testPdf();
+    static bool         havePdf;
+    static bool         tested;
+    LayoutExportFormat m_currentFormat;
+};
+
+#endif

--- a/src/libs/vwidgets/vabstractmainwindow.cpp
+++ b/src/libs/vwidgets/vabstractmainwindow.cpp
@@ -45,7 +45,7 @@ VAbstractMainWindow::VAbstractMainWindow(QWidget *parent)
 bool VAbstractMainWindow::ContinueFormatRewrite(const QString &currentFormatVersion,
                                                 const QString &maxFormatVersion)
 {
-    if (qApp->Settings()->GetConfirmFormatRewriting())
+    if (qApp->Settings()->getConfirmFormatRewriting())
     {
         Utils::CheckableMessageBox msgBox(this);
         msgBox.setWindowTitle(tr("Confirm format rewriting"));
@@ -61,7 +61,7 @@ bool VAbstractMainWindow::ContinueFormatRewrite(const QString &currentFormatVers
 
         if (dialogResult == QDialog::Accepted)
         {
-            qApp->Settings()->SetConfirmFormatRewriting(not msgBox.isChecked());
+            qApp->Settings()->setConfirmFormatRewriting(not msgBox.isChecked());
             return true;
         }
         else

--- a/src/libs/vwidgets/vwidgets.pri
+++ b/src/libs/vwidgets/vwidgets.pri
@@ -5,6 +5,7 @@ SOURCES += \
     $$PWD/calculator/button.cpp \
     $$PWD/calculator/calculator.cpp \
     $$PWD/color_combobox.cpp \
+    $$PWD/export_format_combobox.cpp \
     $$PWD/linetype_combobox.cpp \
     $$PWD/lineweight_combobox.cpp \
     $$PWD/scene_rect.cpp \
@@ -36,6 +37,7 @@ HEADERS += \
     $$PWD/calculator/button.h \
     $$PWD/calculator/calculator.h \
     $$PWD/color_combobox.h \
+    $$PWD/export_format_combobox.h \
     $$PWD/linetype_combobox.h \
     $$PWD/lineweight_combobox.h \
     $$PWD/scene_rect.h \


### PR DESCRIPTION
This adds:

- A default export file format preference, and a "Save last used" checkbox that when checked will save the last used export format to the format preference.  
- 
- To maintain consistency replaces the standard save file dialog with the Export Layout / Pieces dialog for the Export Draft blocks. 
- 
- Adds the TIF format to the exports.
- 
- Adds the PDF to the Export Draft blocks. 