### PR TITLE
feat: add group sorting

### DIFF
--- a/src/app/seamly2d/dialogs/groups_widget.cpp
+++ b/src/app/seamly2d/dialogs/groups_widget.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   groups_widget.cpp
  **  @author Douglas S Caskey
- **  @date   Mar 1, 2023
+ **  @date   11 Jun, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2023 Seamly, LLC
@@ -73,6 +73,7 @@
 #include "../vgeometry/vcubicbezierpath.h"
 #include "../vgeometry/vpointf.h"
 #include "../vpatterndb/vcontainer.h"
+#include "../vwidgets/group_tablewidgetitem.h"
 #include "../vwidgets/vabstractmainwindow.h"
 #include "../vmisc/vabstractapplication.h"
 #include "../vmisc/vsettings.h"
@@ -114,6 +115,7 @@ GroupsWidget::GroupsWidget(VContainer *data, VAbstractPattern *doc, QWidget *par
     ui->groups_Splitter->restoreState(settings.value("splitterSizes").toByteArray());
 
     fillTable(m_doc->getGroups());
+    ui->groups_TableWidget->sortItems(settings.value("groupSort", 4).toInt(), Qt::AscendingOrder);
 
     connect(m_doc, &VAbstractPattern::patternHasGroups, this, &GroupsWidget::draftBlockHasGroups);
 
@@ -138,6 +140,7 @@ GroupsWidget::GroupsWidget(VContainer *data, VAbstractPattern *doc, QWidget *par
     connect(ui->groupItems_ListWidget, &QListWidget::customContextMenuRequested, this, &GroupsWidget::groupItemContextMenu);
     connect(ui->groupItems_ListWidget, &QListWidget::itemDoubleClicked,          this, &GroupsWidget::itemDoubleClicked);
 
+    connect(ui->groups_TableWidget->horizontalHeader(), &QHeaderView::sectionClicked, this, &GroupsWidget::headerClicked);
     connect(ui->groups_Splitter, &QSplitter::splitterMoved, this, &GroupsWidget::splitterMoved);
 }
 
@@ -382,7 +385,7 @@ void GroupsWidget::editGroup()
         ui->groups_TableWidget->blockSignals(false);
         return;
     }
-    QTableWidgetItem *item = ui->groups_TableWidget->item(row,1);
+
     const quint32 groupId = ui->groups_TableWidget->item(row, 0)->data(Qt::UserRole).toUInt();
     const bool locked = m_doc->getGroupLock(groupId);
     QString oldGroupName = m_doc->getGroupName(groupId);
@@ -434,14 +437,22 @@ void GroupsWidget::editGroup()
         }
 
         const QString groupColor = dialog->getColor();
-        QPixmap pixmap = VAbstractTool::createColorIcon(32, 12, groupColor);
-
         const QString groupLineType = dialog->getLineType();
         const QString groupLineWeight = dialog->getLineWeight();
 
-        item = ui->groups_TableWidget->item(row,3);
+        QTableWidgetItem *item = ui->groups_TableWidget->item(row, 3);
+        item->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+        item->setSizeHint(QSize(20, 20));
+        QPixmap pixmap(20, 20);
+        pixmap.fill(QColor(groupColor));
         item->setIcon(QIcon(pixmap));
+        item->setFlags(item->flags() &= ~(Qt::ItemIsEditable));  // set the item non-editable (view only), and non-selectable
+        item->setToolTip(tr("Group color"));
+        ui->groups_TableWidget->setItem(row, 3, item);
+
+        item = ui->groups_TableWidget->item(row, 4);
         item->setText(groupName);
+
         m_doc->setGroupName(groupId, groupName);
         m_doc->setGroupColor(groupId, groupColor);
         m_doc->setGroupLineType(groupId, groupLineType);
@@ -455,6 +466,9 @@ void GroupsWidget::editGroup()
 //---------------------------------------------------------------------------------------------------------------------
 void GroupsWidget::groupContextMenu(const QPoint &pos)
 {
+    ui->groups_TableWidget->setSortingEnabled(false);
+    ui->groups_TableWidget->blockSignals(true);
+
     QTableWidgetItem *item = ui->groups_TableWidget->itemAt(pos);
     if (!item)
     {
@@ -526,10 +540,19 @@ void GroupsWidget::groupContextMenu(const QPoint &pos)
 
       const QString groupColor = dialog->getColor();
       const QString groupLineType = dialog->getLineType();
-       const QString groupLineWeight = dialog->getLineWeight();
-      QPixmap pixmap = VAbstractTool::createColorIcon(32, 12, groupColor);
+      const QString groupLineWeight = dialog->getLineWeight();
+
       item = ui->groups_TableWidget->item(row, 3);
+      item->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+      item->setSizeHint(QSize(20, 20));
+      QPixmap pixmap(20, 20);
+      pixmap.fill(QColor(groupColor));
       item->setIcon(QIcon(pixmap));
+      item->setFlags(item->flags() &= ~(Qt::ItemIsEditable));  // set the item non-editable (view only), and non-selectable
+      item->setToolTip(tr("Group color"));
+      ui->groups_TableWidget->setItem(row, 3, item);
+
+      item = ui->groups_TableWidget->item(row, 4);
       item->setText(groupName);
       m_doc->setGroupName(groupId, groupName);
       m_doc->setGroupColor(groupId, groupColor);
@@ -542,6 +565,10 @@ void GroupsWidget::groupContextMenu(const QPoint &pos)
         connect(command, &DelGroup::updateGroups, this, &GroupsWidget::updateGroups);
         qApp->getUndoStack()->push(command);
     }
+
+    ui->groups_TableWidget->setSortingEnabled(true);
+    ui->groups_TableWidget->blockSignals(false);
+
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -561,8 +588,10 @@ void GroupsWidget::fillTable(const QMap<quint32, GroupAttributes> &groups)
 {
     ui->groups_TableWidget->blockSignals(true);
     ui->groups_TableWidget->clear();
-    ui->groups_TableWidget->setColumnCount(4);
+    ui->groups_TableWidget->setColumnCount(5);
     ui->groups_TableWidget->setRowCount(groups.size());
+    ui->groups_TableWidget->setSortingEnabled(false);
+
     qint32 currentRow = -1;
     auto i = groups.constBegin();
     while (i != groups.constEnd())
@@ -571,8 +600,9 @@ void GroupsWidget::fillTable(const QMap<quint32, GroupAttributes> &groups)
         const GroupAttributes data = i.value();
 
         // Add visibility item
-        QTableWidgetItem *item = new QTableWidgetItem();
+        GroupTableWidgetItem *item = new GroupTableWidgetItem(m_doc);
         item->setTextAlignment(Qt::AlignHCenter);
+        item->setSizeHint(QSize(20, 20));
 
         setGroupVisibility(item, i.key(), data.visible);
 
@@ -582,49 +612,55 @@ void GroupsWidget::fillTable(const QMap<quint32, GroupAttributes> &groups)
         ui->groups_TableWidget->setItem(currentRow, 0, item);
 
         // Add locked item
-        item = new QTableWidgetItem();
+        item = new GroupTableWidgetItem(m_doc);
         item->setTextAlignment(Qt::AlignHCenter);
-
-        if (data.locked)
-        {
-            item->setIcon(QIcon("://icon/32x32/lock_on.png"));
-        }
-        else
-        {
-            item->setIcon(QIcon("://icon/32x32/lock_off.png"));
-        }
-
+        item->setSizeHint(QSize(20, 20));
+        item->setIcon(data.locked ? QIcon("://icon/32x32/lock_on.png") : QIcon("://icon/32x32/lock_off.png"));
         item->setData(Qt::UserRole, i.key());
         item->setFlags(item->flags() &= ~(Qt::ItemIsEditable));  // set the item non-editable (view only), and non-selectable
         item->setToolTip(tr("Show which groups in the list are locked"));
         ui->groups_TableWidget->setItem(currentRow, 1, item);
 
-        // Add Edit Item
-        if (!m_doc->isGroupEmpty(i.key()))
-        {
-            item = new QTableWidgetItem();
-            item->setTextAlignment(Qt::AlignHCenter);
-            item->setIcon(QIcon("://icon/32x32/history.png"));
-            item->setData(Qt::UserRole, i.key());
-            item->setFlags(item->flags() &= ~(Qt::ItemIsEditable));  // set the item non-editable (view only), and non-selectable
-            item->setToolTip(tr("Show which groups contain objects"));
-            ui->groups_TableWidget->setItem(currentRow, 2, item);
-        }
+        // Add contain objects Item
+        item = new GroupTableWidgetItem(m_doc);
+        item->setTextAlignment(Qt::AlignHCenter);
+        item->setIcon(!m_doc->isGroupEmpty(i.key()) ? QIcon("://icon/32x32/history.png") : QIcon());
+        item->setData(Qt::UserRole, i.key());
+        item->setFlags(item->flags() &= ~(Qt::ItemIsEditable));  // set the item non-editable (view only), and non-selectable
+        item->setToolTip(tr("Show which groups contain objects"));
+        ui->groups_TableWidget->setItem(currentRow, 2, item);
+
+        // Add color item
+        item = new GroupTableWidgetItem(m_doc);
+        item->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+        item->setSizeHint(QSize(20, 20));
+        QPixmap pixmap(20, 20);
+        pixmap.fill(QColor(data.color));
+        item->setIcon(QIcon(pixmap));
+        item->setData(Qt::UserRole, data.color);
+        item->setFlags(item->flags() &= ~(Qt::ItemIsEditable));  // set the item non-editable (view only), and non-selectable
+        item->setToolTip(tr("Group color"));
+        ui->groups_TableWidget->setItem(currentRow, 3, item);
 
         // Add group name item
-        QPixmap pixmap = VAbstractTool::createColorIcon(32,12,data.color);
-
-        item = new QTableWidgetItem(data.name);
-        item->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
-        item->setIcon(QIcon(pixmap));
-        item->setToolTip(tr("Group color and name"));
-        ui->groups_TableWidget->setItem(currentRow, 3, item);
+        QTableWidgetItem *nameItem = new QTableWidgetItem(data.name);
+        nameItem->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+        nameItem->setToolTip(tr("Group name"));
+        ui->groups_TableWidget->setItem(currentRow, 4, nameItem);
 
         ++i;
     }
-    ui->groups_TableWidget->sortItems(1, Qt::AscendingOrder);
+
+    ui->groups_TableWidget->setHorizontalHeaderItem(0, new QTableWidgetItem(makeHeaderName(QString("Visible"))));
+    ui->groups_TableWidget->setHorizontalHeaderItem(1, new QTableWidgetItem(makeHeaderName(QString("Locked"))));
+    ui->groups_TableWidget->setHorizontalHeaderItem(2, new QTableWidgetItem(makeHeaderName(QString("Objects"))));
+    ui->groups_TableWidget->setHorizontalHeaderItem(3, new QTableWidgetItem(makeHeaderName(QString("Color"))));
+    ui->groups_TableWidget->setHorizontalHeaderItem(4, new QTableWidgetItem(tr("Name")));
+    ui->groups_TableWidget->horizontalHeaderItem(4)->setTextAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    ui->groups_TableWidget->horizontalHeader()->setSectionResizeMode(QHeaderView::Fixed);
     ui->groups_TableWidget->resizeColumnsToContents();
     ui->groups_TableWidget->resizeRowsToContents();
+    ui->groups_TableWidget->setSortingEnabled(true);
     ui->groups_TableWidget->blockSignals(false);
 }
 
@@ -675,7 +711,7 @@ QString GroupsWidget::getCurrentGroupName()
     }
     int row = ui->groups_TableWidget->row(item);
     qCDebug(WidgetGroups, "Row = %d\n", row);
-    const QString groupName = ui->groups_TableWidget->item(row, 3)->text();
+    const QString groupName = ui->groups_TableWidget->item(row, 4)->text();
     return groupName;
 }
 
@@ -998,7 +1034,6 @@ void GroupsWidget::addGroupItem(const quint32 &toolId, const quint32 &objId, con
             itemData.append(objId);
             itemData.append(toolId);
 
-            qCDebug(WidgetGroups, "Icon Name = %s", qUtf8Printable(iconFileName));
             QListWidgetItem *item = new QListWidgetItem(objName);
             item->setIcon(QIcon(iconFileName));
             item->setData(Qt::UserRole,  QVariant::fromValue(itemData));
@@ -1326,4 +1361,15 @@ void GroupsWidget::splitterMoved(int pos, int index)
 
     QSettings settings;
     settings.setValue("splitterSizes", ui->groups_Splitter->saveState());
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/**
+ * @brief headerClicked Sort state whenever header section clicked.
+ * @param index
+ */
+void GroupsWidget::headerClicked(int index)
+{
+    QSettings settings;
+    settings.setValue("groupSort", index);
 }

--- a/src/app/seamly2d/dialogs/groups_widget.h
+++ b/src/app/seamly2d/dialogs/groups_widget.h
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   groups_widget.h
  **  @author Douglas S Caskey
- **  @date   Mar 1, 2023
+ **  @date   11 Jun, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2023 Seamly, LLC
@@ -118,6 +118,7 @@ private:
     quint32           attrUInt(const QDomElement &domElement, const QString &name);
     QString           getObjName(quint32 id);
     void              splitterMoved(int pos, int index);
+    void              headerClicked(int index);
 };
 
 #endif // GROUPS_WIDGET_H

--- a/src/app/seamly2d/dialogs/groups_widget.ui
+++ b/src/app/seamly2d/dialogs/groups_widget.ui
@@ -311,16 +311,19 @@
           <enum>QAbstractItemView::SelectRows</enum>
          </property>
          <property name="sortingEnabled">
-          <bool>false</bool>
+          <bool>true</bool>
+         </property>
+         <property name="columnCount">
+          <number>5</number>
          </property>
          <attribute name="horizontalHeaderVisible">
-          <bool>false</bool>
+          <bool>true</bool>
          </attribute>
          <attribute name="horizontalHeaderMinimumSectionSize">
           <number>16</number>
          </attribute>
          <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
-          <bool>false</bool>
+          <bool>true</bool>
          </attribute>
          <attribute name="horizontalHeaderStretchLastSection">
           <bool>true</bool>
@@ -334,6 +337,11 @@
          <attribute name="verticalHeaderHighlightSections">
           <bool>false</bool>
          </attribute>
+         <column/>
+         <column/>
+         <column/>
+         <column/>
+         <column/>
         </widget>
        </item>
       </layout>

--- a/src/libs/vmisc/def.cpp
+++ b/src/libs/vmisc/def.cpp
@@ -393,6 +393,17 @@ QString strippedName(const QString &fullFileName)
     return QFileInfo(fullFileName).fileName();
 }
 
+/**
+ * @brief makeHeaderName make a 1 char tablewidgetitem header name based on a translated string.
+ * @param name full name of header item.
+ * @return 1 char name.
+ */
+QString makeHeaderName(const QString &name)
+{
+    QString headerStr = QObject::tr("%1").arg(name);
+    return headerStr.left(1).toUpper();
+}
+
 //---------------------------------------------------------------------------------------------------------------------
 QString RelativeMPath(const QString &patternPath, const QString &absoluteMPath)
 {

--- a/src/libs/vmisc/def.h
+++ b/src/libs/vmisc/def.h
@@ -461,6 +461,7 @@ Q_REQUIRED_RESULT QMarginsF UnitConvertor(const QMarginsF &margins, const Unit &
 void InitLanguages(QComboBox *combobox);
 Q_REQUIRED_RESULT QStringList SupportedLocales();
 
+QString makeHeaderName(const QString &name);
 Q_REQUIRED_RESULT QString strippedName(const QString &fullFileName);
 Q_REQUIRED_RESULT QString RelativeMPath(const QString &patternPath, const QString &absoluteMPath);
 Q_REQUIRED_RESULT QString AbsoluteMPath(const QString &patternPath, const QString &relativeMPath);
@@ -645,4 +646,6 @@ inline QList<T> convertToList(const C<T> &set)
 {
     return QList<T>(set.begin(), set.end());
 }
+
+
 #endif // DEF_H

--- a/src/libs/vwidgets/group_tablewidgetitem.cpp
+++ b/src/libs/vwidgets/group_tablewidgetitem.cpp
@@ -1,0 +1,64 @@
+/***************************************************************************
+ **  @file   group_tablewidgetitem.cpp
+ **  @author Douglas S Caskey
+ **  @date   11 Jun, 2023
+ **
+ **  @brief
+ **  @copyright
+ **  This source code is part of the Seamly2D project, a pattern making
+ **  program to create and model patterns of clothing.
+ **  Copyright (C) 2017-2023 Seamly2D project
+ **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+ **
+ *************************************************************************/
+
+#include "group_tablewidgetitem.h"
+
+#include "../ifc/xml/vabstractpattern.h"
+
+GroupTableWidgetItem::GroupTableWidgetItem(VAbstractPattern *doc)
+    : QTableWidgetItem()
+    , m_doc(doc)
+    {}
+
+//---------------------------------------------------------------------------------------------------------------------
+bool GroupTableWidgetItem::operator<(const QTableWidgetItem &other) const
+{
+    if (other.column() == 0)
+    {
+        bool thisVisible  = m_doc->getGroupVisibility(this->data(Qt::UserRole).toUInt());
+        bool otherVisible = m_doc->getGroupVisibility(other.data(Qt::UserRole).toUInt());
+        return int(thisVisible) < int(otherVisible);
+    }
+    else if (other.column() == 1)
+    {
+        bool thisLocked  = m_doc->getGroupLock(this->data(Qt::UserRole).toUInt());
+        bool otherLocked = m_doc->getGroupLock(other.data(Qt::UserRole).toUInt());
+        return int(thisLocked) < int(otherLocked);
+    }
+    else if (other.column() == 2)
+    {
+        bool thisEmpty  = m_doc->isGroupEmpty(this->data(Qt::UserRole).toUInt());
+        bool otherEmpty = m_doc->isGroupEmpty(other.data(Qt::UserRole).toUInt());
+        return int(!thisEmpty) < int(!otherEmpty);
+    }
+    else if (other.column() == 3)
+    {
+        return this->data(Qt::UserRole).toString() < other.data(Qt::UserRole).toString();
+    }
+
+    return false;
+}

--- a/src/libs/vwidgets/group_tablewidgetitem.h
+++ b/src/libs/vwidgets/group_tablewidgetitem.h
@@ -1,0 +1,46 @@
+/***************************************************************************
+ **  @file   group_tablewidgetitem.h
+ **  @author Douglas S Caskey
+ **  @date   11 Jun, 2023
+ **
+ **  @brief
+ **  @copyright
+ **  This source code is part of the Seamly2D project, a pattern making
+ **  program to create and model patterns of clothing.
+ **  Copyright (C) 2017-2023 Seamly2D project
+ **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+ **
+ *************************************************************************/
+
+#ifndef GROUP_TABLEWIDGETITEM_H
+#define GROUP_TABLEWIDGETITEM_H
+
+#include <QTableWidgetItem>
+
+class VAbstractPattern;
+
+class GroupTableWidgetItem : public QTableWidgetItem
+{
+
+public:
+    explicit     GroupTableWidgetItem(VAbstractPattern *doc);
+    virtual bool operator<(const QTableWidgetItem &other) const Q_DECL_OVERRIDE;
+
+private:
+    VAbstractPattern *m_doc;
+};
+
+#endif // GROUP_TABLEWIDGETITEM_H

--- a/src/libs/vwidgets/vwidgets.pri
+++ b/src/libs/vwidgets/vwidgets.pri
@@ -7,6 +7,7 @@ SOURCES += \
     $$PWD/color_combobox.cpp \
     $$PWD/export_format_combobox.cpp \
     $$PWD/fill_combobox.cpp \
+    $$PWD/group_tablewidgetitem.cpp \
     $$PWD/linetype_combobox.cpp \
     $$PWD/lineweight_combobox.cpp \
     $$PWD/mouse_coordinates.cpp \
@@ -40,6 +41,7 @@ HEADERS += \
     $$PWD/color_combobox.h \
     $$PWD/export_format_combobox.h \
     $$PWD/fill_combobox.h \
+    $$PWD/group_tablewidgetitem.h \
     $$PWD/linetype_combobox.h \
     $$PWD/lineweight_combobox.h \
     $$PWD/mouse_coordinates.h \


### PR DESCRIPTION
This adds sorting to the Groups table list via a custom QTableWidgetItem to handle the custom sorting for the boolean and color based columns.  Table now contains a Header item with  texts V L O C and Name. 

![groups](https://github.com/FashionFreedom/Seamly2D/assets/31944718/d6af4286-c511-4cee-a215-9031da9c067a)

closes issue #979