### PR TITLE
ci: enable parallel builds for mac as github hosted mac runners have 3 CPUs

### DIFF
--- a/.github/workflows/build-auto-prerelease-on-merge.yml
+++ b/.github/workflows/build-auto-prerelease-on-merge.yml
@@ -155,8 +155,8 @@ jobs:
 
       - name: make Seamly2D for macos
         run: |
-          qmake Seamly2D.pro -r CONFIG+=no_ccache CONFIG+=noDebugSymbols
-          make
+          qmake Seamly2D.pro CONFIG+=no_ccache CONFIG+=noDebugSymbols
+          make -j
 
       - name: build dmg packages
         run: |

--- a/.github/workflows/build-auto-prerelease-on-merge.yml
+++ b/.github/workflows/build-auto-prerelease-on-merge.yml
@@ -156,7 +156,7 @@ jobs:
       - name: make Seamly2D for macos
         run: |
           qmake Seamly2D.pro CONFIG+=no_ccache CONFIG+=noDebugSymbols
-          make -j
+          make -j$(sysctl -n hw.logicalcpu)
 
       - name: build dmg packages
         run: |

--- a/.github/workflows/build-auto-release-on-cron.yml
+++ b/.github/workflows/build-auto-release-on-cron.yml
@@ -156,8 +156,8 @@ jobs:
 
       - name: make Seamly2D for macos
         run: |
-          qmake Seamly2D.pro -r CONFIG+=no_ccache CONFIG+=noDebugSymbols
-          make
+          qmake Seamly2D.pro CONFIG+=no_ccache CONFIG+=noDebugSymbols
+          make -j
 
       - name: build dmg packages
         run: |

--- a/.github/workflows/build-auto-release-on-cron.yml
+++ b/.github/workflows/build-auto-release-on-cron.yml
@@ -157,7 +157,7 @@ jobs:
       - name: make Seamly2D for macos
         run: |
           qmake Seamly2D.pro CONFIG+=no_ccache CONFIG+=noDebugSymbols
-          make -j
+          make -j$(sysctl -n hw.logicalcpu)
 
       - name: build dmg packages
         run: |

--- a/.github/workflows/build-manual-prerelease-macos.yml
+++ b/.github/workflows/build-manual-prerelease-macos.yml
@@ -73,8 +73,8 @@ jobs:
 
       - name: qmake Seamly2D and SeamlyMe
         run: |
-          qmake Seamly2D.pro -r CONFIG+=no_ccache CONFIG+=noDebugSymbols
-          make
+          qmake Seamly2D.pro CONFIG+=no_ccache CONFIG+=noDebugSymbols
+          make -j
 
       - name: build dmg packages
         run: |

--- a/.github/workflows/build-manual-prerelease-macos.yml
+++ b/.github/workflows/build-manual-prerelease-macos.yml
@@ -74,7 +74,7 @@ jobs:
       - name: qmake Seamly2D and SeamlyMe
         run: |
           qmake Seamly2D.pro CONFIG+=no_ccache CONFIG+=noDebugSymbols
-          make -j
+          make -j$(sysctl -n hw.logicalcpu)
 
       - name: build dmg packages
         run: |

--- a/.github/workflows/build-manual-release-all.yml
+++ b/.github/workflows/build-manual-release-all.yml
@@ -154,7 +154,7 @@ jobs:
       - name: make Seamly2D for macos
         run: |
           qmake Seamly2D.pro CONFIG+=no_ccache CONFIG+=noDebugSymbols
-          make -j
+          make -j$(sysctl -n hw.logicalcpu)
 
       - name: build dmg packages
         run: |

--- a/.github/workflows/build-manual-release-all.yml
+++ b/.github/workflows/build-manual-release-all.yml
@@ -153,8 +153,8 @@ jobs:
 
       - name: make Seamly2D for macos
         run: |
-          qmake Seamly2D.pro -r CONFIG+=no_ccache CONFIG+=noDebugSymbols
-          make
+          qmake Seamly2D.pro CONFIG+=no_ccache CONFIG+=noDebugSymbols
+          make -j
 
       - name: build dmg packages
         run: |


### PR DESCRIPTION
see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

The linux appimage already uses parallel build in the appimage recipe, and windows nmake does not support parallel build afaik.