### PR TITLE
fix: language default prefs

### DIFF
--- a/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp
@@ -217,10 +217,15 @@ PreferencesConfigurationPage::PreferencesConfigurationPage(QWidget *parent)
     SetLabelComboBox(VApplication::LabelLanguages());
 
     index = ui->labelCombo->findData(qApp->Seamly2DSettings()->GetLabelLanguage());
+    if (index == -1)
+    {
+        index = ui->labelCombo->findData("en");
+    }
     if (index != -1)
     {
         ui->labelCombo->setCurrentIndex(index);
     }
+
     connect(ui->labelCombo, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, [this]()
     {
         m_labelLangChanged = true;

--- a/src/libs/vmisc/def.cpp
+++ b/src/libs/vmisc/def.cpp
@@ -210,7 +210,7 @@ void SetItemOverrideCursor(QGraphicsItem *item, const QString &pixmapPath, int h
 
     QPixmap pixmap;
 
-    if (not QPixmapCache::find(pixmapPath, &pixmap))
+    if (!QPixmapCache::find(pixmapPath, &pixmap))
     {
         pixmap = QPixmap(pixmapPath);
         QPixmapCache::insert(pixmapPath, pixmap);
@@ -746,19 +746,24 @@ void InitLanguages(QComboBox *combobox)
         locale.truncate(locale.lastIndexOf('.'));  // "seamly2d_de_De"
         locale.remove(0, locale.indexOf('_') + 1); // "de_De"
 
-        if (not englishUS)
+        if (!englishUS)
         {
-            englishUS = (en_US == locale);
+            englishUS = (locale == en_US);
         }
 
         QLocale loc = QLocale(locale);
         QString lang = loc.nativeLanguageName();
-        QIcon ico(QString("%1/%2.png").arg(":/flags").arg(QLocale::countryToString(loc.country())));
+        QString country = QLocale::countryToString(loc.country());
+        if (country == QLatin1String("Czechia"))
+        {
+            country = QLatin1String("CzechRepublic");
+        }
+        QIcon ico(QString("://flags/%1.png").arg(country));
 
         combobox->addItem(ico, lang, locale);
     }
 
-    if (combobox->count() == 0 || not englishUS)
+    if (combobox->count() == 0 || !englishUS)
     {
         // English language is internal and doens't have own *.qm file.
         QIcon ico(QString(":/flags/United States.png"));
@@ -771,5 +776,9 @@ void InitLanguages(QComboBox *combobox)
     if (index != -1)
     {
         combobox->setCurrentIndex(index);
+    }
+    else
+    {
+        combobox->setCurrentIndex(combobox->findData(en_US));
     }
 }


### PR DESCRIPTION
This fixes the default language prefs  to display American English if a user's locale is not one of the tanslation languages. 

Fixes issue #990 