### PR TITLE
AppImage: Add librsvg2-common for libpixbufloader-svg.so

### DIFF
--- a/dist/appimage-builder-recipe-jammy.yml
+++ b/dist/appimage-builder-recipe-jammy.yml
@@ -50,6 +50,7 @@ AppDir:
     - libdrm-common
     - libgcrypt20
     - libjpeg-turbo8
+    - librsvg2-common
     - liblz4-1
     - libpoppler118
     - libqt5core5a


### PR DESCRIPTION
Fixes error:

Gtk:ERROR:../../../../gtk/gtkiconhelper.c:494:ensure_surface_for_gicon: assertion failed (error == NULL): Failed to load /usr/share/icons/Mint-Y/actions/16/image-missing.svg: Unable to load image-loading module: libpixbufloader-svg.so: libpixbufloader-svg.so: cannot open shared object file: No such file or directory (gdk-pixbuf-error-quark, 5)
Bail out! Gtk:ERROR:../../../../gtk/gtkiconhelper.c:494:ensure_surface_for_gicon: assertion failed (error == NULL): Failed to load /usr/share/icons/Mint-Y/actions/16/image-missing.svg: Unable to load image-loading module: libpixbufloader-svg.so: libpixbufloader-svg.so: cannot open shared object file: No such file or directory (gdk-pixbuf-error-quark, 5)