### PR TITLE
Refactor: Seam allowance to cut line

### DIFF
--- a/share/translations/seamly2d.ts
+++ b/share/translations/seamly2d.ts
@@ -10869,18 +10869,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11047,6 +11035,22 @@ Do you want to save your changes?</translation>
     <message>
         <source>Just rear</source>
         <translation type="unfinished">Just rear</translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12167,10 +12171,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12208,14 +12208,6 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12260,6 +12252,18 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -8793,18 +8793,6 @@ Chcete uložit své změny?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8970,6 +8958,22 @@ Chcete uložit své změny?</translation>
     </message>
     <message>
         <source>Just rear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10043,10 +10047,6 @@ Chcete uložit své změny?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10084,14 +10084,6 @@ Chcete uložit své změny?</translation>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10136,6 +10128,18 @@ Chcete uložit své změny?</translation>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -10428,18 +10428,6 @@ Sollen die Änderungen gespeichert werden?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10606,6 +10594,22 @@ Sollen die Änderungen gespeichert werden?</translation>
     <message>
         <source>Just rear</source>
         <translation type="unfinished">Nur hinten</translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11702,10 +11706,6 @@ Sollen die Änderungen gespeichert werden?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11743,14 +11743,6 @@ Sollen die Änderungen gespeichert werden?</translation>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11795,6 +11787,18 @@ Sollen die Änderungen gespeichert werden?</translation>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -10731,18 +10731,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10909,6 +10897,22 @@ Do you want to save your changes?</source>
     <message>
         <source>Just rear</source>
         <translation type="unfinished">Μόνο πίσω</translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12005,10 +12009,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12046,14 +12046,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12098,6 +12090,18 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -11152,18 +11152,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11330,6 +11318,22 @@ Do you want to save your changes?</translation>
     <message>
         <source>Just rear</source>
         <translation type="unfinished">Just rear</translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12450,10 +12454,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12491,14 +12491,6 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12543,6 +12535,18 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -11152,18 +11152,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11330,6 +11318,22 @@ Do you want to save your changes?</translation>
     <message>
         <source>Just rear</source>
         <translation type="unfinished">Just rear</translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12450,10 +12454,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12491,14 +12491,6 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12543,6 +12535,18 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -11152,18 +11152,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11330,6 +11318,22 @@ Do you want to save your changes?</translation>
     <message>
         <source>Just rear</source>
         <translation type="unfinished">Just rear</translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12450,10 +12454,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12491,14 +12491,6 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12543,6 +12535,18 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -10860,18 +10860,6 @@ Quiere guardar los cambios?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11038,6 +11026,22 @@ Quiere guardar los cambios?</translation>
     <message>
         <source>Just rear</source>
         <translation type="unfinished">Justo detrás</translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12138,10 +12142,6 @@ Quiere guardar los cambios?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12179,14 +12179,6 @@ Quiere guardar los cambios?</translation>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12231,6 +12223,18 @@ Quiere guardar los cambios?</translation>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -8811,18 +8811,6 @@ Haluatko tallentaa muutokset?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8988,6 +8976,22 @@ Haluatko tallentaa muutokset?</translation>
     </message>
     <message>
         <source>Just rear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10053,10 +10057,6 @@ Haluatko tallentaa muutokset?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10094,14 +10094,6 @@ Haluatko tallentaa muutokset?</translation>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10146,6 +10138,18 @@ Haluatko tallentaa muutokset?</translation>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -10763,18 +10763,6 @@ Voulez-vous sauvegarder les changements?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10941,6 +10929,22 @@ Voulez-vous sauvegarder les changements?</translation>
     <message>
         <source>Just rear</source>
         <translation type="unfinished">Juste l&apos;arrière</translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12033,10 +12037,6 @@ Voulez-vous sauvegarder les changements?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12074,14 +12074,6 @@ Voulez-vous sauvegarder les changements?</translation>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12126,6 +12118,18 @@ Voulez-vous sauvegarder les changements?</translation>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -7268,18 +7268,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7445,6 +7433,22 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Just rear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8490,10 +8494,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8531,14 +8531,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8583,6 +8575,18 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -7681,18 +7681,6 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7858,6 +7846,22 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
     </message>
     <message>
         <source>Just rear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8919,10 +8923,6 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8963,14 +8963,6 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9008,6 +9000,18 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -10357,18 +10357,6 @@ Vuoi salvare i cambiamenti?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10534,6 +10522,22 @@ Vuoi salvare i cambiamenti?</translation>
     </message>
     <message>
         <source>Just rear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11631,10 +11635,6 @@ Vuoi salvare i cambiamenti?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11672,14 +11672,6 @@ Vuoi salvare i cambiamenti?</translation>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11724,6 +11716,18 @@ Vuoi salvare i cambiamenti?</translation>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -11179,18 +11179,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11357,6 +11345,22 @@ Do you want to save your changes?</source>
     <message>
         <source>Just rear</source>
         <translation type="unfinished">Alleen achterkant</translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12481,10 +12485,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12522,14 +12522,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12574,6 +12566,18 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -9588,18 +9588,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9766,6 +9754,22 @@ Do you want to save your changes?</source>
     <message>
         <source>Just rear</source>
         <translation type="unfinished">Apenas costas</translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10846,10 +10850,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10887,14 +10887,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10939,6 +10931,18 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -8991,18 +8991,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9168,6 +9156,22 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Just rear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10241,10 +10245,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10282,14 +10282,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10334,6 +10326,18 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -11108,18 +11108,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11286,6 +11274,22 @@ Do you want to save your changes?</source>
     <message>
         <source>Just rear</source>
         <translation type="unfinished">Только вниз</translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12406,10 +12410,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12447,14 +12447,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12499,6 +12491,18 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -11107,18 +11107,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11285,6 +11273,22 @@ Do you want to save your changes?</source>
     <message>
         <source>Just rear</source>
         <translation type="unfinished">Тільки нижня</translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12405,10 +12409,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12446,14 +12446,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12498,6 +12490,18 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -7522,18 +7522,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source> Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7699,6 +7687,22 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Just rear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the cut line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on the seam line.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8760,10 +8764,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Internal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Cutouts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8804,14 +8804,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show notch on seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show  notch on seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Attributes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8849,6 +8841,18 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Import template</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show notch on Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Internals</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
@@ -70,7 +70,7 @@
     <enum>QTabWidget::West</enum>
    </property>
    <property name="currentIndex">
-    <number>4</number>
+    <number>0</number>
    </property>
    <widget class="QWidget" name="tab_4">
     <attribute name="title">
@@ -221,8 +221,13 @@
        <layout class="QVBoxLayout" name="verticalLayout_6">
         <item>
          <widget class="QCheckBox" name="showSeamAllowanceNotch_CheckBox">
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+           </font>
+          </property>
           <property name="text">
-           <string>Show notch on seam allowance</string>
+           <string>Show notch on cut line</string>
           </property>
          </widget>
         </item>
@@ -261,7 +266,7 @@
        <property name="minimumSize">
         <size>
          <width>0</width>
-         <height>100</height>
+         <height>150</height>
         </size>
        </property>
        <property name="title">
@@ -370,8 +375,7 @@
                </size>
               </property>
               <property name="font">
-               <font>
-               </font>
+               <font/>
               </property>
              </widget>
             </item>
@@ -1085,7 +1089,7 @@
        </font>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>2</number>
       </property>
       <widget class="QWidget" name="tab">
        <attribute name="title">
@@ -1513,7 +1517,7 @@
       </widget>
       <widget class="QWidget" name="tab_8">
        <attribute name="title">
-        <string>Internal</string>
+        <string>Internals</string>
        </attribute>
        <layout class="QVBoxLayout" name="verticalLayout_18">
         <item>

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
@@ -70,7 +70,7 @@
     <enum>QTabWidget::West</enum>
    </property>
    <property name="currentIndex">
-    <number>0</number>
+    <number>1</number>
    </property>
    <widget class="QWidget" name="tab_4">
     <attribute name="title">
@@ -227,7 +227,7 @@
            </font>
           </property>
           <property name="text">
-           <string>Show notch on cut line</string>
+           <string>Show notch on Cut Line</string>
           </property>
          </widget>
         </item>
@@ -248,7 +248,7 @@
            <string>Show notch on both the seam allowance and seam line.</string>
           </property>
           <property name="text">
-           <string>Show  notch on seam line</string>
+           <string>Show  notch on Seam Line</string>
           </property>
          </widget>
         </item>

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
@@ -248,7 +248,7 @@
            <string>Show notch on both the seam allowance and seam line.</string>
           </property>
           <property name="text">
-           <string>Show  notch on Seam Line</string>
+           <string>Show notch on Seam Line</string>
           </property>
          </widget>
         </item>

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
@@ -5050,7 +5050,7 @@ QListWidget::item:selected {
                    <string>Show notch on the cut line.</string>
                   </property>
                   <property name="text">
-                   <string>Show notch on cut line</string>
+                   <string>Show notch on Cut Line</string>
                   </property>
                  </widget>
                 </item>
@@ -5063,7 +5063,7 @@ QListWidget::item:selected {
                    <string>Show notch on the seam line.</string>
                   </property>
                   <property name="text">
-                   <string>Show notch on seam line</string>
+                   <string>Show notch on Seam Line</string>
                   </property>
                  </widget>
                 </item>

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
@@ -305,12 +305,18 @@ QListWidget::item:selected {
         <enum>QFrame::Sunken</enum>
        </property>
        <property name="currentIndex">
-        <number>0</number>
+        <number>6</number>
        </property>
        <widget class="QWidget" name="properties_Page">
         <layout class="QVBoxLayout" name="verticalLayout_19">
          <item>
           <widget class="QGroupBox" name="labelData_GroupBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="minimumSize">
             <size>
              <width>0</width>
@@ -2315,8 +2321,7 @@ QListWidget::item:selected {
                 </size>
                </property>
                <property name="font">
-                <font>
-                </font>
+                <font/>
                </property>
               </widget>
              </widget>
@@ -4760,8 +4765,8 @@ QListWidget::item:selected {
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>235</width>
-              <height>542</height>
+              <width>292</width>
+              <height>559</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -5045,7 +5050,7 @@ QListWidget::item:selected {
                    <string>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</string>
                   </property>
                   <property name="text">
-                   <string>Show notch on seam allowance</string>
+                   <string>Show notch on cut line</string>
                   </property>
                  </widget>
                 </item>

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
@@ -5047,7 +5047,7 @@ QListWidget::item:selected {
                    </sizepolicy>
                   </property>
                   <property name="toolTip">
-                   <string>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</string>
+                   <string>Show notche on the cut line.</string>
                   </property>
                   <property name="text">
                    <string>Show notch on cut line</string>
@@ -5060,7 +5060,7 @@ QListWidget::item:selected {
                    <bool>false</bool>
                   </property>
                   <property name="toolTip">
-                   <string>This option has effect only if the second notch on seam line is enabled in global preferences. The option helps disable the second notch for this notch only.</string>
+                   <string>Show notch on the seam line.</string>
                   </property>
                   <property name="text">
                    <string>Show notch on seam line</string>

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
@@ -5047,7 +5047,7 @@ QListWidget::item:selected {
                    </sizepolicy>
                   </property>
                   <property name="toolTip">
-                   <string>Show notche on the cut line.</string>
+                   <string>Show notch on the cut line.</string>
                   </property>
                   <property name="text">
                    <string>Show notch on cut line</string>


### PR DESCRIPTION
Refactors text "Show notch on seam allowance" to "Show notch on cut line" in the Prefs and Pattern Piece dialogs. Also updates the tooltips. 

![notch_prefs](https://user-images.githubusercontent.com/31944718/212754145-3cc691dc-5986-4e9d-af34-fae442216a34.png)


![notch_piece](https://user-images.githubusercontent.com/31944718/212754704-9e30f410-1a1a-47b1-b92b-bd6537b89168.png)
