### PR TITLE
docs: mac version requires 10.13+

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -24,7 +24,7 @@ Learn more about Seamly2D by joining our friendly, active user [forum](https://f
 ## Supported platforms:  
    * Windows 10 & 11 (32-bit and 64-bit)
    * Most current Linux distros via [Flathub](https://flathub.org/apps/details/net.seamly.seamly2d)
-   * Mac OS X 10.13 (64-bit) or later
+   * macOS High Sierra 10.13 (64-bit) or later
 
 ## Download Seamly2D:
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -24,7 +24,7 @@ Learn more about Seamly2D by joining our friendly, active user [forum](https://f
 ## Supported platforms:  
    * Windows 10 & 11 (32-bit and 64-bit)
    * Most current Linux distros via [Flathub](https://flathub.org/apps/details/net.seamly.seamly2d)
-   * Mac OS X 10.8 (64-bit) or later
+   * Mac OS X 10.13 (64-bit) or later
 
 ## Download Seamly2D:
 


### PR DESCRIPTION
Qt 5.15.2 that we have been using for a while requries at least 10.13, so adapt the README accordingly.

See https://doc.qt.io/qt-5/supported-platforms.html#macos for background