### PR TITLE
feat: add copy to clipboard and measurement number to table

### DIFF
--- a/src/app/seamlyme/tmainwindow.h
+++ b/src/app/seamlyme/tmainwindow.h
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   tmainwindow.h
+ **  @author Douglas S Caskey
+ **  @date   Mar 25, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2015 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,11 +19,10 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+ /************************************************************************
  **
  **  @file   tmainwindow.h
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -218,6 +219,7 @@ private:
     QString             ClearCustomName(const QString &name) const;
 
     bool                EvalFormula(const QString &formula, bool fromUser, VContainer *data, QLabel *label);
+    QString             getMeasurementNumber(const QString &name);
     void                ShowMDiagram(const QString &name);
 
     void                Open(const QString &pathTo, const QString &filter);
@@ -242,6 +244,7 @@ private:
 
     template <class T>
     void                HackWidget(T **widget);
+    void                copyToClipboard();
 };
 
 #endif // TMAINWINDOW_H

--- a/src/app/seamlyme/tmainwindow.ui
+++ b/src/app/seamlyme/tmainwindow.ui
@@ -47,7 +47,7 @@
        <string/>
       </property>
       <property name="currentIndex">
-       <number>1</number>
+       <number>0</number>
       </property>
       <widget class="QWidget" name="tabMeasurements">
        <attribute name="icon">
@@ -60,6 +60,17 @@
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QToolButton" name="clipboard_ToolButton">
+            <property name="text">
+             <string>...</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../../libs/vmisc/share/resources/icon.qrc">
+              <normaloff>:/icon/32x32/clipboard_icon.png</normaloff>:/icon/32x32/clipboard_icon.png</iconset>
+            </property>
+           </widget>
+          </item>
           <item>
            <widget class="QLabel" name="labelFind">
             <property name="text">
@@ -142,6 +153,11 @@
           <column>
            <property name="text">
             <string>Name</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Number</string>
            </property>
           </column>
           <column>


### PR DESCRIPTION
This adds a tool button to copy selected Measurment table items to the clipboard to facilitate cut and paste. Also adds a new column to display the measurement number of Known Measurements.

![number column](https://user-images.githubusercontent.com/31944718/227803815-7b625b53-e451-4a86-96ca-a85066dffb95.png)

Closes: Issue #909 