### PR TITLE
Change location where Doxygen output is generated

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           = share/img/Seamly2D_logo_128x128.png
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ./docs/html
+OUTPUT_DIRECTORY       = ./docs/doxygen
 
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-


### PR DESCRIPTION
Documentation was being created in docs/html instead of docs/doxygen, which is used to deploy the wiki page.