### PR TITLE
BUG: fix zero width seam allowance in pattern piece tool

### DIFF
--- a/share/translations/seamly2d.ts
+++ b/share/translations/seamly2d.ts
@@ -9875,10 +9875,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9888,10 +9884,6 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10637,10 +10629,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10650,10 +10638,6 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11052,6 +11036,14 @@ Do you want to save your changes?</translation>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -11256,6 +11248,10 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12103,14 +12099,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12264,6 +12252,14 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -18032,6 +18028,10 @@ Do you want to save your changes?</translation>
     <message>
         <source>Delete</source>
         <translation>Delete</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -7922,10 +7922,6 @@ Chcete uložit své změny?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7935,10 +7931,6 @@ Chcete uložit své změny?</translation>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8561,10 +8553,6 @@ Chcete uložit své změny?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8574,10 +8562,6 @@ Chcete uložit své změny?</translation>
     </message>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8976,6 +8960,14 @@ Chcete uložit své změny?</translation>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -9180,6 +9172,10 @@ Chcete uložit své změny?</translation>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9979,14 +9975,6 @@ Chcete uložit své změny?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10140,6 +10128,14 @@ Chcete uložit své změny?</translation>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15038,6 +15034,10 @@ Do you want to save your changes?</source>
     <message>
         <source>Delete</source>
         <translation type="unfinished">Smazat</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -9478,10 +9478,6 @@ Sollen die Änderungen gespeichert werden?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9491,10 +9487,6 @@ Sollen die Änderungen gespeichert werden?</translation>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10196,10 +10188,6 @@ Sollen die Änderungen gespeichert werden?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10209,10 +10197,6 @@ Sollen die Änderungen gespeichert werden?</translation>
     </message>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10611,6 +10595,14 @@ Sollen die Änderungen gespeichert werden?</translation>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -10815,6 +10807,10 @@ Sollen die Änderungen gespeichert werden?</translation>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11638,14 +11634,6 @@ Sollen die Änderungen gespeichert werden?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11799,6 +11787,14 @@ Sollen die Änderungen gespeichert werden?</translation>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -17184,6 +17180,10 @@ Do you want to save your changes?</source>
     <message>
         <source>Delete</source>
         <translation>Löschen</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -9741,10 +9741,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9754,10 +9750,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10499,10 +10491,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10513,10 +10501,6 @@ Do you want to save your changes?</source>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished">Απόκρυψη του κύριου μονοπατιού αν το περιθώριο ραφής είναι ενεργοποιημένο</translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Automatic</source>
@@ -10914,6 +10898,14 @@ Do you want to save your changes?</source>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -11118,6 +11110,10 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11941,14 +11937,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12102,6 +12090,14 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -17514,6 +17510,10 @@ Do you want to save your changes?</source>
     <message>
         <source>Delete</source>
         <translation>Διαγραφή</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -10086,10 +10086,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10099,10 +10095,6 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10920,10 +10912,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished">Internal paths</translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished">The seam allowance is part of main path</translation>
     </message>
@@ -10934,10 +10922,6 @@ Do you want to save your changes?</translation>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished">Hide the main path if the seam allowance is enabled</translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Automatic</source>
@@ -11335,6 +11319,14 @@ Do you want to save your changes?</translation>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -11539,6 +11531,10 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12386,14 +12382,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished">Notches</translation>
     </message>
@@ -12547,6 +12535,14 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -18447,6 +18443,10 @@ Do you want to save your changes?</translation>
     <message>
         <source>Delete</source>
         <translation>Delete</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -10086,10 +10086,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10099,10 +10095,6 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10920,10 +10912,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished">Internal paths</translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished">The seam allowance is part of main path</translation>
     </message>
@@ -10934,10 +10922,6 @@ Do you want to save your changes?</translation>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished">Hide the main path if the seam allowance is enabled</translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Automatic</source>
@@ -11335,6 +11319,14 @@ Do you want to save your changes?</translation>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -11539,6 +11531,10 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12386,14 +12382,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished">Notches</translation>
     </message>
@@ -12547,6 +12535,14 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -18447,6 +18443,10 @@ Do you want to save your changes?</translation>
     <message>
         <source>Delete</source>
         <translation>Delete</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -10086,10 +10086,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10099,10 +10095,6 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10920,10 +10912,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished">Internal paths</translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished">The seam allowance is part of main path</translation>
     </message>
@@ -10934,10 +10922,6 @@ Do you want to save your changes?</translation>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished">Hide the main path if the seam allowance is enabled</translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Automatic</source>
@@ -11335,6 +11319,14 @@ Do you want to save your changes?</translation>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -11539,6 +11531,10 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12386,14 +12382,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished">Notches</translation>
     </message>
@@ -12547,6 +12535,14 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -18447,6 +18443,10 @@ Do you want to save your changes?</translation>
     <message>
         <source>Delete</source>
         <translation>Delete</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -9862,10 +9862,6 @@ Quiere guardar los cambios?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9875,10 +9871,6 @@ Quiere guardar los cambios?</translation>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10628,10 +10620,6 @@ Quiere guardar los cambios?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10641,10 +10629,6 @@ Quiere guardar los cambios?</translation>
     </message>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11043,6 +11027,14 @@ Quiere guardar los cambios?</translation>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -11247,6 +11239,10 @@ Quiere guardar los cambios?</translation>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12074,14 +12070,6 @@ Quiere guardar los cambios?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12235,6 +12223,14 @@ Quiere guardar los cambios?</translation>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -17901,6 +17897,10 @@ Do you want to save your changes?</source>
     <message>
         <source>Delete</source>
         <translation>Eliminar</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -7936,10 +7936,6 @@ Haluatko tallentaa muutokset?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7949,10 +7945,6 @@ Haluatko tallentaa muutokset?</translation>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8579,10 +8571,6 @@ Haluatko tallentaa muutokset?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8592,10 +8580,6 @@ Haluatko tallentaa muutokset?</translation>
     </message>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8994,6 +8978,14 @@ Haluatko tallentaa muutokset?</translation>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -9198,6 +9190,10 @@ Haluatko tallentaa muutokset?</translation>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -9989,14 +9985,6 @@ Haluatko tallentaa muutokset?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10150,6 +10138,14 @@ Haluatko tallentaa muutokset?</translation>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15003,6 +14999,10 @@ Do you want to save your changes?</source>
     <message>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -9780,10 +9780,6 @@ Voulez-vous sauvegarder les changements?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9793,10 +9789,6 @@ Voulez-vous sauvegarder les changements?</translation>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10531,10 +10523,6 @@ Voulez-vous sauvegarder les changements?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10544,10 +10532,6 @@ Voulez-vous sauvegarder les changements?</translation>
     </message>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10946,6 +10930,14 @@ Voulez-vous sauvegarder les changements?</translation>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -11150,6 +11142,10 @@ Voulez-vous sauvegarder les changements?</translation>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11969,14 +11965,6 @@ Voulez-vous sauvegarder les changements?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished">Repères de montage</translation>
     </message>
@@ -12130,6 +12118,14 @@ Voulez-vous sauvegarder les changements?</translation>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -17740,6 +17736,10 @@ Voulez-vous enregistrer les changements?</translation>
     <message>
         <source>Delete</source>
         <translation>Effacer</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -6493,10 +6493,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6506,10 +6502,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7036,10 +7028,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7049,10 +7037,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7451,6 +7435,14 @@ Do you want to save your changes?</source>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -7655,6 +7647,10 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8426,14 +8422,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8587,6 +8575,14 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12962,6 +12958,10 @@ Do you want to save your changes?</source>
     <message>
         <source>Delete</source>
         <translation type="unfinished">למחוק</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -6903,10 +6903,6 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6916,10 +6912,6 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7449,10 +7441,6 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7462,10 +7450,6 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
     </message>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7864,6 +7848,14 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8068,6 +8060,10 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8855,14 +8851,6 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9012,6 +9000,14 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -13481,6 +13477,10 @@ Do you want to save your changes?</source>
     <message>
         <source>Delete</source>
         <translation type="unfinished">hapus</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -9403,10 +9403,6 @@ Vuoi salvare i cambiamenti?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9416,10 +9412,6 @@ Vuoi salvare i cambiamenti?</translation>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10125,10 +10117,6 @@ Vuoi salvare i cambiamenti?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10138,10 +10126,6 @@ Vuoi salvare i cambiamenti?</translation>
     </message>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10540,6 +10524,14 @@ Vuoi salvare i cambiamenti?</translation>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -10744,6 +10736,10 @@ Vuoi salvare i cambiamenti?</translation>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11567,14 +11563,6 @@ Vuoi salvare i cambiamenti?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11728,6 +11716,14 @@ Vuoi salvare i cambiamenti?</translation>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16958,6 +16954,10 @@ Vuoi salvare le tue modifiche?</translation>
     <message>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -10129,10 +10129,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10142,10 +10138,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10947,10 +10939,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished">Binnenste pad</translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished">De naadtoeslag is deel van het hoofdpad</translation>
     </message>
@@ -10961,10 +10949,6 @@ Do you want to save your changes?</source>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished">Verberg de hoofdpad wanneer naadtoeslag is ingeschakeld</translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Automatic</source>
@@ -11362,6 +11346,14 @@ Do you want to save your changes?</source>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -11566,6 +11558,10 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12417,14 +12413,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished">Pasmarkeringen</translation>
     </message>
@@ -12578,6 +12566,14 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -18478,6 +18474,10 @@ Wil je deze veranderingen opslaan?</translation>
     <message>
         <source>Delete</source>
         <translation>Verwijder</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -8709,10 +8709,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8722,10 +8718,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9356,10 +9348,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9369,10 +9357,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9771,6 +9755,14 @@ Do you want to save your changes?</source>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -9975,6 +9967,10 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10782,14 +10778,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10943,6 +10931,14 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15886,6 +15882,10 @@ Do you want to save your changes?</source>
     <message>
         <source>Delete</source>
         <translation>Excluir</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -8159,10 +8159,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8172,10 +8168,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -8759,10 +8751,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8772,10 +8760,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9174,6 +9158,14 @@ Do you want to save your changes?</source>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -9378,6 +9370,10 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -10177,14 +10173,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10338,6 +10326,14 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -15068,6 +15064,10 @@ Do you want to save your changes?</source>
     <message>
         <source>Delete</source>
         <translation type="unfinished">Șterge</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -10058,10 +10058,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10071,10 +10067,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10876,10 +10868,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished">Внутренние контуры</translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished">Прибавка на швы часть основного контура</translation>
     </message>
@@ -10890,10 +10878,6 @@ Do you want to save your changes?</source>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished">Прятать главный контур если прибавка на швы включена</translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Automatic</source>
@@ -11291,6 +11275,14 @@ Do you want to save your changes?</source>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -11495,6 +11487,10 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12342,14 +12338,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished">Надсечки</translation>
     </message>
@@ -12503,6 +12491,14 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -18408,6 +18404,10 @@ Do you want to save your changes?</source>
     <message>
         <source>Delete</source>
         <translation>Удалить</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -10053,10 +10053,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10066,10 +10062,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10875,10 +10867,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished">Внутрішні шляхи</translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished">Прибавка на шви є частиною основного контуру</translation>
     </message>
@@ -10889,10 +10877,6 @@ Do you want to save your changes?</source>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
         <translation type="unfinished">Ховати головний контур якщо прибавка на шви була увімкнута</translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Automatic</source>
@@ -11290,6 +11274,14 @@ Do you want to save your changes?</source>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -11494,6 +11486,10 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12341,14 +12337,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished">Надсічки</translation>
     </message>
@@ -12502,6 +12490,14 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -18401,6 +18397,10 @@ Do you want to save your changes?</source>
     <message>
         <source>Delete</source>
         <translation>Видалити</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -6719,10 +6719,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show which groups in the list are visible</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Piece mode</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6732,10 +6728,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Pattern Pieces</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show which pattern pieces will included in layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7290,10 +7282,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>The seam allowance is part of main path</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7303,10 +7291,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Hide the main path if the seam allowance is enabled</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -7705,6 +7689,14 @@ Do you want to save your changes?</source>
         <source>Show notch on Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -7909,6 +7901,10 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Invert locked pieces</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle inclusion of pattern piece in layout</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -8696,14 +8692,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show seam allowances</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide seam line</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Notches</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8853,6 +8841,14 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Internals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show Cut Line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -13353,6 +13349,10 @@ Do you want to save your changes?</source>
     <message>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
+    </message>
+    <message>
+        <source>Toggle visibility of group</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
@@ -70,7 +70,7 @@
     <enum>QTabWidget::West</enum>
    </property>
    <property name="currentIndex">
-    <number>1</number>
+    <number>0</number>
    </property>
    <widget class="QWidget" name="tab_4">
     <attribute name="title">
@@ -116,7 +116,7 @@
              </font>
             </property>
             <property name="text">
-             <string>Show seam allowances</string>
+             <string>Show Cut Line</string>
             </property>
             <property name="checked">
              <bool>true</bool>
@@ -140,7 +140,13 @@
              <string>By default hide the main path if the seam allowance was enabled</string>
             </property>
             <property name="text">
-             <string>Hide seam line</string>
+             <string>Hide Seam Line</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
             </property>
            </widget>
           </item>

--- a/src/app/seamly2d/dialogs/vwidgetgroups.cpp
+++ b/src/app/seamly2d/dialogs/vwidgetgroups.cpp
@@ -192,6 +192,7 @@ void VWidgetGroups::FillTable(const QMap<quint32, QPair<QString, bool> > &groups
         // set the item non-editable (view only), and non-selectable
         Qt::ItemFlags flags = item->flags();
         flags &= ~(Qt::ItemIsEditable); // reset/clear the flag
+        item->setToolTip(tr("Toggle visibility of group"));
         item->setFlags(flags);
 
         ui->tableWidget->setItem(currentRow, 0, item);

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -3331,7 +3331,6 @@ void MainWindow::showDraftMode(bool checked)
 
         ui->groups_DockWidget->setWidget(groupsWidget);
         ui->groups_DockWidget->setWindowTitle(tr("Group Manager"));
-        ui->groups_DockWidget->setToolTip(tr("Show which groups in the list are visible"));
         ui->groups_DockWidget->setVisible(isGroupsDockVisible);
     }
     else
@@ -3418,7 +3417,6 @@ void MainWindow::showPieceMode(bool checked)
 
         ui->groups_DockWidget->setWidget(patternPiecesWidget);
         ui->groups_DockWidget->setWindowTitle(tr("Pattern Pieces"));
-        ui->groups_DockWidget->setToolTip(tr("Show which pattern pieces will included in layout"));
         ui->groups_DockWidget->setVisible(isGroupsDockVisible);
 
         helpLabel->setText("");

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
@@ -305,7 +305,7 @@ QListWidget::item:selected {
         <enum>QFrame::Sunken</enum>
        </property>
        <property name="currentIndex">
-        <number>6</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="properties_Page">
         <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -1259,24 +1259,9 @@ QListWidget::item:selected {
        <widget class="QWidget" name="seamAllowance_Page">
         <layout class="QVBoxLayout" name="verticalLayout_6">
          <item>
-          <widget class="QCheckBox" name="seams_CheckBox">
-           <property name="font">
-            <font>
-             <pointsize>9</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>Show seam allowance</string>
-           </property>
-           <property name="checked">
-            <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
           <widget class="QCheckBox" name="builtIn_CheckBox">
            <property name="enabled">
-            <bool>false</bool>
+            <bool>true</bool>
            </property>
            <property name="font">
             <font>
@@ -1292,6 +1277,21 @@ QListWidget::item:selected {
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="seams_CheckBox">
+           <property name="font">
+            <font>
+             <pointsize>9</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>Show Cut Line</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QCheckBox" name="hideSeamLine_CheckBox">
            <property name="font">
             <font>
@@ -1302,7 +1302,7 @@ QListWidget::item:selected {
             <string>Hide the main path if the seam allowance is enabled</string>
            </property>
            <property name="text">
-            <string>Hide seam line</string>
+            <string>Hide Seam Line</string>
            </property>
           </widget>
          </item>
@@ -5502,8 +5502,8 @@ QListWidget::item:selected {
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../../../vmisc/share/resources/theme.qrc"/>
   <include location="../../../../vmisc/share/resources/icon.qrc"/>
+  <include location="../../../../vmisc/share/resources/theme.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -82,7 +82,7 @@
 #include "../undocommands/toggle_piecelock.h"
 #include "../vwidgets/vabstractmainwindow.h"
 #include "../vwidgets/vmaingraphicsview.h"
-#include "../vwidgets/vnobrushscalepathitem.h"
+#include "../vwidgets/nonscalingfill_pathitem.h"
 
 #include <QGraphicsScene>
 #include <QGraphicsSceneMouseEvent>
@@ -1440,8 +1440,8 @@ PatternPieceTool::PatternPieceTool(VAbstractPattern *doc, VContainer *data, cons
     , m_cutPath()
     , m_pieceScene(scene)
     , m_blockName(blockName)
-    , m_cutLine(new VNoBrushScalePathItem(this))
-    , m_seamLine(new VNoBrushScalePathItem(this))
+    , m_cutLine(new NonScalingFillPathItem(this))
+    , m_seamLine(new NonScalingFillPathItem(this))
     , m_dataLabel(new VTextGraphicsItem(this))
     , m_patternInfo(new VTextGraphicsItem(this))
     , m_grainLine(new VGrainlineItem(this))

--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -87,10 +87,11 @@
 #include <QGraphicsScene>
 #include <QGraphicsSceneMouseEvent>
 #include <QGraphicsView>
+#include <QInputDialog>
 #include <QKeyEvent>
 #include <QMenu>
 #include <QMessageBox>
-#include <QInputDialog>
+#include <QPainterPathStroker>
 
 
 // Current version of seam allowance tag need for backward compatibility
@@ -613,7 +614,7 @@ void PatternPieceTool::retranslateUi()
 void PatternPieceTool::Highlight(quint32 id)
 {
     setSelected(m_id == id);
-    VPiece piece = VAbstractTool::data.GetPiece(m_id);
+    RefreshGeometry();
 }
 
 void PatternPieceTool::updatePieceDetails()
@@ -889,10 +890,10 @@ void PatternPieceTool::paint(QPainter *painter, const QStyleOptionGraphicsItem *
     lineWeight = ToPixel(qApp->Settings()->getDefaultCutLineweight(), Unit::Mm);
 
     m_cutLine->setPen(QPen(color, scaleWidth(lineWeight, sceneScale(scene())),
-                            lineTypeToPenStyle(lineType), Qt::RoundCap, Qt::RoundJoin));
+                           lineTypeToPenStyle(lineType), Qt::RoundCap, Qt::RoundJoin));
     m_cutLine->setZValue(-10);
 
-    //set seamline, grainline, & labels pen
+    //set seamline pen
     const VPiece piece = VAbstractTool::data.GetPiece(m_id);
 
     if (qApp->Settings()->showSeamAllowances())
@@ -910,21 +911,22 @@ void PatternPieceTool::paint(QPainter *painter, const QStyleOptionGraphicsItem *
             lineWeight = ToPixel(qApp->Settings()->getDefaultCutLineweight(), Unit::Mm);
         }
 
-
-        this->setPen(QPen(color, scaleWidth(lineWeight, sceneScale(scene())),
-                       lineTypeToPenStyle(lineType), Qt::RoundCap, Qt::RoundJoin));
+        m_seamLine->setPen(QPen(color, scaleWidth(lineWeight, sceneScale(scene())),
+                                lineTypeToPenStyle(lineType), Qt::RoundCap, Qt::RoundJoin));
 
         QBrush brush = QBrush(QColor(piece.getColor()));
         brush.setStyle(static_cast<Qt::BrushStyle>(fills().indexOf(QRegExp(piece.getFill()))));
         brush.setTransform(brush.transform().scale(150.0, 150.0));
         brush.setTransform(painter->combinedTransform().inverted());
+        m_seamLine->setBrush(brush);
         this->setBrush(brush);
-
-        //set notches pen
-        color = QColor(qApp->Settings()->getDefaultNotchColor());
-        m_notches->setPen(QPen(color, scaleWidth(lineWeight,
-        sceneScale(scene())), Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
     }
+
+    //set notches pen
+    color = QColor(qApp->Settings()->getDefaultNotchColor());
+    m_notches->setPen(QPen(color, scaleWidth(lineWeight, sceneScale(scene())),
+                           Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+
 
     if ((m_dataLabel->IsIdle() == false
             || m_patternInfo->IsIdle() == false
@@ -951,13 +953,13 @@ QRectF PatternPieceTool::boundingRect() const
 //---------------------------------------------------------------------------------------------------------------------
 QPainterPath PatternPieceTool::shape() const
 {
-    if (m_mainPath == QPainterPath())
+    if (m_mainPath == QPainterPath() && m_cutPath == QPainterPath())
     {
         return QGraphicsPathItem::shape();
     }
     else
     {
-        return ItemShapeFromPath(m_mainPath, pen());
+        return ItemShapeFromPath(m_mainPath + m_cutPath, pen());
     }
 }
 
@@ -1439,6 +1441,7 @@ PatternPieceTool::PatternPieceTool(VAbstractPattern *doc, VContainer *data, cons
     , m_pieceScene(scene)
     , m_blockName(blockName)
     , m_cutLine(new VNoBrushScalePathItem(this))
+    , m_seamLine(new VNoBrushScalePathItem(this))
     , m_dataLabel(new VTextGraphicsItem(this))
     , m_patternInfo(new VTextGraphicsItem(this))
     , m_grainLine(new VGrainlineItem(this))
@@ -1508,32 +1511,23 @@ void PatternPieceTool::RefreshGeometry()
 
     const VPiece piece = VAbstractTool::data.GetPiece(m_id);
 
-    QString pieceColor = piece.getColor();
-
-    QString pieceFill = piece.getFill();
-    const QStringList fillNames = fills();
-    int index = fillNames.indexOf(QRegExp(pieceFill));
-
-    QBrush newBrush = QBrush(QColor(pieceColor), static_cast<Qt::BrushStyle>(index));
-    this->setBrush(newBrush);   //set pattern piece color & brush style
-
     QPainterPath path = piece.MainPathPath(this->getData());
-    path.setFillRule(Qt::OddEvenFill);
 
     if (!piece.isHideSeamLine() || !piece.IsSeamAllowance() || piece.IsSeamAllowanceBuiltIn())
     {
         m_mainPath = QPainterPath();
-        m_pieceRect = QRectF();
+        m_seamLine->setPath(m_mainPath);
         m_cutLine->setBrush(QBrush(QColor(qApp->Settings()->getDefaultCutColor()), Qt::Dense7Pattern));
     }
     else
     {
-        m_cutLine->setBrush(QBrush(Qt::NoBrush)); // Disable if the main path was hidden
-        // need for returning a bounding rect when main path is not visible
-        m_mainPath = path;
-        m_pieceRect = m_mainPath.controlPointRect();
+        m_mainPath = path; // need for returning a bounding rect when main path is not visible
         path = QPainterPath();
+        m_seamLine->setPath(QPainterPath());
+        m_cutLine->setBrush(QBrush(Qt::NoBrush)); // Disable if the main path was hidden
     }
+
+    this->setPath(path);
 
     QVector<QPointF> seamAllowancePoints;
 
@@ -1546,18 +1540,25 @@ void PatternPieceTool::RefreshGeometry()
 
     if (piece.IsSeamAllowance() && !piece.IsSeamAllowanceBuiltIn() && qApp->Settings()->showSeamAllowances())
     {
-        //m_cutPath = piece.SeamAllowancePath(seamAllowancePoints);
-        m_cutPath = piece.SeamAllowancePath(seamAllowancePoints).subtracted(path);
-        m_cutPath.setFillRule(Qt::OddEvenFill);
+        path.addPath(piece.SeamAllowancePath(seamAllowancePoints));
+        path.setFillRule(Qt::OddEvenFill);
+        m_cutPath = path;
         m_cutLine->setPath(m_cutPath);
-        m_pieceRect = m_cutLine->boundingRect();
+        if (piece.isHideSeamLine())
+        {
+            m_seamLine->setPath(QPainterPath());
+        }
+        else
+        {
+            m_seamLine->setPath(m_mainPath);
+        }
     }
     else
     {
         m_cutLine->setPath(QPainterPath());
     }
 
-    this->setPath(path);
+    m_pieceRect = path.boundingRect();
     this->setPos(piece.GetMx(), piece.GetMy());
     this->setFlag(QGraphicsItem::ItemSendsGeometryChanges, true);
 }

--- a/src/libs/vtools/tools/pattern_piece_tool.h
+++ b/src/libs/vtools/tools/pattern_piece_tool.h
@@ -176,10 +176,11 @@ private:
 
     QPainterPath           m_mainPath;    // Must be first to prevent crash
     QRectF                 m_pieceRect;
-    QPainterPath           m_cutPath;     // Must be first to prevent crash
+    QPainterPath           m_cutPath;
     VMainGraphicsScene    *m_pieceScene;  /** @brief pieceScene pointer to the scene. */
     QString                m_blockName;
     VNoBrushScalePathItem *m_cutLine;
+    VNoBrushScalePathItem *m_seamLine;
     VTextGraphicsItem     *m_dataLabel;
     VTextGraphicsItem     *m_patternInfo;
     VGrainlineItem        *m_grainLine;

--- a/src/libs/vtools/tools/pattern_piece_tool.h
+++ b/src/libs/vtools/tools/pattern_piece_tool.h
@@ -64,7 +64,7 @@
 #include "../vwidgets/vgrainlineitem.h"
 
 class DialogTool;
-class VNoBrushScalePathItem;
+class NonScalingFillPathItem;
 
 class PatternPieceTool : public VInteractiveTool, public QGraphicsPathItem
 {
@@ -179,8 +179,8 @@ private:
     QPainterPath           m_cutPath;
     VMainGraphicsScene    *m_pieceScene;  /** @brief pieceScene pointer to the scene. */
     QString                m_blockName;
-    VNoBrushScalePathItem *m_cutLine;
-    VNoBrushScalePathItem *m_seamLine;
+    NonScalingFillPathItem *m_cutLine;
+    NonScalingFillPathItem *m_seamLine;
     VTextGraphicsItem     *m_dataLabel;
     VTextGraphicsItem     *m_patternInfo;
     VGrainlineItem        *m_grainLine;

--- a/src/libs/vwidgets/nonscalingfill_pathitem.cpp
+++ b/src/libs/vwidgets/nonscalingfill_pathitem.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   nonscalingfill_pathitem.cpp
+ **  @author Douglas S Caskey
+ **  @date   Jan 29, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,11 +19,10 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
  **  @file   vnobrushscalepathitem.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -29,52 +30,52 @@
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
+ **  Copyright (C) 2016 Valentina project
  **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+ **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
  **
  *************************************************************************/
 
-#include "vnobrushscalepathitem.h"
+#include "nonscalingfill_pathitem.h"
 
 #include <QBrush>
 #include <QMatrix>
 #include <QPainter>
 
 //---------------------------------------------------------------------------------------------------------------------
-VNoBrushScalePathItem::VNoBrushScalePathItem(QGraphicsItem *parent) :
-    QGraphicsPathItem(parent)
+NonScalingFillPathItem::NonScalingFillPathItem(QGraphicsItem *parent)
+    : QGraphicsPathItem(parent)
 {
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VNoBrushScalePathItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
+void NonScalingFillPathItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
     /*
-     * how to avoid transformation of QBrush
+     * How to avoid transformation of QBrush fill
      * http://www.qtforum.org/article/23942/how-to-avoid-transformation-of-qbrush-texture.html
      * ?s=b4ba78dd6758da78fe395d8f6bb7512511a0833e#post84983
      *
-     * Not Scaling QBrush style fro qgraphics view item
+     * Non Scaling QBrush fill style for qgraphicspathitem
      * http://www.qtcentre.org/archive/index.php/t-13950.html
      *
      * You'll have to scale the brush down. The QStyleOptionGraphicsItem option passed in paint() will give you the
      * transform being used, and you can set a transform on a QBrush. Put the two together and you can scale the brush
-     * opposite of the item.
+     * inversely of the item.
      */
     QBrush brush = this->brush();
     brush.setTransform(painter->combinedTransform().inverted());

--- a/src/libs/vwidgets/nonscalingfill_pathitem.h
+++ b/src/libs/vwidgets/nonscalingfill_pathitem.h
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   nonscalingfill_pathitem.h
+ **  @author Douglas S Caskey
+ **  @date   Jan 29, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,11 +19,10 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
  **  @file   vnobrushscalepathitem.h
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -29,28 +30,28 @@
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
+ **  Copyright (C) 2016 Valentina project
  **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+ **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
  **
  *************************************************************************/
 
-#ifndef VNOBRUSHSCALEPATHITEM_H
-#define VNOBRUSHSCALEPATHITEM_H
+#ifndef  NONSCALINGFILL_PATHITEM_H
+#define  NONSCALINGFILL_PATHITEM_H
 
 #include <qcompilerdetection.h>
 #include <QGraphicsPathItem>
@@ -58,20 +59,20 @@
 
 #include "../vmisc/def.h"
 
-class VNoBrushScalePathItem : public QGraphicsPathItem
+class NonScalingFillPathItem : public QGraphicsPathItem
 {
 public:
-    explicit VNoBrushScalePathItem(QGraphicsItem *parent = nullptr);
+    explicit     NonScalingFillPathItem(QGraphicsItem *parent = nullptr);
 
 protected:
     virtual void paint(QPainter * painter, const QStyleOptionGraphicsItem * option,
                        QWidget * widget = nullptr) Q_DECL_OVERRIDE;
 
     virtual int  type() const Q_DECL_OVERRIDE {return Type;}
-    enum { Type = UserType + static_cast<int>(Vis::NoBrush)};
+    enum         {Type = UserType + static_cast<int>(Vis::NoBrush)};
 
 private:
-    Q_DISABLE_COPY(VNoBrushScalePathItem)
+    Q_DISABLE_COPY(NonScalingFillPathItem)
 };
 
-#endif // VNOBRUSHSCALEPATHITEM_H
+#endif // NONSCALINGFILL_PATHITEM_H

--- a/src/libs/vwidgets/vgrainlineitem.cpp
+++ b/src/libs/vwidgets/vgrainlineitem.cpp
@@ -134,15 +134,15 @@ void VGrainlineItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
 
     if (m_eMode != mNormal)
     {
-        painter->setPen(QPen(color, 2, Qt::DashLine));
+        painter->setPen(QPen(Qt::black, 2, Qt::DashLine));
         painter->setBrush(Qt::NoBrush);
         // bounding polygon
         painter->drawPolygon(m_polyBound);
-        painter->setPen(QPen(color, 3));
 
         if (m_eMode != mRotate)
         {
-            painter->setBrush(color);
+            painter->setPen(QPen(Qt::black, 3));
+            painter->setBrush(Qt::black);
             UpdatePolyResize();
             painter->drawPolygon(m_polyResize);
         }
@@ -150,7 +150,7 @@ void VGrainlineItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
         painter->setBrush(Qt::NoBrush);
         if (m_eMode == mResize)
         {
-            painter->setPen(color);
+            painter->setPen(Qt::black);
             painter->drawLine(m_polyBound.at(0), m_polyBound.at(2));
             painter->drawLine(m_polyBound.at(1), m_polyBound.at(3));
         }
@@ -159,7 +159,7 @@ void VGrainlineItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
         {
             QPointF ptC = (m_polyBound.at(0) + m_polyBound.at(2))/2;
             qreal dRad = m_dScale * ROTATE_CIRC_R;
-            painter->setBrush(color);
+            painter->setBrush(Qt::black);
             painter->drawEllipse(ptC, dRad, dRad);
 
             painter->setBrush(Qt::NoBrush);

--- a/src/libs/vwidgets/vwidgets.pri
+++ b/src/libs/vwidgets/vwidgets.pri
@@ -10,6 +10,7 @@ SOURCES += \
     $$PWD/linetype_combobox.cpp \
     $$PWD/lineweight_combobox.cpp \
     $$PWD/mouse_coordinates.cpp \
+    $$PWD/nonscalingfill_pathitem.cpp \
     $$PWD/piece_tablewidgetitem.cpp \
     $$PWD/scene_rect.cpp \
     $$PWD/vmaingraphicsscene.cpp \
@@ -19,7 +20,6 @@ SOURCES += \
     $$PWD/vgraphicssimpletextitem.cpp \
     $$PWD/vsimplepoint.cpp \
     $$PWD/vabstractsimple.cpp \
-    $$PWD/vnobrushscalepathitem.cpp \
     $$PWD/vsimplecurve.cpp \
     $$PWD/vabstractmainwindow.cpp \
     $$PWD/vtextgraphicsitem.cpp \
@@ -42,6 +42,7 @@ HEADERS += \
     $$PWD/linetype_combobox.h \
     $$PWD/lineweight_combobox.h \
     $$PWD/mouse_coordinates.h \
+    $$PWD/nonscalingfill_pathitem.h \
     $$PWD/piece_tablewidgetitem.h \
     $$PWD/scene_rect.h \
     $$PWD/stable.h \
@@ -52,7 +53,6 @@ HEADERS += \
     $$PWD/vgraphicssimpletextitem.h \
     $$PWD/vsimplepoint.h \
     $$PWD/vabstractsimple.h \
-    $$PWD/vnobrushscalepathitem.h \
     $$PWD/vsimplecurve.h \
     $$PWD/vabstractmainwindow.h \
     $$PWD/vtextgraphicsitem.h \


### PR DESCRIPTION
This fixes the issue when using zero width seam allowances in the Pattern Piece tool.  

Additional changes:
The VNoBrushScalePathItem class is renamed to - NonScalingFillPathItem - something more accurately descriptive. 
The label "Show Seam Allowance" is changed to "Show Cut Line" in the Pattern Piece Tool dialog.
An Lupdate run for the change in UI. 
The dock widget -> Pieces now disables the Color Picker & Piece Properties when double clicking if the piece is locked.
The dock widget-> Pieces now displays specific tooltips per column item. 

Closes issue #846 