### PR TITLE
ci: Replace deprecated set-output

### DIFF
--- a/.github/workflows/build-auto-release-on-cron.yml
+++ b/.github/workflows/build-auto-release-on-cron.yml
@@ -32,8 +32,8 @@ jobs:
         id: names
         run: |
           version_date_time="$(date +v%F.%H%M)"
-          echo "::set-output name=TAG_NAME::$version_date_time"
-          echo "::set-output name=RELEASE_NAME::$version_date_time"
+          echo "TAG_NAME=$version_date_time" >> $GITHUB_OUTPUT
+          echo "RELEASE_NAME:=$version_date_time" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build-manual-release-all.yml
+++ b/.github/workflows/build-manual-release-all.yml
@@ -30,8 +30,8 @@ jobs:
         id: names
         run: |
           version_date_time="$(date +v%F.%H%M)"
-          echo "::set-output name=TAG_NAME::$version_date_time"
-          echo "::set-output name=RELEASE_NAME::$version_date_time"
+          echo "TAG_NAME=$version_date_time" >> $GITHUB_OUTPUT
+          echo "RELEASE_NAME=$version_date_time" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
