### PR TITLE
build: remove broken gcc variant qmake code

### DIFF
--- a/Seamly2D.pro
+++ b/Seamly2D.pro
@@ -15,33 +15,6 @@ count(LIST, 1, >): error("The build will fail. Path '$${PWD}' contains space!!!"
 LIST = $$split(OUT_PWD,' ')
 count(LIST, 1, >): error("The build will fail. Path '$${OUT_PWD}' contains space!!!")
 
-unix {
-    *g++* {
-        GCC_VERSION = $$system("g++ -dumpversion")
-        contains(GCC_VERSION, ^15.*$) {
-            message( "Seamly2D.pro: g++ version 15.x found" )
-            CONFIG += g++7
-        } else {
-            contains(GCC_VERSION, ^14.*$) {
-                message( "Seamly2D.pro: g++ version 14.x found" )
-                CONFIG += g++6
-            } else {
-                contains(GCC_VERSION, ^13.*$) {
-                    message( "Seamly2D.pro: g++ version 13.x found" )
-                    CONFIG += g++5
-                } else {
-                    contains(GCC_VERSION, ^12.*$) {
-                        message( "Seamly2D.pro: g++ version 12.x found" )
-                        CONFIG += g++4
-                    } else {
-                        message( "Seamly2D.pro: GCC version $${GCC_VERSION} found")
-                    }
-                }
-            }
-        }
-    }
-}
-
 TEMPLATE = subdirs
 SUBDIRS = \
     src \


### PR DESCRIPTION
GCC <=11 was not triggering anything, and gcc 12+ then gcc-4 warnings
Remove as this is not needed and Qt does a better job at handling gcc
variant topics in the builtin mkspecs
