### PR TITLE
linux: use PREFIX instead of hardcoded /usr during install

### DIFF
--- a/src/app/seamly2d/seamly2d.pro
+++ b/src/app/seamly2d/seamly2d.pro
@@ -164,12 +164,12 @@ unix{
         seamlyme.files += $${OUT_PWD}/../seamlyme/$${DESTDIR}/seamlyme
 
         # .desktop file
-        desktop.path = /usr/share/applications/
+        desktop.path = $$PREFIX/share/applications/
         desktop.files += ../../../dist/$${TARGET}.desktop \
         desktop.files += ../../../dist/seamlyme.desktop
 
         # logo
-        pixmaps.path = /usr/share/pixmaps/
+        pixmaps.path = $$PREFIX/share/pixmaps/
         pixmaps.files += \
             ../../../dist/$${TARGET}.png \
             ../../../dist/seamlyme.png \
@@ -178,19 +178,19 @@ unix{
             ../../../dist/application-x-seamly2d-s-measurements.png \
 
         # Path to translation files after installation
-        translations.path = /usr/share/$${TARGET}/translations/
+        translations.path = $$PREFIX/share/$${TARGET}/translations/
         translations.files = $$INSTALL_TRANSLATIONS
 
         # Path to multisize measurement after installation
-        multisize.path = /usr/share/$${TARGET}/tables/multisize/
+        multisize.path = $$PREFIX/share/$${TARGET}/tables/multisize/
         multisize.files = $$INSTALL_MULTISIZE_MEASUREMENTS
 
         # Path to templates after installation
-        templates.path = /usr/share/$${TARGET}/tables/templates/
+        templates.path = $$PREFIX/share/$${TARGET}/tables/templates/
         templates.files = $$INSTALL_STANDARD_TEMPLATES
 
         # Path to label templates after installation
-        label.path = /usr/share/$${TARGET}/labels/
+        label.path = $$PREFIX/share/$${TARGET}/labels/
         label.files = $$INSTALL_LABEL_TEMPLATES
 
         INSTALLS += \

--- a/src/app/seamlyme/seamlyme.pro
+++ b/src/app/seamlyme/seamlyme.pro
@@ -214,7 +214,7 @@ unix{
         # Path to bin file after installation
         target.path = $$PREFIX/bin
 
-        rcc_diagrams.path = /usr/share/seamly2d/
+        rcc_diagrams.path = $$PREFIX/share/seamly2d/
         rcc_diagrams.files = $${OUT_PWD}/$${DESTDIR}/diagrams.rcc
         rcc_diagrams.CONFIG = no_check_exist
 


### PR DESCRIPTION
We (@csett86 and me) are preparing the submission of Seamly2D at Flathub (https://flathub.org/) at https://github.com/luki-ev/net.seamly.seamly2d/tree/net.seamly.seamly2d.

Flatpak/Flathub is our recommended way of distributing an app to Linux users since it allows you as developer to ship a current version of the application to all kinds of Linux distributions. In comparison to the AppImage it is not necessary to maintain the whole stack of dependencies anymore and users would get updates automatically. The user is not required to manually update the app anymore.

The build of the app is done by Flathub. You are able to maintain the manifest that controls the build process of the app.

This PR fixes the build process so that the patch currently applied for Flathub (see above) would not be necessary anymore.