### PR TITLE
mac: fix f(x) crash

### DIFF
--- a/src/app/seamly2d/dialogs/dialoghistory.cpp
+++ b/src/app/seamly2d/dialogs/dialoghistory.cpp
@@ -217,7 +217,7 @@ void DialogHistory::FillTable()
             }
 
             QTableWidgetItem *item = new QTableWidgetItem(historyRecord);
-            item->setFont(QFont("Times", 10, QFont::Bold));
+            item->setFont(QFont("Arial", 10, QFont::Bold));
             item->setFlags(item->flags() ^ Qt::ItemIsEditable);
             ui->tableWidget->setItem(currentRow, 1, item);//2nd column is Tool history description
             ++count;

--- a/src/libs/vtools/dialogs/support/dialogeditwrongformula.cpp
+++ b/src/libs/vtools/dialogs/support/dialogeditwrongformula.cpp
@@ -530,7 +530,7 @@ void DialogEditWrongFormula::ShowVariable(const QMap<key, val> &var)
         {// If we create this variable don't show
             ui->tableWidget->setRowCount(ui->tableWidget->rowCount() + 1);
             QTableWidgetItem *item = new QTableWidgetItem(iMap.key());
-            item->setFont(QFont("Times", 12, QFont::Bold));
+            item->setFont(QFont("Arial", 12, QFont::Bold));
             ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, ColumnName, item);
         }
     }
@@ -564,11 +564,11 @@ void DialogEditWrongFormula::ShowMeasurements(const QMap<QString, QSharedPointer
         {// If we create this variable don't show
             ui->tableWidget->setRowCount(ui->tableWidget->rowCount() + 1);
             QTableWidgetItem *itemName = new QTableWidgetItem(iMap.key());
-            itemName->setFont(QFont("Times", 12, QFont::Bold));
+            itemName->setFont(QFont("Arial", 12, QFont::Bold));
             itemName->setToolTip(itemName->text());
 
             QTableWidgetItem *itemFullName = new QTableWidgetItem();
-            itemFullName->setFont(QFont("Times", 12, QFont::Bold));
+            itemFullName->setFont(QFont("Arial", 12, QFont::Bold));
             if (iMap.value()->IsCustom())
             {
                 itemFullName->setText(iMap.value()->GetGuiText());
@@ -605,7 +605,7 @@ void DialogEditWrongFormula::ShowFunctions()
     {
         ui->tableWidget->setRowCount(ui->tableWidget->rowCount() + 1);
         QTableWidgetItem *item = new QTableWidgetItem(i.value().translate());
-        item->setFont(QFont("Times", 12, QFont::Bold));
+        item->setFont(QFont("Arial", 12, QFont::Bold));
         ui->tableWidget->setItem(ui->tableWidget->rowCount()-1, ColumnName, item);
         item->setToolTip(i.value().getMdisambiguation());
         ++i;

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp
@@ -303,7 +303,7 @@ void DialogCubicBezierPath::currentPointChanged(int index)
 void DialogCubicBezierPath::NewItem(const VPointF &point)
 {
     auto item = new QListWidgetItem(point.name());
-    item->setFont(QFont("Times", 12, QFont::Bold));
+    item->setFont(QFont("Arial", 12, QFont::Bold));
     item->setData(Qt::UserRole, QVariant::fromValue(point));
 
     ui->listWidget->addItem(item);

--- a/src/libs/vtools/dialogs/tools/dialogsplinepath.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogsplinepath.cpp
@@ -801,7 +801,7 @@ void DialogSplinePath::NewItem(const VSplinePoint &point)
     flagLength2.append(true);
 
     auto item = new QListWidgetItem(point.P().name());
-    item->setFont(QFont("Times", 12, QFont::Bold));
+    item->setFont(QFont("Arial", 12, QFont::Bold));
     item->setData(Qt::UserRole, QVariant::fromValue(point));
 
     ui->listWidget->addItem(item);

--- a/src/libs/vtools/dialogs/tools/piece/dialogseamallowance.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/dialogseamallowance.cpp
@@ -2240,7 +2240,7 @@ void DialogSeamAllowance::NewCustomSA(const CustomSARecord &record)
         const QString name = GetPathName(record.path, record.reverse);
 
         QListWidgetItem *item = new QListWidgetItem(name);
-        item->setFont(QFont("Times", 12, QFont::Bold));
+        item->setFont(QFont("Arial", 12, QFont::Bold));
         item->setData(Qt::UserRole, QVariant::fromValue(record));
         uiPathsTab->customSeamAllowance_ListWidget->addItem(item);
         uiPathsTab->customSeamAllowance_ListWidget->setCurrentRow(uiPathsTab->customSeamAllowance_ListWidget->count()-1);
@@ -2255,7 +2255,7 @@ void DialogSeamAllowance::NewInternalPath(quint32 path)
         const QString name = GetPathName(path);
 
         QListWidgetItem *item = new QListWidgetItem(name);
-        item->setFont(QFont("Times", 12, QFont::Bold));
+        item->setFont(QFont("Arial", 12, QFont::Bold));
         item->setData(Qt::UserRole, QVariant::fromValue(path));
         uiPathsTab->internalPaths_ListWidget->addItem(item);
         uiPathsTab->internalPaths_ListWidget->setCurrentRow(uiPathsTab->internalPaths_ListWidget->count()-1);
@@ -2270,7 +2270,7 @@ void DialogSeamAllowance::newAnchorPoint(quint32 anchorPoint)
         const QSharedPointer<VGObject> anchor = data->GetGObject(anchorPoint);
 
         QListWidgetItem *item = new QListWidgetItem(anchor->name());
-        item->setFont(QFont("Times", 12, QFont::Bold));
+        item->setFont(QFont("Arial", 12, QFont::Bold));
         item->setData(Qt::UserRole, QVariant::fromValue(anchorPoint));
         uiAnchorPointsTab->anchorPoints_ListWidget->addItem(item);
         uiAnchorPointsTab->anchorPoints_ListWidget->setCurrentRow(uiAnchorPointsTab->anchorPoints_ListWidget->count()-1);


### PR DESCRIPTION
this is a quickfix by switching to a font that is available by default (Arial).
Thanks to the bug-hunting in https://forum.seamly.net/t/seamly-2d-crashes-when-adding-formula-for-measurements-mac-os-monterey/7043/7

Tested with macOS Ventura (13.1)

Closes: #572 #589 #536
