### PR TITLE
lupdate: use lupdate via path from qmake

### DIFF
--- a/Seamly2D.pro
+++ b/Seamly2D.pro
@@ -14,7 +14,8 @@ SUBDIRS = \
 
 out.depends = src
 
-lupdate.commands = lupdate -recursive $$shell_path($${PWD}/share/translations/translations.pro)
-lupdate.commands += && lupdate -recursive $$shell_path($${PWD}/share/translations/measurements.pro)
+qtPrepareTool(LUPDATE, lupdate)
+lupdate.commands = $$LUPDATE $$shell_path($${PWD}/share/translations/translations.pro)
+lupdate.commands += && $$LUPDATE $$shell_path($${PWD}/share/translations/measurements.pro)
 
 QMAKE_EXTRA_TARGETS += lupdate


### PR DESCRIPTION
before just the first lupdate on path was used, now referencing
the same as the Qt version used for all other build commands
