### PR TITLE
seamlyme: bundle diagrams for measurements in binary

### DIFF
--- a/.github/workflows/build-auto-prerelease-on-merge.yml
+++ b/.github/workflows/build-auto-prerelease-on-merge.yml
@@ -200,7 +200,6 @@ jobs:
           copy 'c:\Program Files\OpenSSL\bin\dasync.dll' ..\windows-build\
           New-Item '..\windows-build\translations' -ItemType Directory -Force | Out-Null
           Copy-Item 'share\translations\*.qm' '..\windows-build\translations' -Force -Recurse
-          Copy-Item 'src\app\seamlyme\bin\diagrams.rcc' '..\windows-build'
           cd ..\windows-build\
           & 'C:\Program Files (x86)\NSIS\makensis.exe' seamly2d-installer.nsi
 

--- a/.github/workflows/build-auto-release-on-cron.yml
+++ b/.github/workflows/build-auto-release-on-cron.yml
@@ -201,7 +201,6 @@ jobs:
           copy 'c:\Program Files\OpenSSL\bin\dasync.dll' ..\windows-build\
           New-Item '..\windows-build\translations' -ItemType Directory -Force | Out-Null
           Copy-Item 'share\translations\*.qm' '..\windows-build\translations' -Force -Recurse
-          Copy-Item 'src\app\seamlyme\bin\diagrams.rcc' '..\windows-build'
           cd ..\windows-build\
           & 'C:\Program Files (x86)\NSIS\makensis.exe' seamly2d-installer.nsi
 

--- a/.github/workflows/build-manual-prerelease-windows.yml
+++ b/.github/workflows/build-manual-prerelease-windows.yml
@@ -103,7 +103,6 @@ jobs:
           copy 'c:\Program Files\OpenSSL\bin\dasync.dll' ..\windows-build\
           New-Item '..\windows-build\translations' -ItemType Directory -Force | Out-Null
           Copy-Item 'share\translations\*.qm' '..\windows-build\translations' -Force -Recurse
-          Copy-Item 'src\app\seamlyme\bin\diagrams.rcc' '..\windows-build'
           cd ..\windows-build\
           & 'C:\Program Files (x86)\NSIS\makensis.exe' seamly2d-installer.nsi
 

--- a/.github/workflows/build-manual-release-all.yml
+++ b/.github/workflows/build-manual-release-all.yml
@@ -199,7 +199,6 @@ jobs:
           copy 'c:\Program Files\OpenSSL\bin\dasync.dll' ..\windows-build\
           New-Item '..\windows-build\translations' -ItemType Directory -Force | Out-Null
           Copy-Item 'share\translations\*.qm' '..\windows-build\translations' -Force -Recurse
-          Copy-Item 'src\app\seamlyme\bin\diagrams.rcc' '..\windows-build'
           cd ..\windows-build\
           & 'C:\Program Files (x86)\NSIS\makensis.exe' seamly2d-installer.nsi
 

--- a/dist/OBS_debian/debian.include-binaries
+++ b/dist/OBS_debian/debian.include-binaries
@@ -5,7 +5,6 @@ debian/usr/share/pixmaps/application-x-seamly2d-i-measurements.png
 debian/usr/share/pixmaps/application-x-seamly2d-s-measurements.png
 debian/seamly2d/usr/bin/seamly2d
 debian/seamly2d/usr/bin/seamlyme
-debian/seamly2d/usr/share/seamly2d/diagrams.rcc
 debian/seamly2d/usr/share/seamly2d/translations/measurements_p0_cs_CZ.qm
 debian/seamly2d/usr/share/seamly2d/translations/measurements_p0_de_DE.qm
 debian/seamly2d/usr/share/seamly2d/translations/measurements_p0_en_CA.qm

--- a/dist/debian/source/include-binaries
+++ b/dist/debian/source/include-binaries
@@ -5,7 +5,6 @@ debian/usr/share/pixmaps/application-x-seamly2d-i-measurements.png
 debian/usr/share/pixmaps/application-x-seamly2d-s-measurements.png
 debian/seamly2d/usr/bin/seamly2d
 debian/seamly2d/usr/bin/seamlyme
-debian/seamly2d/usr/share/seamly2d/diagrams.rcc
 debian/seamly2d/usr/share/seamly2d/translations/measurements_p0_cs_CZ.qm
 debian/seamly2d/usr/share/seamly2d/translations/measurements_p0_de_DE.qm
 debian/seamly2d/usr/share/seamly2d/translations/measurements_p0_en_CA.qm

--- a/src/app/seamly2d/seamly2d.pro
+++ b/src/app/seamly2d/seamly2d.pro
@@ -271,10 +271,6 @@ unix{
         icns_resources.files += $$PWD/../../../dist/macx/s-measurements.icns
         icns_resources.files += $$PWD/../../../dist/macx/pattern.icns
 
-        # Copy to bundle multisize measurements files
-        # We cannot add none exist files to bundle through QMAKE_BUNDLE_DATA. That's why we must do this manually.
-        QMAKE_POST_LINK += $$VCOPY $$quote($${OUT_PWD}/../seamlyme/$${DESTDIR}/seamlyme.app/$$RESOURCES_DIR/diagrams.rcc) $$quote($$shell_path($${OUT_PWD}/$$DESTDIR/$${TARGET}.app/$$RESOURCES_DIR/)) $$escape_expand(\\n\\t)
-
         QMAKE_BUNDLE_DATA += \
             templates \
             multisize \
@@ -293,7 +289,6 @@ win32:*g++* {
     package.files += \
         $${OUT_PWD}/$${DESTDIR}/seamly2d.exe \
         $${OUT_PWD}/../seamlyme/$${DESTDIR}/seamlyme.exe \
-        $${OUT_PWD}/../seamlyme/$${DESTDIR}/diagrams.rcc \
         $$PWD/../../../dist/win/seamly2d.ico \
         $$PWD/../../../dist/win/i-measurements.ico \
         $$PWD/../../../dist/win/s-measurements.ico \

--- a/src/app/seamlyme/mapplication.cpp
+++ b/src/app/seamlyme/mapplication.cpp
@@ -422,8 +422,6 @@ void MApplication::InitOptions()
        //This does not happen under GNOME or KDE
        QIcon::setThemeName("win.icon.theme");
     }
-
-    QResource::registerResource(diagramsPath());
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -497,27 +495,6 @@ VSeamlyMeSettings *MApplication::SeamlyMeSettings()
 {
     SCASSERT(settings != nullptr)
     return qobject_cast<VSeamlyMeSettings *>(settings);
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-QString MApplication::diagramsPath() const
-{
-    const QString dPath = QStringLiteral("diagrams.rcc");
-    QDir appDirectory(QCoreApplication::applicationDirPath());
-    QFileInfo appDirFile(appDirectory.filePath(dPath));
-    QFileInfo appDirPath2(QCoreApplication::applicationDirPath() + QStringLiteral("/../share/seamly2d/") + dPath);
-    if (appDirFile.exists())
-    {
-        return appDirFile.absoluteFilePath();
-    }
-    else if (appDirPath2.exists())
-    {
-        return appDirPath2.absoluteFilePath();
-    }
-    else
-    {
-        return QStandardPaths::locate(QStandardPaths::AppDataLocation, dPath);
-    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/app/seamlyme/mapplication.h
+++ b/src/app/seamlyme/mapplication.h
@@ -92,8 +92,6 @@ public:
     virtual void  OpenSettings() Q_DECL_OVERRIDE;
     VSeamlyMeSettings *SeamlyMeSettings();
 
-    QString diagramsPath() const;
-
     void ShowDataBase();
     void retranslateGroups();
     void RetranslateTables();

--- a/src/app/seamlyme/seamlyme.pro
+++ b/src/app/seamlyme/seamlyme.pro
@@ -50,130 +50,8 @@ UI_DIR = uic
 include(seamlyme.pri)
 
 RESOURCES += \
-    share/resources/seamlymeicon.qrc
-
-DATA_RESOURCE = share/resources/diagrams.qrc # External Binary Resource
-
-# The list helps to check that all files are exist.
-# Don't forget to convert text to curves.
-DIAGRAMS += \
-        $${PWD}/share/resources/diagrams/Ap1.svg \
-        $${PWD}/share/resources/diagrams/Ap2.svg \
-        $${PWD}/share/resources/diagrams/Bp1.svg \
-        $${PWD}/share/resources/diagrams/Bp2.svg \
-        $${PWD}/share/resources/diagrams/Cp1.svg \
-        $${PWD}/share/resources/diagrams/Cp2.svg \
-        $${PWD}/share/resources/diagrams/Dp1.svg \
-        $${PWD}/share/resources/diagrams/Dp2.svg \
-        $${PWD}/share/resources/diagrams/Dp3.svg \
-        $${PWD}/share/resources/diagrams/Ep1.svg \
-        $${PWD}/share/resources/diagrams/Ep2.svg \
-        $${PWD}/share/resources/diagrams/Fp1.svg \
-        $${PWD}/share/resources/diagrams/Fp2.svg \
-        $${PWD}/share/resources/diagrams/Fp3.svg \
-        $${PWD}/share/resources/diagrams/Gp1.svg \
-        $${PWD}/share/resources/diagrams/Gp2.svg \
-        $${PWD}/share/resources/diagrams/Gp3.svg \
-        $${PWD}/share/resources/diagrams/Gp4.svg \
-        $${PWD}/share/resources/diagrams/Gp5.svg \
-        $${PWD}/share/resources/diagrams/Gp6.svg \
-        $${PWD}/share/resources/diagrams/Gp7.svg \
-        $${PWD}/share/resources/diagrams/Gp8.svg \
-        $${PWD}/share/resources/diagrams/Gp9.svg \
-        $${PWD}/share/resources/diagrams/Hp1.svg \
-        $${PWD}/share/resources/diagrams/Hp2.svg \
-        $${PWD}/share/resources/diagrams/Hp3.svg \
-        $${PWD}/share/resources/diagrams/Hp4.svg \
-        $${PWD}/share/resources/diagrams/Hp5.svg \
-        $${PWD}/share/resources/diagrams/Hp6.svg \
-        $${PWD}/share/resources/diagrams/Hp7.svg \
-        $${PWD}/share/resources/diagrams/Hp8.svg \
-        $${PWD}/share/resources/diagrams/Hp9.svg \
-        $${PWD}/share/resources/diagrams/Hp10.svg \
-        $${PWD}/share/resources/diagrams/Hp11.svg \
-        $${PWD}/share/resources/diagrams/Hp12.svg \
-        $${PWD}/share/resources/diagrams/Hp13.svg \
-        $${PWD}/share/resources/diagrams/Ip1.svg \
-        $${PWD}/share/resources/diagrams/Ip2.svg \
-        $${PWD}/share/resources/diagrams/Ip3.svg \
-        $${PWD}/share/resources/diagrams/Ip4.svg \
-        $${PWD}/share/resources/diagrams/Ip5.svg \
-        $${PWD}/share/resources/diagrams/Ip6.svg \
-        $${PWD}/share/resources/diagrams/Ip7.svg \
-        $${PWD}/share/resources/diagrams/Jp1.svg \
-        $${PWD}/share/resources/diagrams/Jp2.svg \
-        $${PWD}/share/resources/diagrams/Jp3.svg \
-        $${PWD}/share/resources/diagrams/Jp4.svg \
-        $${PWD}/share/resources/diagrams/Jp5.svg \
-        $${PWD}/share/resources/diagrams/Jp6.svg \
-        $${PWD}/share/resources/diagrams/Kp1.svg \
-        $${PWD}/share/resources/diagrams/Kp2.svg \
-        $${PWD}/share/resources/diagrams/Kp3.svg \
-        $${PWD}/share/resources/diagrams/Kp4.svg \
-        $${PWD}/share/resources/diagrams/Kp5.svg \
-        $${PWD}/share/resources/diagrams/Kp6.svg \
-        $${PWD}/share/resources/diagrams/Kp7.svg \
-        $${PWD}/share/resources/diagrams/Kp8.svg \
-        $${PWD}/share/resources/diagrams/Kp9.svg \
-        $${PWD}/share/resources/diagrams/Kp10.svg \
-        $${PWD}/share/resources/diagrams/Kp11.svg \
-        $${PWD}/share/resources/diagrams/Lp1.svg \
-        $${PWD}/share/resources/diagrams/Lp2.svg \
-        $${PWD}/share/resources/diagrams/Lp3.svg \
-        $${PWD}/share/resources/diagrams/Lp4.svg \
-        $${PWD}/share/resources/diagrams/Lp5.svg \
-        $${PWD}/share/resources/diagrams/Lp6.svg \
-        $${PWD}/share/resources/diagrams/Lp7.svg \
-        $${PWD}/share/resources/diagrams/Lp8.svg \
-        $${PWD}/share/resources/diagrams/Lp9.svg \
-        $${PWD}/share/resources/diagrams/Lp10.svg \
-        $${PWD}/share/resources/diagrams/Mp1.svg \
-        $${PWD}/share/resources/diagrams/Mp2.svg \
-        $${PWD}/share/resources/diagrams/Mp3.svg \
-        $${PWD}/share/resources/diagrams/Np1.svg \
-        $${PWD}/share/resources/diagrams/Np2.svg \
-        $${PWD}/share/resources/diagrams/Np3.svg \
-        $${PWD}/share/resources/diagrams/Np4.svg \
-        $${PWD}/share/resources/diagrams/Np5.svg \
-        $${PWD}/share/resources/diagrams/Op1.svg \
-        $${PWD}/share/resources/diagrams/Op2.svg \
-        $${PWD}/share/resources/diagrams/Op3.svg \
-        $${PWD}/share/resources/diagrams/Op4.svg \
-        $${PWD}/share/resources/diagrams/Op5.svg \
-        $${PWD}/share/resources/diagrams/Op6.svg \
-        $${PWD}/share/resources/diagrams/Op7.svg \
-        $${PWD}/share/resources/diagrams/Op8.svg \
-        $${PWD}/share/resources/diagrams/Op9.svg \
-        $${PWD}/share/resources/diagrams/Op10.svg \
-        $${PWD}/share/resources/diagrams/Op11.svg \
-        $${PWD}/share/resources/diagrams/Pp1.svg \
-        $${PWD}/share/resources/diagrams/Pp2.svg \
-        $${PWD}/share/resources/diagrams/Pp3.svg \
-        $${PWD}/share/resources/diagrams/Pp4.svg \
-        $${PWD}/share/resources/diagrams/Pp5.svg \
-        $${PWD}/share/resources/diagrams/Pp6.svg \
-        $${PWD}/share/resources/diagrams/Pp7.svg \
-        $${PWD}/share/resources/diagrams/Pp8.svg \
-        $${PWD}/share/resources/diagrams/Pp9.svg \
-        $${PWD}/share/resources/diagrams/Pp10.svg \
-        $${PWD}/share/resources/diagrams/Pp11.svg \
-        $${PWD}/share/resources/diagrams/Pp12.svg \
-        $${PWD}/share/resources/diagrams/Qp1.svg \
-        $${PWD}/share/resources/diagrams/Qp2.svg \
-        $${PWD}/share/resources/diagrams/Qp3.svg
-
-!exists($${OUT_PWD}/$${DESTDIR}/diagrams.rcc) {
-    diagrams.name = resource diagrams
-    diagrams.CONFIG += no_link target_predeps
-    diagrams.depends = $$DIAGRAMS # expects a list of files
-    diagrams.input = DATA_RESOURCE # expects the name of a variable
-    diagrams.output = ${QMAKE_FILE_BASE}.rcc
-    diagrams.commands = $$shell_path($$[QT_INSTALL_BINS]/rcc) -binary -no-compress ${QMAKE_FILE_IN} -o $${OUT_PWD}/$${DESTDIR}/${QMAKE_FILE_OUT}
-
-QMAKE_EXTRA_COMPILERS += diagrams
-}
-
-QMAKE_CLEAN += $${OUT_PWD}/$${DESTDIR}/diagrams.rcc
+    share/resources/seamlymeicon.qrc \
+    share/resources/diagrams.qrc
 
 # INSTALL_MULTISIZE_MEASUREMENTS and INSTALL_STANDARD_TEMPLATES inside tables.pri
 include(../tables.pri)
@@ -214,13 +92,8 @@ unix{
         # Path to bin file after installation
         target.path = $$PREFIX/bin
 
-        rcc_diagrams.path = $$PREFIX/share/seamly2d/
-        rcc_diagrams.files = $${OUT_PWD}/$${DESTDIR}/diagrams.rcc
-        rcc_diagrams.CONFIG = no_check_exist
-
         INSTALLS += \
-            target \
-            rcc_diagrams
+            target
     }
     macx{
         # Some macx stuff
@@ -273,10 +146,6 @@ unix{
         templates.path = $$RESOURCES_DIR/tables/templates/
         templates.files = $$INSTALL_STANDARD_TEMPLATES
 
-        # Copy to bundle multisize measurements files
-        # We cannot add none exist files to bundle through QMAKE_BUNDLE_DATA. That's why we must do this manually.
-        QMAKE_POST_LINK += $$VCOPY $$quote($${OUT_PWD}/$${DESTDIR}/diagrams.rcc) $$quote($$shell_path($${OUT_PWD}/$$DESTDIR/$${TARGET}.app/$$RESOURCES_DIR/)) $$escape_expand(\\n\\t)
-
         format.path = $$RESOURCES_DIR/
         format.files += $$PWD/../../../dist/macx/i-measurements.icns
         format.files += $$PWD/../../../dist/macx/s-measurements.icns
@@ -300,8 +169,7 @@ win32 {
 
 # Compilation will fail without this files after we added them to this section.
 OTHER_FILES += \
-    share/resources/seamlymeicon/64x64/logo.ico \ # SeamlyMe's logo.
-    $$DATA_RESOURCE
+    share/resources/seamlymeicon/64x64/logo.ico # SeamlyMe's logo.
 
 # Set using ccache. Function enable_ccache() defined in common.pri.
 $$enable_ccache()

--- a/test_appvyr.yml
+++ b/test_appvyr.yml
@@ -30,7 +30,6 @@ build_script:
   - sh: cp dist/seamly2d.desktop $buildDirPath/share/applications
   - sh: cp share/img/Seamly2D_logo_256x256.png $buildDirPath/share/icons/hicolor/256x256/seamly2d.png
   - sh: cp share/translations/*.qm $buildDirPath/share/translations
-  - sh: cp src/app/seamlyme/bin/diagrams.rcc $buildDirPath/share
   - sh: docker run --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined --security-opt seccomp=unconfined -v $buildDirPath:/app/usr -e EXTRA_BINARIES="seamlyme" --rm mhitza/linuxdeployqt:5.15.2
   - sh: mv $buildDirPath/Seamly2D*.AppImage ./
   - sh: ls *.AppImage


### PR DESCRIPTION
The diagrams are 1.5MB, this can be easily bundled into eg. the 95MB seamlyme
binary on mac, and with that saving a lot of hassle and custom code to
ensure that the diagrams are there.
