### PR TITLE
build: use builtin OSX deployment targets

### DIFF
--- a/dist/macx/seamly2d/Info.plist
+++ b/dist/macx/seamly2d/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.6</string>
+	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2013-2017, Seamly2D project</string>
 	<key>CFBundleSignature</key>

--- a/dist/macx/seamlyme/Info.plist
+++ b/dist/macx/seamlyme/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.6</string>
+	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>© 2013-2017, Seamly2D project</string>
 	<key>CFBundleSignature</key>

--- a/src/app/seamly2d/seamly2d.pro
+++ b/src/app/seamly2d/seamly2d.pro
@@ -201,29 +201,9 @@ unix{
             label
     }
     macx{
-        # Some macx stuff
-        QMAKE_MAC_SDK = macosx
-
-        # Check which minimal OSX version supports current Qt version
-        # See page https://doc.qt.io/qt-5/supported-platforms-and-configurations.html
-        equals(QT_MAJOR_VERSION, 5):greaterThan(QT_MINOR_VERSION, 7) {# Qt 5.8
-            QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
-        } else {
-            equals(QT_MAJOR_VERSION, 5):greaterThan(QT_MINOR_VERSION, 6) {# Qt 5.7
-                QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.8
-            } else {
-                equals(QT_MAJOR_VERSION, 5):greaterThan(QT_MINOR_VERSION, 3) {# Qt 5.4
-                    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
-                } else {
-                    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.6
-                }
-            }
-        }
-
-        QMAKE_RPATHDIR += @executable_path/../Frameworks
+        message(seamly2d.pro: mac deployment target: $$QMAKE_MACOSX_DEPLOYMENT_TARGET)
 
         # Path to resources in app bundle
-        #RESOURCES_DIR = "Contents/Resources" defined in translation.pri
         FRAMEWORKS_DIR = "Contents/Frameworks"
         MACOS_DIR = "Contents/MacOS"
         # On macx we will use app bundle. Bundle doesn't need bin directory inside.

--- a/src/app/seamlyme/seamlyme.pro
+++ b/src/app/seamlyme/seamlyme.pro
@@ -96,29 +96,9 @@ unix{
             target
     }
     macx{
-        # Some macx stuff
-        QMAKE_MAC_SDK = macosx
-
-        # Check which minimal OSX version supports current Qt version
-        # See page https://doc.qt.io/qt-5/supported-platforms-and-configurations.html
-        equals(QT_MAJOR_VERSION, 5):greaterThan(QT_MINOR_VERSION, 7) {# Qt 5.8
-            QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
-        } else {
-            equals(QT_MAJOR_VERSION, 5):greaterThan(QT_MINOR_VERSION, 6) {# Qt 5.7
-                QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.8
-            } else {
-                equals(QT_MAJOR_VERSION, 5):greaterThan(QT_MINOR_VERSION, 3) {# Qt 5.4
-                    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
-                } else {
-                    QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.6
-                }
-            }
-        }
-
-        QMAKE_RPATHDIR += @executable_path/../Frameworks
+        message(seamlyme.pro: mac deployment target: $$QMAKE_MACOSX_DEPLOYMENT_TARGET)
 
         # Path to resources in app bundle
-        #RESOURCES_DIR = "Contents/Resources" defined in translation.pri
         FRAMEWORKS_DIR = "Contents/Frameworks"
         MACOS_DIR = "Contents/MacOS"
         # On macx we will use app bundle. Bundle doesn't need bin directory inside.


### PR DESCRIPTION
Qt internally sets the deployment target automatically, use that
See https://doc.qt.io/qt-5/macos-deployment.html#macos-version-dependencies

Closes: #451
