### PR TITLE
updater: no version check launch

### DIFF
--- a/src/app/seamly2d/main.cpp
+++ b/src/app/seamly2d/main.cpp
@@ -51,7 +51,6 @@
 
 #include "mainwindow.h"
 #include "core/vapplication.h"
-#include "../fervor/fvupdater.h"
 #include "../vpatterndb/vpiecenode.h"
 
 #include <QApplication>
@@ -90,19 +89,6 @@ int main(int argc, char *argv[])
     VApplication app(argc, argv);
 
     app.InitOptions();
-
-    // Due to unknown reasons version checker cause a crash. See issue #633.
-    // Before we will find what cause such crashes it will stay disabled in Release mode.
-#ifndef V_NO_ASSERT
-    if (VApplication::IsGUIMode())
-    {
-        // Set feed URL before doing anything else
-        FvUpdater::sharedUpdater()->SetFeedURL(defaultFeedURL);
-
-        // Check for updates automatically
-        FvUpdater::sharedUpdater()->CheckForUpdatesSilent();
-    }
-#endif // V_NO_ASSERT
 
     MainWindow w;
 #if !defined(Q_OS_MAC)

--- a/src/app/seamlyme/main.cpp
+++ b/src/app/seamlyme/main.cpp
@@ -51,7 +51,6 @@
 
 #include "tmainwindow.h"
 #include "mapplication.h"
-#include "../fervor/fvupdater.h"
 
 #include <QMessageBox> // For QT_REQUIRE_VERSION
 #include <QTimer>


### PR DESCRIPTION
It was already disabled in release mode anyway, and when debugging
the last thing we need is a popup on launch if there is a new
version available