### PR TITLE
Fix issue #203

### DIFF
--- a/share/translations/measurements_fr_FR.ts
+++ b/share/translations/measurements_fr_FR.ts
@@ -3793,7 +3793,7 @@
         <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1857"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
-        <translation>longueur_entrejambe</translation>
+        <translation type="unfinished">longueur_entrejambe_dos</translation>
     </message>
     <message>
         <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1859"/>


### PR DESCRIPTION
- fix: missing measurement in French translation

This fixes issue #203  and missing measurement. 

The issue is due to the fact that the measurement names MUST be unique, and there were 2 French translations with the same name. 

Merging closes issue #203