### PR TITLE
fix: UTF-8 sources in MSVC

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -44,6 +44,10 @@ win32 {
                        ../../../dist/win/libssl-1_1.dll
 }
 
+# MSVC: force utf-8 source for ° symbol and other utf-8 strings in source files
+# Source: https://stackoverflow.com/questions/48705747/how-utf-8-may-not-work-in-qt-5
+win32:!win32-g++: QMAKE_CXXFLAGS += /utf-8
+
 CONFIG(debug, debug|release){
     # Debug mode, intentionally left empty
 } else {


### PR DESCRIPTION
This forces MSVC to use UTF-8 as source encoding, and with that the degree symbol finally works also when compiled with msvc.

Before:

![Bildschirmfoto 2023-06-14 um 22 14 52](https://github.com/FashionFreedom/Seamly2D/assets/1392875/e9406331-4e0b-4bdf-9c30-5af67d601475)

After:

![Bildschirmfoto 2023-06-14 um 22 13 49](https://github.com/FashionFreedom/Seamly2D/assets/1392875/64a257db-7503-4b6c-8680-734d5bd2d521)

Closes: #315
