### PR TITLE
run builddocs.yml as manual action

### DIFF
--- a/.github/workflows/builddocs.yml
+++ b/.github/workflows/builddocs.yml
@@ -1,16 +1,16 @@
 name: BuildDocs
 
 # for a description, see README.md in this folder
-
+# use this file for testing Doxygen
 on:
-  schedule:
-    - cron: '30 1 * * MON'
+  #schedule:
+  #  - cron: '30 1 * * MON'
   workflow_dispatch:
-  push:
-    branches:
-    - develop
-    - test
-  pull_request:
+  #push:
+  #  branches:
+  #  - develop
+  #  - test
+  #pull_request:
 
 permissions:
   contents: write


### PR DESCRIPTION
fixed: builddocs.yml runs as a manual action, so it doesn't duplicate doxygen step in CI.yml