### PR TITLE
fix: intersectxy dialog

### DIFF
--- a/src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>270</width>
-    <height>270</height>
+    <height>300</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -446,6 +446,19 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION
Increase dialog height and set vertical property in the dialog to preferred to allow it to expand vertically.

Closes issue #938 