### PR TITLE
mac: fix context menus

### DIFF
--- a/src/app/seamly2d/dialogs/pieces_widget.cpp
+++ b/src/app/seamly2d/dialogs/pieces_widget.cpp
@@ -350,7 +350,8 @@ void PiecesWidget::showContextMenu(const QPoint &pos)
     ui->tableWidget->setSortingEnabled(false);
     ui->tableWidget->blockSignals(true);
 
-    QScopedPointer<QMenu> menu(new QMenu());
+    // workaround for https://bugreports.qt.io/browse/QTBUG-97559: assign parent to QMenu
+    QScopedPointer<QMenu> menu(new QMenu(ui->tableWidget));
     QAction *selectAll = menu->addAction(tr("Include all pieces"));
     QAction *selectNone = menu->addAction(tr("Exclude all pieces"));
     QAction *invertSelection = menu->addAction(tr("Invert included pieces"));

--- a/src/app/seamly2d/dialogs/vwidgetgroups.cpp
+++ b/src/app/seamly2d/dialogs/vwidgetgroups.cpp
@@ -129,7 +129,8 @@ void VWidgetGroups::CtxMenu(const QPoint &pos)
     item = ui->tableWidget->item(row, 0);
     const quint32 id = item->data(Qt::UserRole).toUInt();
 
-    QScopedPointer<QMenu> menu(new QMenu());
+    // workaround for https://bugreports.qt.io/browse/QTBUG-97559: assign parent to QMenu
+    QScopedPointer<QMenu> menu(new QMenu(ui->tableWidget));
     QAction *actionRename = menu->addAction(tr("Rename"));
     QAction *actionDelete = menu->addAction(tr("Delete"));
     QAction *selectedAction = menu->exec(ui->tableWidget->viewport()->mapToGlobal(pos));

--- a/src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp
@@ -292,7 +292,8 @@ void InsertNodesDialog::showContextMenu(const QPoint &pos)
         return;
     }
 
-    QScopedPointer<QMenu> menu(new QMenu());
+    // workaround for https://bugreports.qt.io/browse/QTBUG-97559: assign parent to QMenu
+    QScopedPointer<QMenu> menu(new QMenu(ui->nodes_ListWidget));
     NodeInfo info;
     NotchType notchType = NotchType::Slit;
     bool isNotch = false;

--- a/src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp
@@ -251,7 +251,8 @@ void DialogInternalPath::ShowContextMenu(const QPoint &pos)
         return;
     }
 
-    QScopedPointer<QMenu> menu(new QMenu());
+    // workaround for https://bugreports.qt.io/browse/QTBUG-97559: assign parent to QMenu
+    QScopedPointer<QMenu> menu(new QMenu(ui->listWidget));
 
     NodeInfo info;
 

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -776,7 +776,8 @@ void PatternPieceDialog::showMainPathContextMenu(const QPoint &pos)
         return;
     }
 
-    QScopedPointer<QMenu> menu(new QMenu());
+    // workaround for https://bugreports.qt.io/browse/QTBUG-97559: assign parent to QMenu
+    QScopedPointer<QMenu> menu(new QMenu(ui->mainPath_ListWidget));
     NodeInfo info;
     NotchType notchType = NotchType::Slit;
     bool isNotch = false;
@@ -904,7 +905,8 @@ void PatternPieceDialog::showCustomSAContextMenu(const QPoint &pos)
         return;
     }
 
-    QScopedPointer<QMenu> menu(new QMenu());
+    // workaround for https://bugreports.qt.io/browse/QTBUG-97559: assign parent to QMenu
+    QScopedPointer<QMenu> menu(new QMenu(ui->customSeamAllowance_ListWidget));
     QAction *actionOption = menu->addAction(QIcon::fromTheme("preferences-other"), tr("Options"));
 
     QListWidgetItem *rowItem = ui->customSeamAllowance_ListWidget->item(row);
@@ -955,7 +957,8 @@ void PatternPieceDialog::showInternalPathsContextMenu(const QPoint &pos)
         return;
     }
 
-    QScopedPointer<QMenu> menu(new QMenu());
+    // workaround for https://bugreports.qt.io/browse/QTBUG-97559: assign parent to QMenu
+    QScopedPointer<QMenu> menu(new QMenu(ui->internalPaths_ListWidget));
     QAction *actionOption = menu->addAction(QIcon::fromTheme("preferences-other"), tr("Options"));
     QAction *actionDelete = menu->addAction(QIcon::fromTheme("edit-delete"), tr("Delete"));
 

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -993,7 +993,8 @@ void PatternPieceDialog::showAnchorsContextMenu(const QPoint &pos)
         return;
     }
 
-    QScopedPointer<QMenu> menu(new QMenu());
+    // workaround for https://bugreports.qt.io/browse/QTBUG-97559: assign parent to QMenu
+    QScopedPointer<QMenu> menu(new QMenu(ui->anchorPoints_ListWidget));
     QAction *actionDelete = menu->addAction(QIcon::fromTheme("edit-delete"), tr("Delete"));
 
     QAction *selectedAction = menu->exec(ui->anchorPoints_ListWidget->viewport()->mapToGlobal(pos));


### PR DESCRIPTION
A mac specific issue in Qt 5.15.0 - at least 5.15.2, see
https://bugreports.qt.io/browse/QTBUG-97559

Closes: #822
