### PR TITLE
Fixed pattern piece label resize issue when label is rotated (issue #829)

### DIFF
--- a/src/libs/vwidgets/vtextgraphicsitem.cpp
+++ b/src/libs/vwidgets/vtextgraphicsitem.cpp
@@ -249,10 +249,14 @@ void VTextGraphicsItem::paint(QPainter *painter, const QStyleOptionGraphicsItem 
  */
 void VTextGraphicsItem::setSize(qreal width, qreal height)
 {
+    // Take into account the rotation of the bounding rectangle
+    QTransform transform = QTransform().rotate(-rotation());
+    QRectF bbRect = transform.map(parentItem()->boundingRect()).boundingRect();
+
     // don't allow resize under specific size
-    if (width > parentItem()->boundingRect().width())
+    if (width > bbRect.width())
     {
-        width = parentItem()->boundingRect().width();
+        width = bbRect.width();
         qDebug() << "Setting label width to parent item width" << width;
     }
     if (width < minW)
@@ -260,9 +264,9 @@ void VTextGraphicsItem::setSize(qreal width, qreal height)
         width = minW;
         qDebug() << "Setting label width to min width" << width;
     }
-    if (height > parentItem()->boundingRect().height())
+    if (height > bbRect.height())
     {
-        height = parentItem()->boundingRect().height();
+        height = bbRect.height();
         qDebug() << "Setting label height to parent item height" << width;
     }
     if (height < minH)
@@ -518,7 +522,12 @@ void VTextGraphicsItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event )
         }
 
         rectBB.setTopLeft(pt);
-        QSizeF size(m_startSize.width() + ptDiff.x(), m_startSize.height() + ptDiff.y());
+
+        // Apply rotation to ptDiff in order to resize based on current rotation
+        QTransform transform = QTransform().rotate(-rotation());
+        QPointF ptDiff2 = transform.map(ptDiff);
+
+        QSizeF size(m_startSize.width() + ptDiff2.x(), m_startSize.height() + ptDiff2.y());
         rectBB.setSize(size);
         // before resizing the label to a new size, check if it will still be inside the parent item
         if (isContained(rectBB, rotation(), xPos, yPos) == false)


### PR DESCRIPTION
Applying rotation before resizing the pattern piece label