### PR TITLE
build: remove invalid clang warnings

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -305,7 +305,6 @@ CLANG_DEBUG_CXXFLAGS += \
     -Wabstract-final-class \
     -Wabstract-vbase-init \
     -Waddress \
-    -Waddress-of-array-temporary \
     -Waddress-of-temporary \
     -Waggregate-return \
     -Wall \
@@ -416,7 +415,6 @@ CLANG_DEBUG_CXXFLAGS += \
     -Wenum-compare \
     -Wenum-conversion \
     -Wexplicit-ownership-type \
-    -Wextended-offsetof \
     -Wextern-initializer \
     -Wextra \
     -Wextra-semi \


### PR DESCRIPTION
Fixes:

warning: unknown warning option '-Waddress-of-array-temporary'; did you mean '-Waddress-of-temporary'? [-Wunknown-warning-option]
warning: unknown warning option '-Wextended-offsetof'; did you mean '-Winvalid-offsetof'? [-Wunknown-warning-option]
