### PR TITLE
fix: name in line tool dialog

### DIFF
--- a/src/libs/vtools/dialogs/tools/dialogline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogline.cpp
@@ -102,8 +102,6 @@ DialogLine::DialogLine(const VContainer *data, const quint32 &toolId, QWidget *p
 
     number = 0;
 
-    ui->name_LineEdit->setText(tr("Line_") + ui->comboBoxFirstPoint->currentText() +
-                                  "_" + ui->comboBoxSecondPoint->currentText());
     connect(ui->comboBoxFirstPoint,  &QComboBox::currentTextChanged, this, &DialogLine::PointNameChanged);
     connect(ui->comboBoxSecondPoint, &QComboBox::currentTextChanged, this, &DialogLine::PointNameChanged);
 
@@ -128,6 +126,17 @@ void DialogLine::setSecondPoint(const quint32 &value)
     VisToolLine *line = qobject_cast<VisToolLine *>(vis);
     SCASSERT(line != nullptr)
     line->setPoint2Id(value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/**
+ * @brief setLineName set the name of the line
+ * @param value id
+ */
+void DialogLine::setLineName()
+{
+    ui->name_LineEdit->setText(tr("Line_") + ui->comboBoxFirstPoint->currentText() +
+                                  "_" + ui->comboBoxSecondPoint->currentText());
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogline.h
+++ b/src/libs/vtools/dialogs/tools/dialogline.h
@@ -77,6 +77,8 @@ public:
     quint32        getSecondPoint() const;
     void           setSecondPoint(const quint32 &value);
 
+    void           setLineName();
+
     QString        getLineType() const;
     void           setLineType(const QString &value);
 

--- a/src/libs/vtools/dialogs/tools/dialogline.ui
+++ b/src/libs/vtools/dialogs/tools/dialogline.ui
@@ -90,6 +90,9 @@
             <bold>false</bold>
            </font>
           </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
        </layout>

--- a/src/libs/vtools/tools/drawTools/vtoolline.cpp
+++ b/src/libs/vtools/tools/drawTools/vtoolline.cpp
@@ -116,6 +116,7 @@ void VToolLine::setDialog()
     SCASSERT(not dialogTool.isNull())
     dialogTool->setFirstPoint(firstPoint);
     dialogTool->setSecondPoint(secondPoint);
+    dialogTool->setLineName();
     dialogTool->setLineType(m_lineType);
     dialogTool->setLineWeight(m_lineWeight);
     dialogTool->setLineColor(lineColor);


### PR DESCRIPTION
This fixes the display of the name field in the line tool dialog.  Also makes the name field "read only". 

Closes: Issue #923 