### PR TITLE
fix: missing add group icon

### DIFF
--- a/src/app/seamly2d/dialogs/groups_widget.ui
+++ b/src/app/seamly2d/dialogs/groups_widget.ui
@@ -149,7 +149,7 @@
        </property>
        <property name="icon">
         <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
-         <normaloff>:/icon/32x32/add.PNG</normaloff>:/icon/32x32/add.PNG</iconset>
+         <normaloff>:/icon/32x32/add.png</normaloff>:/icon/32x32/add.png</iconset>
        </property>
        <property name="checkable">
         <bool>true</bool>

--- a/src/libs/vtools/tools/drawTools/vdrawtool.h
+++ b/src/libs/vtools/tools/drawTools/vdrawtool.h
@@ -221,7 +221,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
 
     if(not groupsNotContainingItem.empty())
     {
-        QMenu *menuAddGroupItem = menu.addMenu(QIcon("://icon/32x32/add.PNG"), tr("Add Group Object"));
+        QMenu *menuAddGroupItem = menu.addMenu(QIcon("://icon/32x32/add.png"), tr("Add Group Object"));
         QStringList list = QStringList(groupsNotContainingItem.values());
         list.sort(Qt::CaseInsensitive);
 


### PR DESCRIPTION
This fixes the case in the extension of the Group Manager add new group icon name. 

Closes: Issue #921 