### PR TITLE
Issue #399 New backup file naming format

### DIFF
--- a/src/libs/ifc/xml/vabstractconverter.cpp
+++ b/src/libs/ifc/xml/vabstractconverter.cpp
@@ -189,7 +189,7 @@ QString VAbstractConverter::removeVersionNumber(const QString& fileName)
     // For all the above cases the return value should be: myPattern.<ext>
 
     const QRegularExpression newVersionRx(QStringLiteral("_v\\d\\d\\d"));
-    QString ret;
+    QString fileNameWithoutVersion;
     int dotPos = fileName.lastIndexOf(QLatin1Char('.'));
     int versionPos = fileName.indexOf(QLatin1String("(v"));
 
@@ -202,40 +202,40 @@ QString VAbstractConverter::removeVersionNumber(const QString& fileName)
             dotPos = lastParenthesisPos + 1;
         }
 
-        ret = fileName.left(versionPos);
+        fileNameWithoutVersion = fileName.left(versionPos);
     }
     else if ((versionPos = fileName.indexOf(newVersionRx)) > -1)
     {
         // New format version number should be removed until the first '.' (if present)
         dotPos = fileName.indexOf(QLatin1Char('.'), versionPos);
-        ret = fileName.left(versionPos);
+        fileNameWithoutVersion = fileName.left(versionPos);
     }
     else
     {
-        ret = fileName;
+        fileNameWithoutVersion = fileName;
     }
 
     if (versionPos > -1 && dotPos > versionPos)
     {
-        ret += fileName.mid(dotPos);
+        fileNameWithoutVersion += fileName.mid(dotPos);
     }
 
-    return ret;
+    return fileNameWithoutVersion;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 QString VAbstractConverter::removeBakExtension(const QString &fileName)
 {
-    QString ret = fileName;
-    int dotPos = ret.lastIndexOf(QLatin1Char('.'));
+    QString newFileName = fileName;
+    int dotPos = newFileName.lastIndexOf(QLatin1Char('.'));
 
-    while (dotPos > -1 && ret.mid(dotPos) == QLatin1String(".bak"))
+    while (dotPos > -1 && newFileName.mid(dotPos) == QLatin1String(".bak"))
     {
-        ret = ret.left(dotPos);
-        dotPos = ret.lastIndexOf(QLatin1Char('.'));
+        newFileName = newFileName.left(dotPos);
+        dotPos = newFileName.lastIndexOf(QLatin1Char('.'));
     }
 
-    return ret;
+    return newFileName;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -278,7 +278,7 @@ void VAbstractConverter::ReserveFile() const
                               .arg(baseFileName)
                               .arg(sequencePart)
                               .arg(info.completeSuffix());
-        sequencePart = QString(" (%1)").arg(++sequenceNumber);
+        sequencePart = QString("_(%1)").arg(++sequenceNumber);
     } while (QFileInfo(reserveFileName).exists());
 
     if (not SafeCopy(m_convertedFileName, reserveFileName, error))

--- a/src/libs/ifc/xml/vabstractconverter.h
+++ b/src/libs/ifc/xml/vabstractconverter.h
@@ -118,8 +118,14 @@ private:
 
     void            ReserveFile() const;
 
+    /**
+     *  \brief Removes version number from \arg fileName
+     *
+     *  It removes both, "old style" ie. "(v0.6.0)" and new style "v060" patterns.
+     */
     static QString  removeVersionNumber(const QString& fileName);
 
+    /** \brief Removes single or repeated '.bak' extension (as long as it is at the end of \arg fileName) */
     static QString  removeBakExtension(const QString& fileName);
 };
 

--- a/src/libs/ifc/xml/vabstractconverter.h
+++ b/src/libs/ifc/xml/vabstractconverter.h
@@ -117,6 +117,10 @@ private:
     static void     ValidateVersion(const QString &version);
 
     void            ReserveFile() const;
+
+    static QString  removeVersionNumber(const QString& fileName);
+
+    static QString  removeBakExtension(const QString& fileName);
 };
 
 #endif // VABSTRACTCONVERTER_H


### PR DESCRIPTION
Fixes #399 
New backup file naming format, fix problems with backup of backup creating wrong file names.

New filename format is: myPattern_v060.val
Now the app should properly remove old version when converting a file, ex: myPattern(v0.6.0).val 
Should also handle files named like: myPattern(v0(v0.6.0).6.0).val

If the backup file cannot be created before a file with that name already exists it will retry adding "(N)" to the filename, like:
myPattern_v060 (2).val, myPattern_v060 (3).val, etc. until it finds an filename that is available.

