### PR TITLE
fix: wireframe toggle for points

### DIFF
--- a/src/libs/vwidgets/vscenepoint.cpp
+++ b/src/libs/vwidgets/vscenepoint.cpp
@@ -216,7 +216,7 @@ void VScenePoint::setPointPen(qreal scale)
     {
         setPen(QPen(correctColor(this, m_pointColor), width));
         if (!m_onlyPoint)
-        {            
+        {
             if (!qApp->Settings()->isWireframe())
             {
                setBrush(QBrush(correctColor(this, m_pointColor), Qt::SolidPattern));
@@ -235,7 +235,7 @@ void VScenePoint::setPointPen(qreal scale)
     {
         setPen(QPen(correctColor(this, QColor(qApp->Settings()->getPointNameColor())), width));
 
-        if (qApp->Settings()->isWireframe())
+        if (!qApp->Settings()->isWireframe())
         {
            setBrush(QBrush(correctColor(this, QColor(qApp->Settings()->getPointNameColor())),Qt::SolidPattern));
         }


### PR DESCRIPTION
This fixes the toggling of the points so that when the wireframe button / menu  is selected there is no  point fill - which now matches the behavior of the control point squares.

This fixes issue#623