### PR TITLE
mac: remove all references to MS Shell Dlg

### DIFF
--- a/share/translations/seamly2d.ts
+++ b/share/translations/seamly2d.ts
@@ -336,7 +336,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -245,7 +245,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -336,7 +336,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -332,7 +332,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -336,7 +336,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -336,7 +336,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -336,7 +336,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -336,7 +336,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -238,7 +238,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -336,7 +336,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -91,7 +91,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -222,7 +222,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -336,7 +336,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -336,7 +336,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -336,7 +336,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -328,7 +328,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -336,7 +336,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -336,7 +336,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -242,7 +242,7 @@
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui
@@ -163,7 +163,6 @@
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -189,7 +188,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -211,7 +209,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -227,7 +224,6 @@
              <widget class="QLabel" name="label_10">
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -270,7 +266,6 @@
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -321,7 +316,6 @@
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2 UI</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -339,7 +333,6 @@
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2 UI</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -361,7 +354,6 @@
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2 UI</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -377,7 +369,6 @@
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2 UI</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -399,7 +390,6 @@
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2 UI</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -418,7 +408,6 @@
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2 UI</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -452,7 +441,6 @@
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2 UI</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -483,7 +471,6 @@
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2 UI</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -702,7 +689,6 @@
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2</family>
            <pointsize>9</pointsize>
            <weight>50</weight>
            <bold>false</bold>
@@ -727,7 +713,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                 <weight>50</weight>
                 <bold>false</bold>
@@ -757,7 +742,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                 <weight>50</weight>
                 <bold>false</bold>
@@ -915,7 +899,6 @@
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -935,7 +918,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -957,7 +939,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -990,7 +971,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1012,7 +992,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1051,7 +1030,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1073,7 +1051,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1106,7 +1083,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1128,7 +1104,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
@@ -62,7 +62,6 @@
      </property>
      <property name="font">
       <font>
-       <family>MS Shell Dlg 2 UI</family>
        <pointsize>9</pointsize>
       </font>
      </property>
@@ -107,7 +106,6 @@
            </property>
            <property name="font">
             <font>
-             <family>MS Shell Dlg 2 UI</family>
              <pointsize>9</pointsize>
             </font>
            </property>
@@ -125,7 +123,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -284,7 +281,6 @@
            </property>
            <property name="font">
             <font>
-             <family>MS Shell Dlg 2 UI</family>
              <pointsize>9</pointsize>
             </font>
            </property>
@@ -314,7 +310,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -381,7 +376,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -403,7 +397,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>8</pointsize>
                </font>
               </property>
@@ -643,7 +636,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -665,7 +657,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -905,7 +896,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -927,7 +917,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1179,7 +1168,6 @@
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2 UI</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -1205,7 +1193,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1267,7 +1254,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1334,7 +1320,6 @@
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2 UI</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -1360,7 +1345,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1422,7 +1406,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1489,7 +1472,6 @@
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2 UI</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -1515,7 +1497,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1597,7 +1578,6 @@
              </property>
              <property name="font">
               <font>
-               <family>MS Shell Dlg 2 UI</family>
                <pointsize>9</pointsize>
               </font>
              </property>
@@ -1659,7 +1639,6 @@
              </property>
              <property name="font">
               <font>
-               <family>MS Shell Dlg 2 UI</family>
                <pointsize>9</pointsize>
               </font>
              </property>
@@ -1721,7 +1700,6 @@
              </property>
              <property name="font">
               <font>
-               <family>MS Shell Dlg 2 UI</family>
                <pointsize>9</pointsize>
               </font>
              </property>
@@ -1807,7 +1785,6 @@
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2 UI</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -1834,7 +1811,6 @@
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2 UI</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -1864,7 +1840,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1886,7 +1861,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1920,7 +1894,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1942,7 +1915,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1979,7 +1951,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -2001,7 +1972,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -2038,7 +2008,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -2062,7 +2031,6 @@
                 </property>
                 <property name="font">
                  <font>
-                  <family>MS Shell Dlg 2 UI</family>
                   <pointsize>9</pointsize>
                  </font>
                 </property>
@@ -2173,7 +2141,6 @@ border-radius: 4px;
                 </property>
                 <property name="font">
                  <font>
-                  <family>MS Shell Dlg 2 UI</family>
                   <pointsize>9</pointsize>
                  </font>
                 </property>
@@ -2214,7 +2181,6 @@ border-radius: 4px;
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2 UI</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -2238,7 +2204,6 @@ border-radius: 4px;
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2 UI</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -2262,7 +2227,6 @@ border-radius: 4px;
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -2286,7 +2250,6 @@ border-radius: 4px;
                 </property>
                 <property name="font">
                  <font>
-                  <family>MS Shell Dlg 2 UI</family>
                   <pointsize>9</pointsize>
                  </font>
                 </property>
@@ -2400,7 +2363,6 @@ border-radius: 4px;
                 </property>
                 <property name="font">
                  <font>
-                  <family>MS Shell Dlg 2 UI</family>
                   <pointsize>9</pointsize>
                  </font>
                 </property>
@@ -2461,7 +2423,6 @@ border-radius: 4px;
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2 UI</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -2494,7 +2455,6 @@ border-radius: 4px;
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2 UI</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -2524,7 +2484,6 @@ border-radius: 4px;
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -2546,7 +2505,6 @@ border-radius: 4px;
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -2607,7 +2565,6 @@ border-radius: 4px;
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2 UI</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -2619,7 +2576,6 @@ border-radius: 4px;
            <widget class="QCheckBox" name="zoomDoubleClick_CheckBox">
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2 UI</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -2675,7 +2631,6 @@ border-radius: 4px;
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2 UI</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -2699,7 +2654,6 @@ border-radius: 4px;
                 </property>
                 <property name="font">
                  <font>
-                  <family>MS Shell Dlg 2 UI</family>
                   <pointsize>9</pointsize>
                  </font>
                 </property>
@@ -2816,7 +2770,6 @@ border-radius: 4px;
                 </property>
                 <property name="font">
                  <font>
-                  <family>MS Shell Dlg 2 UI</family>
                   <pointsize>9</pointsize>
                  </font>
                 </property>

--- a/src/app/seamly2d/dialogs/configpages/preferencespathpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencespathpage.ui
@@ -30,7 +30,6 @@
     <widget class="QGroupBox" name="groupBox">
      <property name="font">
       <font>
-       <family>MS Shell Dlg 2 UI</family>
        <pointsize>9</pointsize>
       </font>
      </property>
@@ -88,7 +87,6 @@
        </property>
        <property name="font">
         <font>
-         <family>MS Shell Dlg 2 UI</family>
          <pointsize>9</pointsize>
         </font>
        </property>
@@ -123,7 +121,6 @@
        </property>
        <property name="font">
         <font>
-         <family>MS Shell Dlg 2 UI</family>
          <pointsize>9</pointsize>
         </font>
        </property>

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
@@ -81,7 +81,6 @@
        </property>
        <property name="font">
         <font>
-         <family>MS Shell Dlg 2</family>
          <pointsize>9</pointsize>
         </font>
        </property>
@@ -116,7 +115,6 @@
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -138,7 +136,6 @@
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -191,7 +188,6 @@
        </property>
        <property name="font">
         <font>
-         <family>MS Shell Dlg 2</family>
          <pointsize>9</pointsize>
         </font>
        </property>
@@ -209,7 +205,6 @@
           </property>
           <property name="font">
            <font>
-            <family>MS Shell Dlg 2</family>
             <pointsize>9</pointsize>
            </font>
           </property>
@@ -235,7 +230,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -269,7 +263,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -305,7 +298,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -327,7 +319,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                </font>
               </property>
              </widget>
@@ -371,7 +362,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -405,7 +395,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -471,7 +460,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -505,7 +493,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -588,7 +575,6 @@
      </property>
      <property name="font">
       <font>
-       <family>MS Shell Dlg 2</family>
        <pointsize>9</pointsize>
       </font>
      </property>
@@ -608,7 +594,6 @@
           </property>
           <property name="font">
            <font>
-            <family>MS Shell Dlg 2</family>
             <pointsize>9</pointsize>
            </font>
           </property>
@@ -636,7 +621,6 @@
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -658,7 +642,6 @@
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -789,7 +772,6 @@
      </property>
      <property name="font">
       <font>
-       <family>MS Shell Dlg 2</family>
        <pointsize>9</pointsize>
       </font>
      </property>
@@ -816,7 +798,6 @@
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -850,7 +831,6 @@
          </property>
          <property name="font">
           <font>
-           <family>MS Shell Dlg 2</family>
            <pointsize>9</pointsize>
           </font>
          </property>
@@ -931,7 +911,6 @@
       </property>
       <property name="font">
        <font>
-        <family>MS Shell Dlg 2</family>
         <pointsize>9</pointsize>
        </font>
       </property>
@@ -963,7 +942,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -991,7 +969,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1030,7 +1007,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1058,7 +1034,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1185,7 +1160,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1213,7 +1187,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1246,7 +1219,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1274,7 +1246,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1395,7 +1366,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1423,7 +1393,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1462,7 +1431,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1490,7 +1458,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1611,7 +1578,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1639,7 +1605,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1678,7 +1643,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1706,7 +1670,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1826,7 +1789,6 @@
        </property>
        <property name="font">
         <font>
-         <family>MS Shell Dlg 2</family>
          <pointsize>9</pointsize>
         </font>
        </property>
@@ -1846,7 +1808,6 @@
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2</family>
               <pointsize>9</pointsize>
              </font>
             </property>
@@ -1874,7 +1835,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1896,7 +1856,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1938,7 +1897,6 @@
        </property>
        <property name="font">
         <font>
-         <family>MS Shell Dlg 2</family>
          <pointsize>9</pointsize>
         </font>
        </property>
@@ -1960,7 +1918,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -1994,7 +1951,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -2010,7 +1966,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -2046,7 +2001,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -2080,7 +2034,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>
@@ -2096,7 +2049,6 @@
               </property>
               <property name="font">
                <font>
-                <family>MS Shell Dlg 2</family>
                 <pointsize>9</pointsize>
                </font>
               </property>

--- a/src/app/seamly2d/dialogs/decimalchart_dialog.ui
+++ b/src/app/seamly2d/dialogs/decimalchart_dialog.ui
@@ -49,7 +49,7 @@
     <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;1/8 = .125&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;2/8 = .250&lt;/span&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:12pt;&quot;&gt;3/8 = .375&lt;/span&gt;&lt;/p&gt;

--- a/src/app/seamly2d/dialogs/export_layout_dialog.ui
+++ b/src/app/seamly2d/dialogs/export_layout_dialog.ui
@@ -273,7 +273,6 @@
                </property>
                <property name="font">
                 <font>
-                 <family>MS Shell Dlg 2</family>
                  <pointsize>9</pointsize>
                 </font>
                </property>
@@ -306,7 +305,6 @@
                  </property>
                  <property name="font">
                   <font>
-                   <family>MS Shell Dlg 2 UI</family>
                    <pointsize>9</pointsize>
                   </font>
                  </property>
@@ -429,7 +427,6 @@ border-radius: 4px;
                  </property>
                  <property name="font">
                   <font>
-                   <family>MS Shell Dlg 2 UI</family>
                    <pointsize>9</pointsize>
                   </font>
                  </property>

--- a/src/app/seamly2d/dialogs/shortcuts_dialog.ui
+++ b/src/app/seamly2d/dialogs/shortcuts_dialog.ui
@@ -325,7 +325,7 @@
           <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;title&gt;Seamly2S Shortcuts&lt;/title&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:600;&quot;&gt;Seamly2D Keyboard Shortcuts&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;		&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:600;&quot;&gt;File&lt;/span&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;		&lt;/span&gt;&lt;/p&gt;

--- a/src/app/seamlyme/dialogs/me_shortcuts_dialog.ui
+++ b/src/app/seamlyme/dialogs/me_shortcuts_dialog.ui
@@ -348,7 +348,7 @@
          <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;title&gt;Seamly2S Shortcuts&lt;/title&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:600;&quot;&gt;Me Keyboard Shortcuts	&lt;/span&gt;&lt;span style=&quot; font-size:11pt;&quot;&gt;	&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:14pt; font-weight:600;&quot;&gt;File&lt;/span&gt;&lt;/p&gt;

--- a/src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui
@@ -154,7 +154,6 @@
             </property>
             <property name="font">
              <font>
-              <family>MS Shell Dlg 2</family>
               <pointsize>9</pointsize>
               <weight>50</weight>
               <bold>false</bold>


### PR DESCRIPTION
This is a font only available on windows, remove it from the ui files
to use the default font.

Fixes the error

Populating font family aliases took xxx ms.Replace uses of missing
font family "MS Shell Dlg 2" with one that exists to avoid this cost.
