### PR TITLE
Fix various typos in the codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 - [#689] Grainline default values swapped around.
 - [#688] Difficult to enter numbers in SeamlyMe.
 - Fixed bug in SeamlyMe app. SeamlyMe showed birth date in wrong locale.
-- Fixed bug in dialog Internal Piece Path. Value from the field After rewrited data in the field Before.
+- Fixed bug in dialog Internal Piece Path. Value from the field After rewritten data in the field Before.
 - Tab Pins moved to be second in the list after tab Paths. 
 - Added tooltip for tab Passmark. Explained meaning of check box "Show the second passmark on seam line". 
 - [#696] Wrong grainline position on layout.
@@ -45,7 +45,7 @@
 - [#703] Seamly2D warns about format rewriting for unsaved files.
 - [#704] Seamly2D crashes if click on detail.
 - [#706] Default unit in preferences not changing new file unit.
-- Fix bug. Seamly2D overrids exported file even if a user said no.
+- Fix bug. Seamly2D overrides exported file even if a user said no.
 - Fix bug. Date on label doesn't obey GUI language locale.
 - Tool Seam allowance's bounding box should not include passmarks.
 - Fix grainline position on layout.
@@ -151,7 +151,7 @@
 ## Version 0.4.4 April 12, 2016
 - Updated measurement templates with all measurements. Added new template Aldrich/Women measurements.
 - Updated description measurements N06 and N07. Add new measurements A23 and J10.
-- Fixed GUI issue. After full parse some widgets was incorrectly reseted.
+- Fixed GUI issue. After full parse some widgets was incorrectly reset.
 - [#464] Crash. Issue with modeling node objects.
 - [#463] Wrong export to DXF format.
 - Fixed issue with deleting detail nodes.
@@ -178,7 +178,7 @@
 - Regesign dialogs tool 'Spline' and 'Spline Path' for avoiding text squeeze.
 - Fixed getting correct reversed segment for single in the list curve.
 - Fixed triggering validation a detail. Two new cases: has been changed Reverse option and the list 
-has been scrolled. Fixed validation when the list conatains only curve.
+has been scrolled. Fixed validation when the list contains only curve.
 - Fixed broken path to measurements after using Save As option.
 - Tool line. Block selecting the same point twice.
 - [#443] Not valid dxf file. libdxf updated to version 3.12.2.0. Fixed drawing subpaths.

--- a/common.pri
+++ b/common.pri
@@ -49,7 +49,7 @@ macx{
 CONFIG(release, debug|release){
     !noDebugSymbols:win32:!*msvc*{
         unset(QMAKE_STRIP)
-        QMAKE_STRIP = echo # we do striping manualy
+        QMAKE_STRIP = echo # we do stripping manually
     }
 }
 
@@ -220,8 +220,8 @@ CONFIG(debug, debug|release){
 # Default prefix. Use for creation install path.
 DEFAULT_PREFIX = /usr
 
-# In debug mode on Unix system we use all usefull for us compilers keys for checking errors.
-# Also trying make all possible for speed up build time.
+# In debug mode on Unix systems we use all useful compilers keys for checking errors.
+# Also trying make it as possible to speed-up build time.
 unix {
 
 !macx{
@@ -265,12 +265,12 @@ ISYSTEM += \
     -isystem "$$[QT_INSTALL_LIBS]/QtOpenGL.framework/Versions/5/Headers/"
 }
 
-# Usefull GCC warnings keys.
+# Useful GCC warnings keys.
 GCC_DEBUG_CXXFLAGS += \
-    -O0 \ # Turn off oprimization.
+    -O0 \ # Turn off optimization.
     $$ISYSTEM \ # Ignore warnings Qt headers.
     # Last gdb doesn't show debug symbols with Qt Creator (issue with Python 3 and debug scripts that use Python 2.7).
-    # Solution to use older version gdb, that's why we use old standard of debug information.
+    # Solution to use an older version of gdb, that's why we use older formatting of debug information.
     -gdwarf-3 \
     -Wall \
     -Wextra \
@@ -343,12 +343,12 @@ g++7:GCC_DEBUG_CXXFLAGS += \
     -Walloc-zero \
     -Wnonnull
 
-# Usefull Clang warnings keys.
+# Useful Clang warnings keys.
 CLANG_DEBUG_CXXFLAGS += \
-    -O0 \ # Turn off oprimization.
+    -O0 \ # Turn off optimization.
     $$ISYSTEM \ # Ignore warnings in Qt headers.
     # Last gdb doesn't show debug symbols with Qt Creator (issue with Python 3 and debug scripts that use Python 2.7).
-    # Solution to use older version gdb, that's why we use old standard of debug information.
+    # Solution to use older version gdb, that's why we use older formatting of debug information.
     -gdwarf-3 \
     -fparse-all-comments \
     -Wabi \

--- a/dist/Launchpad_README
+++ b/dist/Launchpad_README
@@ -53,7 +53,7 @@ If all goes well, you can leave your pbuilder environment by typing:
 	exit
 - Tell the pbuilder environment that it is going to act just like the Launchpad build farm
 Still in our terminal:
-    sudo pbuilder create --debootstrapopts --variant=buildd
+    sudo pbuilder create --debootstrapopts --variant=build
 -  Update our environment with these new packages
 Still in our terminal, type:
 	sudo pbuilder --update --override-config
@@ -86,7 +86,7 @@ DEBEMAIL="<Your email address>"
         lp:seamly2d
         merge packaging lp:~dismine/seamly2d/debian
 
-	Next command usefull for local testing creation recipe.
+	Next command useful for local testing creation recipe.
 - Run command
     cd bzr
     bzr dailydeb --allow-fallback-to-native seamly2d.recipe working-dir

--- a/dist/OBS_debian/debian.seamly2d.1
+++ b/dist/OBS_debian/debian.seamly2d.1
@@ -179,7 +179,7 @@ The path to output destination folder. By default the directory at which the app
 .IP "-G, --gapwidth <The gap width>"
 .RB "The layout gap width x2, measured in layout units (" "export mode" "). Set distance between details and a detail and a sheet."
 .IP "-g, --groups <Grouping type>"
-.RB "Sets layout groupping cases (" "export mode" "):"
+.RB "Sets layout grouping cases (" "export mode" "):"
 .RS
 .BR "*" " Three groups: big, middle, small = 0,"
 .RE

--- a/dist/appimage-builder-recipe-test.yml
+++ b/dist/appimage-builder-recipe-test.yml
@@ -57,7 +57,7 @@ script:
   - sudo cp share/img/Seamly2D_logo_256x256.png AppDir/usr/share/icons/hicolor/256x256/seamly2d.png
   - sudo ls AppDir/usr/share/icons/hicolor/256x256/seamly2d.png
 
-  # assign ownership of AppDir and subdirs & files to onwer 'runner' and group 'docker'
+  # assign ownership of AppDir and subdirs & files to owner 'runner' and group 'docker'
   - sudo chown -R runner:docker AppDir && ls -al AppDir
 
   - echo "=== END APPIMAGE RECIPE 'BEFORE' SCRIPT ==================================="

--- a/dist/debian/seamly2d.1
+++ b/dist/debian/seamly2d.1
@@ -179,7 +179,7 @@ The path to output destination folder. By default the directory at which the app
 .IP "-G, --gapwidth <The gap width>"
 .RB "The layout gap width x2, measured in layout units (" "export mode" "). Set distance between details and a detail and a sheet."
 .IP "-g, --groups <Grouping type>"
-.RB "Sets layout groupping cases (" "export mode" "):"
+.RB "Sets layout grouping cases (" "export mode" "):"
 .RS
 .BR "*" " Three groups: big, middle, small = 0,"
 .RE

--- a/scripts/generate_tool_cursor.sh
+++ b/scripts/generate_tool_cursor.sh
@@ -25,7 +25,7 @@ do
 	basename=${var##*/} # remove the path from a path-string
 	basename=${basename%.png} # remove the extension from a path-string
 	basename=${basename%@2x} # remove optional @2x suffix
-	if [ ! -f $basename@2x.png ]; then # always prefere hidpi version
+	if [ ! -f $basename@2x.png ]; then # always prefer hidpi version
 		sed "s/<<basename>>/$basename@2x/" $OUTPATH/template_cursor.svg > $OUTPATH/${basename}_cursor.svg
 	else
 		sed "s/<<basename>>/$basename/" $OUTPATH/template_cursor.svg > $OUTPATH/${basename}_cursor.svg

--- a/scripts/make_install.bat
+++ b/scripts/make_install.bat
@@ -8,7 +8,7 @@ if %ARCHITECTURE%==32BIT set nsis_path="C:/Program Files/Inno Setup 5/iscc.exe"
 if %ARCHITECTURE%==64BIT set nsis_path="C:/Program Files (x86)/Inno Setup 5/iscc.exe"
 
 if not exist %nsis_path% (
-  echo Coudn't find Inno Setup. Package will not be created.
+  echo Couldn't find Inno Setup. Package will not be created.
 )
 
 :CONTINUE

--- a/src/libs/fervor/fervor.pri
+++ b/src/libs/fervor/fervor.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 SOURCES += \
     $$PWD/fvupdater.cpp

--- a/src/libs/fervor/fervor.pro
+++ b/src/libs/fervor/fervor.pro
@@ -38,7 +38,7 @@ DESTDIR = bin
 # files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 # Directory for files created uic

--- a/src/libs/ifc/exception/exception.pri
+++ b/src/libs/ifc/exception/exception.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 HEADERS += \
     $$PWD/vexceptionobjecterror.h \

--- a/src/libs/ifc/exception/vexceptionconversionerror.cpp
+++ b/src/libs/ifc/exception/vexceptionconversionerror.cpp
@@ -59,7 +59,7 @@
 /**
  * @brief VExceptionConversionError exception conversion error
  * @param error string with error
- * @param str string, where happend error
+ * @param str string, where the error happened
  */
 VExceptionConversionError::VExceptionConversionError(const QString &error, const QString &str)
     :VException(error), str(str)

--- a/src/libs/ifc/exception/vexceptionconversionerror.h
+++ b/src/libs/ifc/exception/vexceptionconversionerror.h
@@ -71,13 +71,13 @@ public:
     virtual QString ErrorMessage() const Q_DECL_OVERRIDE;
     QString         String() const;
 protected:
-    /** @brief str string, where happend error */
+    /** @brief str string, where the error happened */
     QString         str;
 };
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief String return string, where happend error
+ * @brief String return string, where the error happened
  * @return string
  */
 inline QString VExceptionConversionError::String() const

--- a/src/libs/ifc/ifc.pri
+++ b/src/libs/ifc/ifc.pri
@@ -1,9 +1,9 @@
-# Suport subdirectories. Just better project code tree.
+# Support subdirectories. Just better project code tree.
 include(exception/exception.pri)
 include(xml/xml.pri)
 
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 HEADERS += \
     $$PWD/stable.h \

--- a/src/libs/ifc/ifc.pro
+++ b/src/libs/ifc/ifc.pro
@@ -42,7 +42,7 @@ DESTDIR = bin
 # files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 # Directory for files created rcc

--- a/src/libs/ifc/xml/vabstractconverter.cpp
+++ b/src/libs/ifc/xml/vabstractconverter.cpp
@@ -221,7 +221,7 @@ void VAbstractConverter::ReserveFile() const
 
         if (not IsReadOnly() && isFileWritable)
         {
-            const QString errorMsg(tr("Error creating a reserv copy: %1.").arg(error));
+            const QString errorMsg(tr("Error creating a reserve copy: %1.").arg(error));
             throw VException(errorMsg);
         }
     }

--- a/src/libs/ifc/xml/vabstractpattern.cpp
+++ b/src/libs/ifc/xml/vabstractpattern.cpp
@@ -569,7 +569,7 @@ bool VAbstractPattern::ChangeNamePP(const QString &oldName, const QString &newNa
  * @brief appendPP add new pattern piece.
  *
  * Method check if not exist pattern piece with the same name and change name active pattern piece name, send signal
- * about change pattern piece. Doen't add pattern piece to file structure. This task make SPoint tool.
+ * about change pattern piece. Doesn't add pattern piece to file structure. This task make SPoint tool.
  * @param name pattern peace name.
  * @return true if success.
  */

--- a/src/libs/ifc/xml/vabstractpattern.h
+++ b/src/libs/ifc/xml/vabstractpattern.h
@@ -403,7 +403,7 @@ public slots:
     void           SelectedDetail(quint32 id);
 
 protected:
-    /** @brief nameActivDraw name current pattern peace. */
+    /** @brief nameActivDraw name current pattern piece. */
     QString        activeDraftBlock;
 
     QString        lastSavedExportFormat;
@@ -416,7 +416,7 @@ protected:
     /** @brief history history records. */
     QVector<VToolRecord> history;
 
-    /** @brief patternPieces list of patern pieces names for combobox*/
+    /** @brief patternPieces list of pattern pieces names for combobox*/
     QStringList    patternPieces;
 
     /** @brief modified keep state of the document for cases that do not cover QUndoStack*/

--- a/src/libs/ifc/xml/vdomdocument.cpp
+++ b/src/libs/ifc/xml/vdomdocument.cpp
@@ -948,7 +948,7 @@ bool VDomDocument::SafeCopy(const QString &source, const QString &destination, Q
 //---------------------------------------------------------------------------------------------------------------------
 QVector<VLabelTemplateLine> VDomDocument::GetLabelTemplate(const QDomElement &element) const
 {
-    // We use implicit conversion. That's why check if values are still the same as excpected.
+    // We use implicit conversion. That's why check if values are still the same as expected.
     Q_STATIC_ASSERT(Qt::AlignLeft == 1);
     Q_STATIC_ASSERT(Qt::AlignRight == 2);
     Q_STATIC_ASSERT(Qt::AlignHCenter == 4);

--- a/src/libs/ifc/xml/xml.pri
+++ b/src/libs/ifc/xml/xml.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 HEADERS += \
     $$PWD/vabstractconverter.h \

--- a/src/libs/vformat/vformat.pri
+++ b/src/libs/vformat/vformat.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 SOURCES += \
     $$PWD/vmeasurements.cpp \

--- a/src/libs/vformat/vformat.pro
+++ b/src/libs/vformat/vformat.pro
@@ -41,7 +41,7 @@ DESTDIR = bin
 # files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 # Set using ccache. Function enable_ccache() defined in common.pri.

--- a/src/libs/vgeometry/vabstractcubicbezierpath.cpp
+++ b/src/libs/vgeometry/vabstractcubicbezierpath.cpp
@@ -89,7 +89,7 @@ VAbstractCubicBezierPath::~VAbstractCubicBezierPath()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief GetPath return QPainterPath which reprezent spline path.
+ * @brief GetPath return QPainterPath which represents spline path.
  * @return path.
  */
 QPainterPath VAbstractCubicBezierPath::GetPath() const

--- a/src/libs/vgeometry/vabstractcurve.cpp
+++ b/src/libs/vgeometry/vabstractcurve.cpp
@@ -363,7 +363,7 @@ QVector<DirectionArrow> VAbstractCurve::DirectionArrows() const
         for (qint32 i = 1; i <= points.size()-1; ++i)
         {
             arrow = QLineF(points.at(i-1), points.at(i));
-            found_length += arrow.length();//Length that we aready find
+            found_length += arrow.length();//Length that we already found
 
             if (seek_length <= found_length)// if have found more that need stop.
             {

--- a/src/libs/vgeometry/varc.cpp
+++ b/src/libs/vgeometry/varc.cpp
@@ -274,7 +274,7 @@ QVector<QPointF> VArc::GetPoints() const
         }
 
         if (angle > 360 || angle < 0)
-        {// Filter incorect value
+        {// Filter incorrect value
             QLineF dummy(0,0, 100, 0);
             dummy.setAngle(angle);
             angle = dummy.angle();

--- a/src/libs/vgeometry/vgeometry.pri
+++ b/src/libs/vgeometry/vgeometry.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 SOURCES += \
         $$PWD/vgobject.cpp \

--- a/src/libs/vgeometry/vgeometry.pro
+++ b/src/libs/vgeometry/vgeometry.pro
@@ -37,7 +37,7 @@ DESTDIR = bin
 # files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 # Set using ccache. Function enable_ccache() defined in common.pri.

--- a/src/libs/vgeometry/vgobject.cpp
+++ b/src/libs/vgeometry/vgobject.cpp
@@ -517,7 +517,7 @@ bool VGObject::IsPointOnLineviaPDP(const QPointF &t, const QPointF &p1, const QP
 {
     const double p = qAbs(PerpDotProduct(p1, p2, t));
     const double e = GetEpsilon(p1, p2);
-    // We can't use common "<=" here because of the floating-point accuraccy problem
+    // We can't use common "<=" here because of the floating-point accuracy problem
     return p < e || VFuzzyComparePossibleNulls(p, e);
 }
 
@@ -534,13 +534,13 @@ double VGObject::PerpDotProduct(const QPointF &p1, const QPointF &p2, const QPoi
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief GetEpsilon solve the floating-point accuraccy problem.
+ * @brief GetEpsilon solve the floating-point accuracy problem.
  *
- * There is the floating-point accuraccy problem, so instead of checking against zero, some epsilon value has to be
+ * There is the floating-point accuracy problem, so instead of checking against zero, some epsilon value has to be
  * used. Because the size of the pdp value depends on the length of the vectors, no static value can be used. One
  * approach is to compare the pdp/area value to the fraction of another area which also depends on the length of the
- * line e1=(p1, p2), e.g. the minimal area calucalted with PerpDotProduc() if point still not on the line. This distance
- * is controled by variable accuracyPointOnLine
+ * line e1=(p1, p2), e.g. the minimal area calculated with PerpDotProduc() if point still isn't on the line. This
+ * distance is controlled by variable accuracyPointOnLine
  */
 double VGObject::GetEpsilon(const QPointF &p1, const QPointF &p2)
 {
@@ -570,7 +570,7 @@ int VGObject::PointInCircle(const QPointF &p, const QPointF &center, qreal radiu
 /**
  * @brief GetLengthContour return length of contour.
  * @param contour container with points of contour.
- * @param newPoints point whos we try to add to contour.
+ * @param newPoints point we try to add to contour.
  * @return length length of contour.
  */
 // cppcheck-suppress unusedFunction

--- a/src/libs/vgeometry/vgobject_p.h
+++ b/src/libs/vgeometry/vgobject_p.h
@@ -78,7 +78,7 @@ public:
 
     virtual ~VGObjectData();
 
-    /** @brief _id id in container. Ned for arcs, spline and spline paths. */
+    /** @brief _id id in container. Needed for arcs, spline and spline paths. */
     quint32 _id;
 
     /** @brief type type of graphical object */

--- a/src/libs/vgeometry/vspline.cpp
+++ b/src/libs/vgeometry/vspline.cpp
@@ -527,12 +527,12 @@ QVector<qreal> VSpline::CalcT (qreal curveCoord1, qreal curveCoord2, qreal curve
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief VSpline::ParamT calculate t coeffient that reprezent point on curve.
+ * @brief VSpline::ParamT calculate t coefficient that represents point on curve.
  *
  * Each point that belongs to Cubic Bézier curve can be shown by coefficient in interval [0; 1].
  *
  * @param pBt point on curve
- * @return t coeffient that reprezent this point on curve. Return -1 if point doesn't belongs to curve.
+ * @return t coefficient that represents this point on curve. Return -1 if point doesn't belongs to curve.
  */
 qreal VSpline::ParamT (const QPointF &pBt) const
 {

--- a/src/libs/vlayout/vabstractpiece.h
+++ b/src/libs/vlayout/vabstractpiece.h
@@ -280,7 +280,7 @@ QVector<T> VAbstractPiece::CorrectEquidistantPoints(const QVector<T> &points, bo
     //Remove point on line
     for (qint32 i = 0; i < buf1.size(); ++i)
     {// In this case we alwayse will have bounded intersection, so all is need is to check if point i is on line.
-     // Unfortunatelly QLineF::intersect can't be used in this case because of the floating-point accuraccy problem.
+     // Unfortunately QLineF::intersect can't be used in this case because of the floating-point accuracy problem.
         if (prev == -1)
         {
             i == 0 ? prev = buf1.size() - 1 : prev = i-1;

--- a/src/libs/vlayout/vbestsquare.h
+++ b/src/libs/vlayout/vbestsquare.h
@@ -2,7 +2,7 @@
  *                                                                         *
  *   Copyright (C) 2017  Seamly, LLC                                       *
  *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
+ *   https://github.com/fashionfreedom/seamly2d                            *
  *                                                                         *
  ***************************************************************************
  **
@@ -77,7 +77,7 @@ public:
     bool IsSaveLength() const;
 
 private:
-    // All nedded information about best result
+    // All needed information for best result
     int resI; // Edge of global contour
     int resJ; // Edge of detail
     QTransform resTransform; // Transform for rotation and translation detail

--- a/src/libs/vlayout/vcontour.cpp
+++ b/src/libs/vlayout/vcontour.cpp
@@ -274,7 +274,7 @@ QLineF VContour::GlobalEdge(int i) const
             edge = QLineF(d->globalContour.at(i-1), d->globalContour.at(i));
         }
         else
-        { // Closed countour
+        { // Closed contour
             edge = QLineF(d->globalContour.at(GlobalEdgesCount()-1), d->globalContour.at(0));
         }
         return edge;

--- a/src/libs/vlayout/vlayout.pri
+++ b/src/libs/vlayout/vlayout.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 HEADERS += \
     $$PWD/stable.h \

--- a/src/libs/vlayout/vlayout.pro
+++ b/src/libs/vlayout/vlayout.pro
@@ -37,7 +37,7 @@ DESTDIR = bin
 # files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 # Directory for files created rcc

--- a/src/libs/vmisc/def.cpp
+++ b/src/libs/vmisc/def.cpp
@@ -191,7 +191,7 @@ const QStringList labelTemplatePlaceholders = QStringList() << pl_size
 const QString cursorArrowOpenHand = QStringLiteral("://cursor/cursor-arrow-openhand.png");
 const QString cursorArrowCloseHand = QStringLiteral("://cursor/cursor-arrow-closehand.png");
 
-// From documantation: If you use QStringLiteral you should avoid declaring the same literal in multiple places: This
+// From documentation: If using QStringLiteral, avoid declaring the same literal in multiple places: This
 // furthermore blows up the binary sizes.
 const QString degreeSymbol = QStringLiteral("°");
 const QString trueStr = QStringLiteral("true");
@@ -684,7 +684,7 @@ Unit StrToUnits(const QString &unit)
  * @brief UnitsToStr translate unit to string.
  *
  * This method used when need write unit in xml file and for showing unit in dialogs.
- * @param unit curent unit
+ * @param unit current unit
  * @param translate true if need show translated name. Default value false.
  * @return string reprezantation for unit.
  */
@@ -749,7 +749,7 @@ void InitLanguages(QComboBox *combobox)
 
     if (combobox->count() == 0 || not englishUS)
     {
-        // English language is internal and doens't have own *.qm file.
+        // English language is internal and doesn't have its own *.qm file.
         QIcon ico(QString(":/flags/United States.png"));
         QString lang = QLocale(en_US).nativeLanguageName();
         combobox->addItem(ico, lang, en_US);

--- a/src/libs/vmisc/def.h
+++ b/src/libs/vmisc/def.h
@@ -324,7 +324,7 @@ enum class GSizes : unsigned char { ALL,
  * This macros SCASSERT (for Stop and Continue Assert) will break into the debugger on the line of the assert and allow
  * you to continue afterwards should you choose to.
  * idea: Q_ASSERT no longer pauses debugger - http://qt-project.org/forums/viewthread/13148
- * Usefull links:
+ * Useful links:
  * 1. What's the difference between __PRETTY_FUNCTION__, __FUNCTION__, __func__? -
  *    https://stackoverflow.com/questions/4384765/whats-the-difference-between-pretty-function-function-func
  *

--- a/src/libs/vmisc/vabstractapplication.h
+++ b/src/libs/vmisc/vabstractapplication.h
@@ -135,7 +135,7 @@ protected:
     QUndoStack         *undoStack;
 
     /**
-     * @brief mainWindow pointer to main window. Usefull if need create modal dialog. Without pointer to main window
+     * @brief mainWindow pointer to main window. Useful if need create modal dialog. Without pointer to main window
      * modality doesn't work.
      */
     QWidget            *mainWindow;

--- a/src/libs/vmisc/vmisc.pri
+++ b/src/libs/vmisc/vmisc.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 SOURCES += \
     $$PWD/vsettings.cpp \

--- a/src/libs/vmisc/vmisc.pro
+++ b/src/libs/vmisc/vmisc.pro
@@ -49,7 +49,7 @@ DESTDIR = bin
 # files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 # Set using ccache. Function enable_ccache() defined in common.pri.

--- a/src/libs/vmisc/vsettings.cpp
+++ b/src/libs/vmisc/vsettings.cpp
@@ -662,7 +662,7 @@ QMarginsF VSettings::GetTiledPDFMargins(const Unit &unit) const
  * @brief VSettings::SetTiledPDFMargins sets the setting tiled pdf margins to the given value.
  * @param value the margins to save
  * @param unit the unit in which are the value. Necessary because we save the values
- * internaly as mm so there is conversion beeing made.
+ * internally as mm so there is conversion being made.
  */
 void VSettings::SetTiledPDFMargins(const QMarginsF &value, const Unit &unit)
 {

--- a/src/libs/vobj/vobj.pri
+++ b/src/libs/vobj/vobj.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 SOURCES += \
     $$PWD/vobjengine.cpp \

--- a/src/libs/vobj/vobj.pro
+++ b/src/libs/vobj/vobj.pro
@@ -35,7 +35,7 @@ DESTDIR = bin
 # files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 # Set using ccache. Function enable_ccache() defined in common.pri.

--- a/src/libs/vpatterndb/calculator.cpp
+++ b/src/libs/vpatterndb/calculator.cpp
@@ -62,10 +62,10 @@
 #include <QSharedPointer>
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief Calculator class wraper for QMuParser. Make easy initialization math parser.
+ * @brief Calculator class wrapper for QMuParser. Make easy initialization math parser.
  *
- * This constructor hide initialization variables, operators, character sets.
- * Use this constuctor for evaluation formula. All formulas must be converted to internal look.
+ * This constructor hides initialization variables, operators, character sets.
+ * Use this constructor for evaluation formula. All formulas must be converted to internal look.
  * Example:
  *
  * const QString formula = qApp->FormulaFromUser(edit->text());
@@ -87,7 +87,7 @@ Calculator::Calculator()
 /**
  * @brief eval calculate formula.
  *
- * First we try eval expression without adding variables. If it fail, we take tokens from expression and add variables
+ * First we try eval expression without adding variables. If it fails, we take tokens from expression and add variables
  * to parser and try again.
  *
  * @param formula string of formula.
@@ -95,7 +95,7 @@ Calculator::Calculator()
  */
 qreal Calculator::EvalFormula(const QHash<QString, QSharedPointer<VInternalVariable>> *vars, const QString &formula)
 {
-    // Parser doesn't know any variable on this stage. So, we just use variable factory that for each unknown variable
+    // Parser doesn't know any variable at this stage. So, we just use variable factory that for each unknown variable
     // set value to 0.
     SetVarFactory(AddVariable, this);
     SetSepForEval();//Reset separators options
@@ -107,7 +107,7 @@ qreal Calculator::EvalFormula(const QHash<QString, QSharedPointer<VInternalVaria
 
     QMap<int, QString> tokens = this->GetTokens();
 
-    // Remove "-" from tokens list if exist. If don't do that unary minus operation will broken.
+    // Remove "-" from tokens list if exist or else unary minus operation will broken.
     RemoveAll(tokens, QStringLiteral("-"));
 
     for (int i = 0; i < builInFunctions.size(); ++i)
@@ -133,10 +133,10 @@ qreal Calculator::EvalFormula(const QHash<QString, QSharedPointer<VInternalVaria
 /**
  * @brief Calculator::InitVariables add variables to parser.
  *
- * For optimization purpose we try don't add variables that we don't need.
+ * For optimization purpose we try not to add variables that we don't need.
  *
  * @param vars list of variables.
- * @param tokens all tokens (measurements names, variables with lengths) that parser have found in expression.
+ * @param tokens all tokens (measurements names, variables with lengths) that parser has found in expression.
  * @param formula expression, need for throwing better error message.
  */
 void Calculator::InitVariables(const QHash<QString, QSharedPointer<VInternalVariable> > *vars,

--- a/src/libs/vpatterndb/trmeasurements.pri
+++ b/src/libs/vpatterndb/trmeasurements.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working each file measurements*.pro
+# This need for correct working each file measurements*.pro
 
 HEADERS += \
     $$PWD/vtranslatemeasurements.h

--- a/src/libs/vpatterndb/vcontainer.cpp
+++ b/src/libs/vpatterndb/vcontainer.cpp
@@ -250,7 +250,7 @@ quint32 VContainer::getId()
 quint32 VContainer::getNextId()
 {
     //TODO. Current count of ids are very big and allow us save time before someone will reach its max value.
-    //Better way, of cource, is to seek free ids inside the set of values and reuse them.
+    //Better way, of course, is to seek free ids inside the set of values and reuse them.
     //But for now better to keep it as it is now.
     if (_id == UINT_MAX)
     {

--- a/src/libs/vpatterndb/vcontainer.h
+++ b/src/libs/vpatterndb/vcontainer.h
@@ -258,7 +258,7 @@ private:
 Q_DECLARE_TYPEINFO(VContainer, Q_MOVABLE_TYPE);
 
 /*
-*  Defintion of templated member functions of VContainer
+*  Definition of templated member functions of VContainer
 */
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -295,7 +295,7 @@ const QSharedPointer<T> VContainer::GeometricObject(const quint32 &id) const
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
-* @brief GetVariable return varible by name
+* @brief GetVariable return variable by name
 * @param name variable's name
 * @return variable
 */

--- a/src/libs/vpatterndb/vpatterndb.pri
+++ b/src/libs/vpatterndb/vpatterndb.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 SOURCES += \
     $$PWD/vcontainer.cpp \

--- a/src/libs/vpatterndb/vpatterndb.pro
+++ b/src/libs/vpatterndb/vpatterndb.pro
@@ -38,7 +38,7 @@ DESTDIR = bin
 # files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 # Set using ccache. Function enable_ccache() defined in common.pri.

--- a/src/libs/vpatterndb/vpiece.cpp
+++ b/src/libs/vpatterndb/vpiece.cpp
@@ -329,7 +329,7 @@ QPainterPath VPiece::SeamAllowancePath(const QVector<QPointF> &points) const
 {
     QPainterPath ekv;
 
-    // seam allowence
+    // seam allowance
     if (IsSeamAllowance() && not IsSeamAllowanceBuiltIn())
     {
         if (not points.isEmpty())
@@ -353,7 +353,7 @@ QPainterPath VPiece::getNotchesPath(const VContainer *data, const QVector<QPoint
     const QVector<QLineF> notches = createNotchLines(data, pathPoints);
     QPainterPath path;
 
-    // seam allowence
+    // seam allowance
     if (IsSeamAllowance())
     {
         if (not notches.isEmpty())

--- a/src/libs/vpatterndb/vpiecepath.cpp
+++ b/src/libs/vpatterndb/vpiecepath.cpp
@@ -549,7 +549,7 @@ bool VPiecePath::Contains(quint32 id) const
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief OnEdge checks if two poins located on the edge. Edge is line between two points. If between two points
+ * @brief OnEdge checks if two points located on the edge. Edge is line between two points. If between two points
  * located arcs or splines ignore this.
  * @param p1 id first point.
  * @param p2 id second point.

--- a/src/libs/vpatterndb/vtranslatevars.cpp
+++ b/src/libs/vpatterndb/vtranslatevars.cpp
@@ -221,7 +221,7 @@ void VTranslateVars::InitPatternMakingSystems()
     //=================================================================================================================
     name = translate("VTranslateVars", "Rohr", "System name");
     author = translate("VTranslateVars", "M. Rohr", "Author name");
-    book = translate("VTranslateVars", "Pattern Drafting and Grading: Women's nd Misses' Garment Design", "Book name");
+    book = translate("VTranslateVars", "Pattern Drafting and Grading: Women's and Misses' Garment Design", "Book name");
     InitSystem(p23_S, name, author, book);
     //=================================================================================================================
     name = translate("VTranslateVars", "Moore", "System name");

--- a/src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.h
+++ b/src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.h
@@ -63,7 +63,7 @@ signals:
     //! to select a new file or changing the file path in the line edit.
     void dataChangedByUser(const QString &getFile, VFileEditWidget* editor);
 
-    //! This signal is emitted whenever dataChangedByUser() gets emmitted
+    //! This signal is emitted whenever dataChangedByUser() gets emitted
     //! and is connected to the delegate's commitData() signal
     void commitData(QWidget* editor);
 

--- a/src/libs/vpropertyexplorer/plugins/vshortcutpropertyeditor.h
+++ b/src/libs/vpropertyexplorer/plugins/vshortcutpropertyeditor.h
@@ -59,7 +59,7 @@ signals:
     //! This signal is emitted when the user changed the current shortcut
     void dataChangedByUser(const QKeySequence& sequence, VShortcutEditWidget* editor);
 
-    //! This signal is emitted whenever dataChangedByUser() gets emmitted
+    //! This signal is emitted whenever dataChangedByUser() gets emitted
     //! and is connected to the delegate's commitData() signal
     void commitData(QWidget* editor);
 

--- a/src/libs/vpropertyexplorer/vabstractpropertyfactory.h
+++ b/src/libs/vpropertyexplorer/vabstractpropertyfactory.h
@@ -39,7 +39,7 @@ public:
     //! Empty virtual destructor
     virtual ~VAbstractPropertyFactory() {}
 
-    //! Creates a new property of a certain type and assigns a name and description (otionally)
+    //! Creates a new property of a certain type and assigns a name and description (optionally)
     //! \param type The type of the property as string
     //! \param name The property's name
     //! \return Returns the created property or NULL if it couldn't be be created

--- a/src/libs/vpropertyexplorer/vpropertyexplorer.pri
+++ b/src/libs/vpropertyexplorer/vpropertyexplorer.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 SOURCES += \
     $$PWD/vproperty.cpp \

--- a/src/libs/vpropertyexplorer/vpropertyexplorer.pro
+++ b/src/libs/vpropertyexplorer/vpropertyexplorer.pro
@@ -40,7 +40,7 @@ DESTDIR = bin
 # files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 # Allow MAC OS X to find library inside a bundle

--- a/src/libs/vpropertyexplorer/vpropertyfactorymanager.cpp
+++ b/src/libs/vpropertyexplorer/vpropertyfactorymanager.cpp
@@ -80,7 +80,7 @@ void VPE::VPropertyFactoryManager::unregisterFactory(VAbstractPropertyFactory* f
 
     if (!type.isEmpty())
     {
-        // Remove all occurances
+        // Remove all occurrences
         QString tmpKey;
         do
         {

--- a/src/libs/vpropertyexplorer/vpropertyfactorymanager.h
+++ b/src/libs/vpropertyexplorer/vpropertyfactorymanager.h
@@ -68,7 +68,7 @@ public:
     //! \return Returns NULL, if there is none registered for this type
     VAbstractPropertyFactory* getFactory(const QString& type);
 
-    //! Creates a new property of a certain type and assigns a name and description (otionally)
+    //! Creates a new property of a certain type and assigns a name and description (optionally)
     //! \param type The type of the property as string
     //! \param name The name of the property
     //! \param description The property's description. Optional.

--- a/src/libs/vpropertyexplorer/vpropertyformview.cpp
+++ b/src/libs/vpropertyexplorer/vpropertyformview.cpp
@@ -74,7 +74,7 @@ void VPE::VPropertyFormView::setModel(VPropertyModel *model)
             d_ptr->Properties = model->getPropertySet()->getRootProperties();
         }
 
-        // Connect signals // todo: more signals neccesary!!!
+        // Connect signals // TODO: more signals necessary!!!
         connect(model, &VPropertyModel::destroyed, this, &VPropertyFormView::modelDestroyed);
         connect(model, &VPropertyModel::rowsInserted, this, &VPropertyFormView::rowsInserted);
         connect(model, &VPropertyModel::modelReset, this, &VPropertyFormView::modelReset);
@@ -104,7 +104,7 @@ void VPE::VPropertyFormView::setPropertySet(VPropertySet* property_set)
 
 void VPE::VPropertyFormView::rowsRemoved(const QModelIndex &parent, int start, int end)
 {
-    // todo: Only rebuild the neccessary parts
+    // todo: Only rebuild the necessary parts
     Q_UNUSED(parent)
     Q_UNUSED(start)
     Q_UNUSED(end)
@@ -113,7 +113,7 @@ void VPE::VPropertyFormView::rowsRemoved(const QModelIndex &parent, int start, i
 
 void VPE::VPropertyFormView::rowsInserted(const QModelIndex &parent, int start, int end) //-V524
 {
-    // todo: Only rebuild the neccessary parts
+    // todo: Only rebuild the necessary parts
     Q_UNUSED(parent)
     Q_UNUSED(start)
     Q_UNUSED(end)

--- a/src/libs/vpropertyexplorer/vpropertymodel.cpp
+++ b/src/libs/vpropertyexplorer/vpropertymodel.cpp
@@ -52,7 +52,7 @@ bool VPE::VPropertyModel::addProperty(VProperty* property, const QString& id, co
         return false;
     }
 
-    if (!d_ptr->Properties) // If not existant, create property set
+    if (!d_ptr->Properties) // If not existent, create property set
     {
         d_ptr->Properties = new VPropertySet();
     }
@@ -172,7 +172,7 @@ bool VPE::VPropertyModel::setData (const QModelIndex& index, const QVariant& val
     {
         bool tmpHasChanged = tmpProperty->setData(value, role);
         if (tmpProperty->getUpdateParent() && tmpHasChanged)
-        {   // If neccessary, update the parent as well
+        {   // If necessary, update the parent as well
             QModelIndex tmpParentIndex = parent(index);
             emit dataChanged(tmpParentIndex, tmpParentIndex);
         }

--- a/src/libs/vpropertyexplorer/vpropertymodel.h
+++ b/src/libs/vpropertyexplorer/vpropertymodel.h
@@ -122,14 +122,14 @@ public:
     virtual const VPropertySet* getPropertySet() const;
 
     //! Clears the model, deletes the property set managed by this model.
-    //! \param emit_signals Default: true. Set this to false if you want to prevent the model from emmiting the reset
+    //! \param emit_signals Default: true. Set this to false if you want to prevent the model from emitting the reset
     //! model signals
     virtual void clear(bool emit_signals = true);
 
     //! Removes the current property set and returns it. If new_property_set is set, the old one will be replaced by the
     //! new one
     //! \param new_property_set The new property set to replace the old one with. Default: NULL
-    //! \param emit_signals Default: true. Set this to false if you want to prevent the model from emmiting the reset
+    //! \param emit_signals Default: true. Set this to false if you want to prevent the model from emitting the reset
     //! model signals
     //! \return A constant pointer to the property set or NULL if there currently is none.
     virtual VPropertySet* takePropertySet(VPropertySet* new_property_set = nullptr, bool emit_signals = true);
@@ -137,7 +137,7 @@ public:
     //! Sets a new property set. The model will take ownership of the property set. The old property set will be
     //! deleted.
     //! \param property_set The new property set. Setting this to NULL has the same effect as calling clear.
-    //! \param emit_signals Default: true. Set this to false if you want to prevent the model from emmiting the reset
+    //! \param emit_signals Default: true. Set this to false if you want to prevent the model from emitting the reset
     //! model signals
     virtual void setPropertySet(VPropertySet* property_set, bool emit_signals = true);
 

--- a/src/libs/vpropertyexplorer/vpropertyset.h
+++ b/src/libs/vpropertyexplorer/vpropertyset.h
@@ -57,7 +57,7 @@ public:
     //! Adds the property to the model and attaches it to the parentid. Note that if the property has a parent which is
     //! not part of this set, it will be removed from that parent.
     //! \param property The property to add
-    //! \param id The property ID. If id is empty, the property will not be accessable by it's id but still be added.
+    //! \param id The property ID. If id is empty, the property will not be accessible by its id but still be added.
     //! If the property was filed under another ID before, that will no longer be valid.
     //! \param parentid The property's ID to which to add the property as child. Pass empty string to add it to the
     //! root properties.
@@ -65,7 +65,7 @@ public:
 
     //! Adds the property to the model and attaches it to the parent property.
     //! \param property The property to add
-    //! \param id The property ID. If id is empty, the property will not be accessable by it's id but still be added.
+    //! \param id The property ID. If id is empty, the property will not be accessible by its id but still be added.
     //! If the property was filed under another ID before, that will no longer be valid.
     //! \param parent_property The property to which to add the property as child. Pass NULL to add it to the root
     //! properties.
@@ -88,7 +88,7 @@ public:
     //! Removes a property from the set and deletes it optionally
     virtual void removeProperty(VProperty* prop, bool delete_property = true);
 
-    //! Returns the number of properties with in ID that are directly accessable by getProperty()
+    //! Returns the number of properties with in ID that are directly accessible by getProperty()
     virtual int count() const;
 
     //! Clears the set and (optionally) deletes all properties
@@ -129,7 +129,7 @@ protected:
     //! Clones a property into another property set
     void cloneProperty(VProperty* property_to_clone, VProperty* parent_property, VPropertySet* output_set) const;
 
-    //! Recursivly removes a property's child properties from the set, but not from the parent
+    //! Recursively removes a property's child properties from the set, but not from the parent
     virtual void removePropertyFromSet(VProperty* prop);
 
     //! The data

--- a/src/libs/vpropertyexplorer/vstandardpropertyfactory.h
+++ b/src/libs/vpropertyexplorer/vstandardpropertyfactory.h
@@ -44,7 +44,7 @@ public:
     //! \param manager Registers this factory at the manager for all it's types
     explicit VStandardPropertyFactory(VPropertyFactoryManager* manager);
 
-    //! Creates a new property of a certain type and assigns a name and description (otionally)
+    //! Creates a new property of a certain type and assigns a name and description (optionally)
     //! \param type The type of the property as string
     //! \return Returns the created property or NULL if it couldn't be be created
     Q_REQUIRED_RESULT virtual VProperty* createProperty(const QString& type, const QString &name) Q_DECL_OVERRIDE;

--- a/src/libs/vtest/vtest.pri
+++ b/src/libs/vtest/vtest.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 SOURCES += \
     $$PWD/abstracttest.cpp

--- a/src/libs/vtest/vtest.pro
+++ b/src/libs/vtest/vtest.pro
@@ -43,7 +43,7 @@ DESTDIR = bin
 # files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 # Set using ccache. Function enable_ccache() defined in common.pri.

--- a/src/libs/vtools/dialogs/dialogs.pri
+++ b/src/libs/vtools/dialogs/dialogs.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 HEADERS += \
     $$PWD/tooldialogs.h \

--- a/src/libs/vtools/dialogs/support/dialogeditwrongformula.cpp
+++ b/src/libs/vtools/dialogs/support/dialogeditwrongformula.cpp
@@ -421,7 +421,7 @@ void DialogEditWrongFormula::resizeEvent(QResizeEvent *event)
 void DialogEditWrongFormula::SetFormula(const QString &value)
 {
     formula = qApp->TrVars()->FormulaToUser(value, qApp->Settings()->GetOsSeparator());
-    // increase height if needed. TODO : see if I can get the max number of caracters in one line
+    // increase height if needed. TODO : see if I can get the max number of characters in one line
     // of this PlainTextEdit to change 80 to this value
     if (formula.length() > 80)
     {

--- a/src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp
@@ -148,7 +148,7 @@ QString DialogCurveIntersectAxis::GetAngle() const
 void DialogCurveIntersectAxis::SetAngle(const QString &value)
 {
     formulaAngle = qApp->TrVars()->FormulaToUser(value, qApp->Settings()->GetOsSeparator());
-    // increase height if needed. TODO : see if I can get the max number of caracters in one line
+    // increase height if needed. TODO : see if I can get the max number of characters in one line
     // of this PlainTextEdit to change 80 to this value
     if (formulaAngle.length() > 80)
     {

--- a/src/libs/vtools/dialogs/tools/dialogcutspline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcutspline.cpp
@@ -126,7 +126,7 @@ void DialogCutSpline::SetPointName(const QString &value)
 void DialogCutSpline::SetFormula(const QString &value)
 {
     formula = qApp->TrVars()->FormulaToUser(value, qApp->Settings()->GetOsSeparator());
-    // increase height if needed. TODO : see if I can get the max number of caracters in one line
+    // increase height if needed. TODO : see if I can get the max number of characters in one line
     // of this PlainTextEdit to change 80 to this value
     if (formula.length() > 80)
     {

--- a/src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp
@@ -126,7 +126,7 @@ void DialogCutSplinePath::SetPointName(const QString &value)
 void DialogCutSplinePath::SetFormula(const QString &value)
 {
     formula = qApp->TrVars()->FormulaToUser(value, qApp->Settings()->GetOsSeparator());
-    // increase height if needed. TODO : see if I can get the max number of caracters in one line
+    // increase height if needed. TODO : see if I can get the max number of characters in one line
     // of this PlainTextEdit to change 80 to this value
     if (formula.length() > 80)
     {

--- a/src/libs/vtools/dialogs/tools/dialogellipticalarc.ui
+++ b/src/libs/vtools/dialogs/tools/dialogellipticalarc.ui
@@ -171,7 +171,7 @@
            </size>
           </property>
           <property name="toolTip">
-           <string>Calulation</string>
+           <string>Calculation</string>
           </property>
           <property name="tabChangesFocus">
            <bool>true</bool>
@@ -357,7 +357,7 @@
            </size>
           </property>
           <property name="toolTip">
-           <string>Calulation</string>
+           <string>Calculation</string>
           </property>
           <property name="tabChangesFocus">
            <bool>true</bool>

--- a/src/libs/vtools/dialogs/tools/dialogendline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogendline.cpp
@@ -249,7 +249,7 @@ void DialogEndLine::SetTypeLine(const QString &value)
 void DialogEndLine::SetFormula(const QString &value)
 {
     formulaLength = qApp->TrVars()->FormulaToUser(value, qApp->Settings()->GetOsSeparator());
-    // increase height if needed. TODO : see if I can get the max number of caracters in one line
+    // increase height if needed. TODO : see if I can get the max number of characters in one line
     // of this PlainTextEdit to change 80 to this value
     if (formulaLength.length() > 80)
     {
@@ -272,7 +272,7 @@ void DialogEndLine::SetFormula(const QString &value)
 void DialogEndLine::SetAngle(const QString &value)
 {
     formulaAngle = qApp->TrVars()->FormulaToUser(value, qApp->Settings()->GetOsSeparator());
-    // increase height if needed. TODO : see if I can get the max number of caracters in one line
+    // increase height if needed. TODO : see if I can get the max number of characters in one line
     // of this PlainTextEdit to change 80 to this value
     if (formulaAngle.length() > 80)
     {

--- a/src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp
+++ b/src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp
@@ -160,7 +160,7 @@ QString DialogLineIntersectAxis::GetAngle() const
 void DialogLineIntersectAxis::SetAngle(const QString &value)
 {
     formulaAngle = qApp->TrVars()->FormulaToUser(value, qApp->Settings()->GetOsSeparator());
-    // increase height if needed. TODO : see if I can get the max number of caracters in one line
+    // increase height if needed. TODO : see if I can get the max number of characters in one line
     // of this PlainTextEdit to change 80 to this value
     if (formulaAngle.length() > 80)
     {

--- a/src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui
+++ b/src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui
@@ -35,7 +35,7 @@
       </size>
      </property>
      <property name="title">
-      <string>Seletion</string>
+      <string>Selection</string>
      </property>
      <widget class="QWidget" name="layoutWidget">
       <property name="geometry">

--- a/src/libs/vtools/dialogs/tools/dialognormal.h
+++ b/src/libs/vtools/dialogs/tools/dialognormal.h
@@ -123,7 +123,7 @@ private:
     /** @brief formula formula */
     QString          formula;
 
-    /** @brief angle aditional angle of normal */
+    /** @brief angle additional angle of normal */
     qreal            angle;
 
     /** @brief formulaBaseHeight base height defined by dialogui */

--- a/src/libs/vtools/dialogs/tools/dialogtool.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogtool.cpp
@@ -157,7 +157,7 @@ void DialogTool::keyPressEvent(QKeyEvent *event)
     {
         case Qt::Key_Escape:
             DialogRejected();
-            return; // After reject the dialog will be destroyed, exit imidiately
+            return; // After reject the dialog will be destroyed, exit immediately
         default:
             break;
     }
@@ -166,7 +166,7 @@ void DialogTool::keyPressEvent(QKeyEvent *event)
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief closeEvent handle when dialog cloded
+ * @brief closeEvent handle when dialog closed
  * @param event event
  */
 void DialogTool::closeEvent(QCloseEvent *event)
@@ -177,7 +177,7 @@ void DialogTool::closeEvent(QCloseEvent *event)
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief showEvent handle when window show
+ * @brief showEvent handle when window shown
  * @param event event
  */
 void DialogTool::showEvent(QShowEvent *event)
@@ -785,7 +785,7 @@ void DialogTool::ValFormulaChanged(bool &flag, QPlainTextEdit *edit, QTimer *tim
 //---------------------------------------------------------------------------------------------------------------------
 /**
  * @brief Eval evaluate formula and show result
- * @param text expresion that we parse
+ * @param text expression that we parse
  * @param flag flag state of eval formula
  * @param label label for signal error
  * @param postfix unit name
@@ -797,7 +797,7 @@ qreal DialogTool::Eval(const QString &text, bool &flag, QLabel *label, const QSt
     SCASSERT(label != nullptr)
     SCASSERT(labelEditFormula != nullptr)
 
-    qreal result = INT_MIN;//Value can be 0, so use max imposible value
+    qreal result = INT_MIN;//Value can be 0, so use max impossible value
 
     if (text.isEmpty())
     {
@@ -1264,7 +1264,7 @@ void DialogTool::EvalFormula()
 {
     SCASSERT(plainTextEditFormula != nullptr)
     SCASSERT(labelResultCalculation != nullptr)
-    const QString postfix = UnitsToStr(qApp->patternUnit());//Show unit in dialog lable (cm, mm or inch)
+    const QString postfix = UnitsToStr(qApp->patternUnit());//Show unit in dialog label (cm, mm or inch)
     Eval(plainTextEditFormula->toPlainText(), flagFormula, labelResultCalculation, postfix, false);
 }
 

--- a/src/libs/vtools/dialogs/tools/dialogtool.h
+++ b/src/libs/vtools/dialogs/tools/dialogtool.h
@@ -184,14 +184,14 @@ protected:
     /** @brief flagFormula true if formula correct */
     bool             flagFormula;
 
-    /** @brief flagError use this flag if for you do not enought @see flagName and @see flagFormula.
+    /** @brief flagError use this flag if for you do not @see flagName and @see flagFormula enough.
      *
-     * In many cases you will need more flags fore checking if all data are valid.
+     * In many cases you will need more flags for checking if all data is valid.
      * By default this flag is true.
      */
     bool             flagError;
 
-    /** @brief timerFormula timer for check formula */
+    /** @brief timerFormula timer to check formula */
     QTimer           *timerFormula;
 
     /** @brief bOk button ok */

--- a/src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp
@@ -802,7 +802,7 @@ void DialogInternalPath::InitSeamAllowanceTab()
     m_timerWidthAfter = new QTimer(this);
     connect(m_timerWidthAfter, &QTimer::timeout, this, &DialogInternalPath::evaluateAfterWidth);
 
-    // Default value for seam allowence is 1 cm. But pattern have different units, so just set 1 in dialog not enough.
+    // Default value for seam allowance is 1 cm. But pattern have different units, so just set 1 in dialog not enough.
     m_saWidth = UnitConvertor(1, Unit::Cm, qApp->patternUnit());
     ui->widthFormula_PlainTextEdit->setPlainText(qApp->LocaleToString(m_saWidth));
 

--- a/src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui
+++ b/src/libs/vtools/dialogs/tools/piece/dialoginternalpath.ui
@@ -264,7 +264,7 @@
             </size>
            </property>
            <property name="text">
-            <string>Staus:</string>
+            <string>Status:</string>
            </property>
           </widget>
          </item>
@@ -1214,7 +1214,7 @@
           </size>
          </property>
          <property name="title">
-          <string>Geomtery</string>
+          <string>Geometry</string>
          </property>
          <widget class="QDoubleSpinBox" name="notchAngle_DoubleSpinBox">
           <property name="geometry">

--- a/src/libs/vtools/dialogs/tools/piece/tabs/tabpaths.ui
+++ b/src/libs/vtools/dialogs/tools/piece/tabs/tabpaths.ui
@@ -153,7 +153,7 @@
              <item>
               <widget class="QToolButton" name="moveBottom_ToolButton">
                <property name="toolTip">
-                <string>Molve row to botton of list</string>
+                <string>Move row to bottom of list</string>
                </property>
                <property name="text">
                 <string>...</string>

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp
@@ -83,7 +83,7 @@ const QString VToolArc::ToolType = QStringLiteral("simple");
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief VToolArc constuctor.
+ * @brief VToolArc constructor.
  * @param doc dom document container
  * @param data container with variables
  * @param id object id in container

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp
@@ -60,7 +60,7 @@ const QString VToolEllipticalArc::ToolType = QStringLiteral("simple");
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief VToolEllipticalArc constuctor.
+ * @brief VToolEllipticalArc constructor.
  * @param doc dom document container
  * @param data container with variables
  * @param id object id in container

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp
@@ -83,7 +83,7 @@ const QString VToolAlongLine::ToolType = QStringLiteral("alongLine");
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief VToolAlongLine constuctor.
+ * @brief VToolAlongLine constructor.
  * @param doc dom document container.
  * @param data container with variables.
  * @param id object id in container.

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp
@@ -176,7 +176,7 @@ QPointF VToolPointOfContact::FindPoint(const qreal &radius, const QPointF &cente
             }
         }
         default:
-            qDebug() << "Unxpected value" << res;
+            qDebug() << "Unexpected value" << res;
             break;
     }
     return QPointF();

--- a/src/libs/vtools/tools/drawTools/vtoolline.cpp
+++ b/src/libs/vtools/tools/drawTools/vtoolline.cpp
@@ -309,7 +309,7 @@ void VToolLine::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief AddToFile add tag with informations about tool into file.
+ * @brief AddToFile add tag with information about tool into file.
  */
 void VToolLine::AddToFile()
 {

--- a/src/libs/vtools/tools/nodeDetails/vtoolinternalpath.cpp
+++ b/src/libs/vtools/tools/nodeDetails/vtoolinternalpath.cpp
@@ -110,7 +110,7 @@ VToolInternalPath *VToolInternalPath::Create(quint32 _id, const VPiecePath &path
         else
         {
             if (typeCreation == Source::FromGui && path.GetType() == PiecePathType::InternalPath)
-            { // Seam allowance tool already initializated and can't init the path
+            { // Seam allowance tool already initialized and can't init the path
                 SCASSERT(pieceId > NULL_ID);
                 VToolSeamAllowance *saTool = qobject_cast<VToolSeamAllowance*>(VAbstractPattern::getTool(pieceId));
                 SCASSERT(saTool != nullptr);

--- a/src/libs/vtools/tools/tools.pri
+++ b/src/libs/vtools/tools/tools.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 HEADERS += \
     $$PWD/drawTools/operation/mirror/vabstractmirror.h \

--- a/src/libs/vtools/tools/vtoolseamallowance.cpp
+++ b/src/libs/vtools/tools/vtoolseamallowance.cpp
@@ -219,7 +219,7 @@ void VToolSeamAllowance::InsertNode(VPieceNode node, quint32 pieceId, VMainGraph
         node.SetId(id);
         newPiece.GetPath().Append(node);
 
-        // Seam allowance tool already initializated and can't init the node
+        // Seam allowance tool already initialized and can't init the node
         VToolSeamAllowance *patternPiece = qobject_cast<VToolSeamAllowance*>(VAbstractPattern::getTool(pieceId));
         SCASSERT(patternPiece != nullptr);
 
@@ -702,7 +702,7 @@ void VToolSeamAllowance::SaveRotationDetail(qreal dRot)
     newPiece.GetPatternPieceData().SetPos(m_dataLabel->pos());
     newPiece.GetPatternPieceData().SetFontSize(m_dataLabel->getFontSize());
 
-    // Tranform angle to anticlockwise
+    // Transform angle to anticlockwise
     QLineF line(0, 0, 100, 0);
     line.setAngle(-dRot);
     newPiece.GetPatternPieceData().SetRotation(QString().setNum(line.angle()));
@@ -760,7 +760,7 @@ void VToolSeamAllowance::SaveRotationPattern(qreal dRot)
     newPiece.GetPatternInfo().SetPos(m_patternInfo->pos());
     newPiece.GetPatternInfo().SetFontSize(m_patternInfo->getFontSize());
 
-    // Tranform angle to anticlockwise
+    // Transform angle to anticlockwise
     QLineF line(0, 0, 100, 0);
     line.setAngle(-dRot);
     newPiece.GetPatternInfo().SetRotation(QString().setNum(line.angle()));
@@ -1737,7 +1737,7 @@ void VToolSeamAllowance::deleteTool(bool ask)
     // If UnionDetails tool delete the piece this object will be deleted only after full parse.
     // Deleting inside UnionDetails cause crash.
     // Because this object should be inactive from no one we disconnect all signals that may cause a crash
-    // KEEP THIS LIST ACTUALL!!!
+    // KEEP THIS LIST ACTUAL!!!
     disconnect(doc, nullptr, this, nullptr);
     if (QGraphicsScene *toolScene = scene())
     {

--- a/src/libs/vtools/tools/vtooluniondetails.cpp
+++ b/src/libs/vtools/tools/vtooluniondetails.cpp
@@ -666,7 +666,7 @@ void FindIndexJ(qint32 pointsD2, const VPiecePath &d2Path, quint32 indexD2, qint
         const int k = removedD2.indexOfNode(node2.GetId());
         SCASSERT(k != -1)
         if (k == removedD2.CountNodes()-1)
-        {//We have last node in detail, we wil begin from 0
+        {// We have last node in detail, we will begin from 0
             j = 0;
         }
         else
@@ -1372,7 +1372,7 @@ void UniteDetails(quint32 id, const VToolUnionDetailsInitData &initData)
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief VToolUnionDetails costructor.
+ * @brief VToolUnionDetails constructor.
  * @param id object id in container.
  * @param initData global init data.
  * @param parent parent object.
@@ -1509,7 +1509,7 @@ VToolUnionDetails* VToolUnionDetails::Create(const quint32 _id, const VToolUnion
         //Scene doesn't show this tool, so doc will destroy this object.
         unionDetails = new VToolUnionDetails(id, initData);
         VAbstractPattern::AddTool(id, unionDetails);
-        // Unfortunatelly doc will destroy all objects only in the end, but we should delete them before each FullParse
+        // Unfortunately doc will destroy all objects only in the end, but we should delete them before each FullParse
         initData.doc->AddToolOnRemove(unionDetails);
     }
     UniteDetails(id, initData);

--- a/src/libs/vtools/undocommands/undocommands.pri
+++ b/src/libs/vtools/undocommands/undocommands.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 HEADERS += \
     $$PWD/addtocalc.h \

--- a/src/libs/vtools/visualization/line/operation/vistoolmove.cpp
+++ b/src/libs/vtools/visualization/line/operation/vistoolmove.cpp
@@ -138,7 +138,7 @@ void VisToolMove::RefreshGeometry()
         if (QGuiApplication::keyboardModifiers() == Qt::ShiftModifier)
         {
             line = QLineF(m_origin, Visualization::scenePos);
-            line.setAngle(CorrectAngle(line.angle()));    //contrain move line angle to preference setting
+            line.setAngle(CorrectAngle(line.angle()));    //constrain move line angle to preference setting
         }
         else
         {
@@ -176,7 +176,7 @@ void VisToolMove::RefreshGeometry()
 
             if (QGuiApplication::keyboardModifiers() == Qt::ShiftModifier)
             {
-                rotationLine.setAngle(CorrectAngle(rotationLine.angle())); //contrain rotation line angle to preference
+                rotationLine.setAngle(CorrectAngle(rotationLine.angle())); //constrain rotation line angle to preference
             }
 
             qreal cursorLength = rotationLine.length();

--- a/src/libs/vtools/visualization/visualization.pri
+++ b/src/libs/vtools/visualization/visualization.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 HEADERS += \
     $$PWD/line/intersect_circles_visual.h \

--- a/src/libs/vtools/vtools.pri
+++ b/src/libs/vtools/vtools.pri
@@ -4,7 +4,7 @@ include(visualization/visualization.pri)
 include(undocommands/undocommands.pri)
 
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 HEADERS += \
     $$PWD/stable.h

--- a/src/libs/vtools/vtools.pro
+++ b/src/libs/vtools/vtools.pro
@@ -37,7 +37,7 @@ DESTDIR = bin
 # files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 # Directory for files created rcc

--- a/src/libs/vwidgets/fancytabbar/fancytabbar.cpp
+++ b/src/libs/vwidgets/fancytabbar/fancytabbar.cpp
@@ -171,7 +171,7 @@ QPoint FancyTabBar::GetCorner(const QRect& rect, const Corner corner) const
 // You can pass this method a QRect and tell it to move its edges to the outside (+)
 // or inside (-) of the rect. For example, with a TabBar at the Above,
 //
-//      adjustRect(QRect(0,0,10,10), 1, 2, 3, -4)  // thats a 10 by 10 QRect, starting at 0/0
+//      adjustRect(QRect(0,0,10,10), 1, 2, 3, -4)  // that's a 10 by 10 QRect, starting at 0/0
 //
 //  gives
 //

--- a/src/libs/vwidgets/fancytabbar/stylehelper.cpp
+++ b/src/libs/vwidgets/fancytabbar/stylehelper.cpp
@@ -134,7 +134,7 @@ void StyleHelper::drawIconWithShadow(const QIcon &icon, const QRect &rect, QPain
         // High-dpi support: The in parameters (rect, radius, offset) are in
         // device-independent pixels. The call to QIcon::pixmap() below might
         // return a high-dpi pixmap, which will in that case have a devicePixelRatio
-        // different than 1. The shadow drawing caluculations are done in device
+        // different than 1. The shadow drawing calculations are done in device
         // pixels.
         QPixmap px = icon.pixmap(rect.size());
         int devicePixelRatio = qCeil(px.devicePixelRatio());

--- a/src/libs/vwidgets/vmaingraphicsview.h
+++ b/src/libs/vwidgets/vmaingraphicsview.h
@@ -180,7 +180,7 @@ signals:
     /**
      * @brief mouseRelease help catch mouse release event.
      *
-     * Usefull when you need show dialog after working with tool visualization.
+     * Useful when you need show dialog after working with tool visualization.
      */
     void                  mouseRelease();
     void                  itemClicked(QGraphicsItem *item);

--- a/src/libs/vwidgets/vtextgraphicsitem.cpp
+++ b/src/libs/vwidgets/vtextgraphicsitem.cpp
@@ -540,7 +540,7 @@ void VTextGraphicsItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event )
     else if (m_eMode == mRotate && m_moveType & IsRotatable)
     {
         qDebug() << " Item is Rotatable\n";
-        // if the angle from the original position is small (0.5 degrees), just remeber the new angle
+        // if the angle from the original position is small (0.5 degrees), just remember the new angle
         // new angle will be the starting angle for rotation
         if (fabs(m_angle) < 0.01)
         {

--- a/src/libs/vwidgets/vwidgets.pri
+++ b/src/libs/vwidgets/vwidgets.pri
@@ -1,5 +1,5 @@
 # ADD TO EACH PATH $$PWD VARIABLE!!!!!!
-# This need for corect working file translations.pro
+# This need for correct working file translations.pro
 
 SOURCES += \
     $$PWD/calculator/button.cpp \

--- a/src/libs/vwidgets/vwidgets.pro
+++ b/src/libs/vwidgets/vwidgets.pro
@@ -37,7 +37,7 @@ DESTDIR = bin
 # files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 # Set using ccache. Function enable_ccache() defined in common.pri.

--- a/src/test/CollectionTest/CollectionTest.pro
+++ b/src/test/CollectionTest/CollectionTest.pro
@@ -37,7 +37,7 @@ DESTDIR = bin
 # Directory for files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 DEFINES += SRCDIR=\\\"$$PWD/\\\"

--- a/src/test/ParserTest/ParserTest.pro
+++ b/src/test/ParserTest/ParserTest.pro
@@ -12,7 +12,7 @@ include(../../../common.pri)
 # We use many core functions.
 QT       += core
 
-# Consol application doesn't need gui.
+# Console application doesn't need gui.
 QT       -= gui
 
 # Name of binary file.
@@ -21,7 +21,7 @@ TARGET = ParserTest
 # Console application, we use C++11 standard.
 CONFIG   += console c++11
 
-# CONFIG += testcase adds a  'make check' which is great. But by default it also
+# CONFIG += testcase adds a 'make check' which is great. But by default it also
 # adds a 'make install' that installs the test cases, which we do not want.
 # Can configure it not to do that with 'no_testcase_installs'
 CONFIG += testcase no_testcase_installs
@@ -35,7 +35,7 @@ TEMPLATE = app
 # directory for executable file
 DESTDIR = bin
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 HEADERS += \
@@ -78,7 +78,7 @@ noDebugSymbols{ # For enable run qmake with CONFIG+=noDebugSymbols
     noStripDebugSymbols { # For enable run qmake with CONFIG+=noStripDebugSymbols
         # do nothing
     } else {
-        # Strip after you link all libaries.
+        # Strip after you link all libraries.
         CONFIG(release, debug|release){
             unix:!macx{
                 # Strip debug symbols.

--- a/src/test/Seamly2DTest/Seamly2DTest.pro
+++ b/src/test/Seamly2DTest/Seamly2DTest.pro
@@ -35,7 +35,7 @@ DESTDIR = bin
 # Directory for files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 DEFINES += SRCDIR=\\\"$$PWD/\\\"

--- a/src/test/Seamly2DTest/tst_vabstractpiece.cpp
+++ b/src/test/Seamly2DTest/tst_vabstractpiece.cpp
@@ -2004,7 +2004,7 @@ void TST_VAbstractPiece::PathRemoveLoop_data() const
 
     path.removeLast();
 
-    QTest::newRow("Corect unclosed a path, point on line (four unique points)") << path << path;
+    QTest::newRow("Correct unclosed a path, point on line (four unique points)") << path << path;
 
     path.clear();
     path << QPointF(20, 10);
@@ -2021,7 +2021,7 @@ void TST_VAbstractPiece::PathRemoveLoop_data() const
 
     path.removeLast();
 
-    QTest::newRow("Corect unclosed a path, point on line (six unique points)") << path << path;
+    QTest::newRow("Correct unclosed a path, point on line (six unique points)") << path << path;
 
     path.clear();
     path << QPointF(100.96979100571033, 1797.6153764073072);
@@ -2415,7 +2415,7 @@ void TST_VAbstractPiece::BrokenDetailEquidistant_data() const
     QTest::addColumn<QVector<QPointF>>("ekvOrig");
 
     // For more details see the file "collection/bugs/GAVAUDAN Laure - corsage - figure 4.val".
-    // We will test only one detail. The second require too accurate data that we cannot get from debuger.
+    // We will test only one detail. The second require too accurate data that we cannot get from debugger.
     // The test check an open equdistant of correct detail.
     QVector<VSAPoint> points;// Input points.
 

--- a/src/test/Seamly2DTest/tst_vellipticalarc.cpp
+++ b/src/test/Seamly2DTest/tst_vellipticalarc.cpp
@@ -86,7 +86,7 @@ void TST_VEllipticalArc::CompareTwoWays()
     const qreal lengthEps = ToPixel(0.1, Unit::Mm); // computing error
 
     const QString errorLengthMsg =
-            QString("Difference between real and computing lengthes bigger than eps = %1. l1 = %2; l2 = %3");
+            QString("Difference between real and computing lengths bigger than eps = %1. l1 = %2; l2 = %3");
     QVERIFY2(qAbs(arc2.GetLength() - length) <= lengthEps,
              qUtf8Printable(errorLengthMsg.arg(lengthEps).arg(arc2.GetLength()).arg(length)));
     QVERIFY2(qAbs(arc1.GetLength() - arc2.GetLength()) <= lengthEps,
@@ -119,7 +119,7 @@ void TST_VEllipticalArc::NegativeArc()
 
     const qreal eps = ToPixel(0.45, Unit::Mm); // computing error
     const QString errorMsg =
-            QString("Difference between real and computing lengthes bigger than eps = %1.  v1 = %2; v2 = %3");
+            QString("Difference between real and computing lengths bigger than eps = %1.  v1 = %2; v2 = %3");
 
 
             QVERIFY2(qAbs(arc.GetLength() + length) <= eps,
@@ -361,7 +361,7 @@ void TST_VEllipticalArc::TestGetPoints2()
         const qreal diff = qAbs(resultingDistance - distance);
         const QString errorMsg = QString("Broken the first rule, part 2. Distance from the any point to the focus1"
                                          " plus distance from this point to the focus2 should be the same. Problem"
-                                         " with point '%1'. The disired distance is '%2', but resulting distance"
+                                         " with point '%1'. The desired distance is '%2', but resulting distance"
                                          " is '%3'. Difference is '%4' and it biggest than eps '%5')").number(i)
                                          .number(distance).number(resultingDistance).number(diff).number(eps);
         QVERIFY2( diff <= eps, qUtf8Printable(errorMsg));
@@ -417,7 +417,7 @@ void TST_VEllipticalArc::TestGetPoints4()
         VEllipticalArc arc(center, radius1, radius2, 0, 360, 0);
         const qreal arcLength = arc.GetLength();
         const qreal diffLength = qAbs(arcLength - ellipseLength);
-        const QString errorMsg2 = QString("Difference between real and computing lengthes "
+        const QString errorMsg2 = QString("Difference between real and computing lengths "
                                           "(diff = '%1') bigger than eps = '%2'.").arg(diffLength).arg(epsLength);
         QVERIFY2(diffLength <= epsLength, qUtf8Printable(errorMsg2));
     }
@@ -469,7 +469,7 @@ void TST_VEllipticalArc::TestRotation()
             qUtf8Printable(QString("a1 = %1, a2 - %2").arg(arcOrigin.AngleArc()).arg(rotatedArc.AngleArc())));
 
     QString errorLengthMsg =
-            QString("Difference between real and computing lengthes bigger than eps = %1. l1 = %2; l2 = %3");
+            QString("Difference between real and computing lengths bigger than eps = %1. l1 = %2; l2 = %3");
     QVERIFY2(qAbs(arcOrigin.GetLength() - rotatedArc.GetLength()) <= ToPixel(1, Unit::Mm),
              qUtf8Printable(errorLengthMsg.arg(ToPixel(1, Unit::Mm))
                             .arg(arcOrigin.GetLength())

--- a/src/test/TranslationsTest/TranslationsTest.pro
+++ b/src/test/TranslationsTest/TranslationsTest.pro
@@ -37,7 +37,7 @@ DESTDIR = bin
 # Directory for files created moc
 MOC_DIR = moc
 
-# objecs files
+# objects files
 OBJECTS_DIR = obj
 
 DEFINES += SRCDIR=\\\"$$PWD/\\\"


### PR DESCRIPTION
Found via `codespell -q 3 -S *.ts -L alo,groupd,groupe,mapp,nd,ro,ue`
