### PR TITLE
build: remove generated target_wrapper.sh

### DIFF
--- a/src/test/CollectionTest/target_wrapper.sh
+++ b/src/test/CollectionTest/target_wrapper.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH
-QT_PLUGIN_PATH=/usr/lib/x86_64-linux-gnu/qt5/plugins${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}
-export QT_PLUGIN_PATH
-exec "$@"

--- a/src/test/ParserTest/target_wrapper.sh
+++ b/src/test/ParserTest/target_wrapper.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH
-QT_PLUGIN_PATH=/usr/lib/x86_64-linux-gnu/qt5/plugins${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}
-export QT_PLUGIN_PATH
-exec "$@"

--- a/src/test/Seamly2DTest/target_wrapper.sh
+++ b/src/test/Seamly2DTest/target_wrapper.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH
-QT_PLUGIN_PATH=/usr/lib/x86_64-linux-gnu/qt5/plugins${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}
-export QT_PLUGIN_PATH
-exec "$@"

--- a/src/test/TranslationsTest/target_wrapper.sh
+++ b/src/test/TranslationsTest/target_wrapper.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-export LD_LIBRARY_PATH
-QT_PLUGIN_PATH=/usr/lib/x86_64-linux-gnu/qt5/plugins${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}
-export QT_PLUGIN_PATH
-exec "$@"


### PR DESCRIPTION
They are being generated on build and contain host-specific paths
