### PR TITLE
build: fix Qt declarations in qmudef.h

### DIFF
--- a/src/libs/qmuparser/qmudef.h
+++ b/src/libs/qmuparser/qmudef.h
@@ -22,15 +22,18 @@
 #ifndef QMUDEF_H
 #define QMUDEF_H
 
+#include <qcompilerdetection.h>
+#include <QtGlobal>
+#include <QChar>
+#include <QString>
+#include <QLocale>
+
 QT_WARNING_PUSH
 QT_WARNING_DISABLE_GCC("-Wattributes")
 
 #ifdef Q_CC_MSVC
     #include <ciso646>
 #endif /* Q_CC_MSVC */
-
-class QLocale;
-class QChar;
 
 #define INIT_LOCALE_VARIABLES(locale)                          \
 const QChar positiveSign   = (locale).positiveSign();          \


### PR DESCRIPTION
Discovered by gcc12 as part of flatpak build, fixes:

qmudef.h:25:1: error: ‘QT_WARNING_PUSH’ does not name a type
   25 | QT_WARNING_PUSH
      | ^~~~~~~~~~~~~~~
qmudef.h:53:1: error: ‘QString’ does not name a type
   53 | QString NameRegExp();
      | ^~~~~~~
qmudef.h:55:1: error: ‘QT_WARNING_POP’ does not name a type
   55 | QT_WARNING_POP
      | ^~~~~~~~~~~~~~
qmudef.h:60:8: error: ‘qFuzzyIsNull’ was not declared in this scope
   60 |     if(qFuzzyIsNull(p1))
      |        ^~~~~~~~~~~~
qmudef.h:70:16: error: ‘qFuzzyCompare’ was not declared in this scope
   70 |         return qFuzzyCompare(p1, p2);
      |                ^~~~~~~~~~~~~
qmudef.h: At global scope:
qmudef.h:74:19: error: ‘QString’ does not name a type
   74 | int ReadVal(const QString &formula, qreal &val, const QLocale &locale, const QChar &decimal,
      |                   ^~~~~~~
qmudef.h:74:37: error: ‘qreal’ has not been declared
   74 | int ReadVal(const QString &formula, qreal &val, const QLocale &locale, const QChar &decimal,
      |                                     ^~~~~
qmudef.h:74:55: error: ‘QLocale’ does not name a type
   74 | int ReadVal(const QString &formula, qreal &val, const QLocale &locale, const QChar &decimal,
      |
