### PR TITLE
fix: starting draft block regression

### DIFF
--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -7164,20 +7164,20 @@ bool MainWindow::IgnoreLocking(int error, const QString &path)
             case QLockFile::LockFailedError:
                 answer = QMessageBox::warning(this, tr("Locking file"),
                                                tr("This file already opened in another window. Ignore if you want "
-                                                  "to continue (!recommended, can cause a data corruption)."),
+                                                  "to continue (not recommended, can cause a data corruption)."),
                                                QMessageBox::Abort|QMessageBox::Ignore, QMessageBox::Abort);
                 break;
             case QLockFile::PermissionError:
                 answer = QMessageBox::question(this, tr("Locking file"),
                                                tr("The lock file could not be created, for lack of permissions. "
-                                                  "Ignore if you want to continue (!recommended, can cause "
+                                                  "Ignore if you want to continue (not recommended, can cause "
                                                   "a data corruption)."),
                                                QMessageBox::Abort|QMessageBox::Ignore, QMessageBox::Abort);
                 break;
             case QLockFile::UnknownError:
                 answer = QMessageBox::question(this, tr("Locking file"),
                                                tr("Unknown error happened, for instance a full partition prevented "
-                                                  "writing out the lock file. Ignore if you want to continue (!"
+                                                  "writing out the lock file. Ignore if you want to continue (not"
                                                   "recommended, can cause a data corruption)."),
                                                QMessageBox::Abort|QMessageBox::Ignore, QMessageBox::Abort);
                 break;

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -196,13 +196,13 @@ MainWindow::MainWindow(QWidget *parent)
     {
         if (pattern->DataPieces()->count() == 0)
         {
-            if(not ui->showDraftMode->isChecked())
+            if(!ui->showDraftMode->isChecked())
             {
                 showDraftMode(true);
             }
         }
     });
-    connect(doc, &VPattern::setCurrentDraftBlock, this, &MainWindow::globalDraftBlockChange);
+    connect(doc, &VPattern::setCurrentDraftBlock, this, &MainWindow::changeDraftBlockGlobally);
     connect(doc, &VPattern::CheckLayout, this, [&](){
         this->updateZoomToPointComboBox(draftPointNamesList());
     });
@@ -242,7 +242,7 @@ MainWindow::MainWindow(QWidget *parent)
         if (old == nullptr && isAncestorOf(now) == true)
         {// focus IN
             static bool asking = false;
-            if (not asking && mChanges && not mChangesAsked)
+            if (!asking && mChanges && not mChangesAsked)
             {
                 asking = true;
                 mChangesAsked = true;
@@ -323,11 +323,11 @@ void MainWindow::addDraftBlock(const QString &blockName)
                                          Source::FromGui);
     ui->view->itemClicked(spoint);
 
-    setEnableTools(true);
-    SetEnableWidgets(true);
+    setToolsEnabled(true);
+    setWidgetsEnabled(true);
 
     const qint32 index = draftBlockComboBox->findText(blockName);
-    if ( index != -1 )
+    if (index != -1)
     { // -1 for not found
         draftBlockComboBox->setCurrentIndex(index);
     }
@@ -457,7 +457,7 @@ QSharedPointer<VMeasurements> MainWindow::OpenMeasurementFile(const QString &pat
             measurements->setXMLContent(converter.Convert());// Read again after conversion
         }
 
-        if (not measurements->IsDefinedKnownNamesValid())
+        if (!measurements->IsDefinedKnownNamesValid())
         {
             VException e(tr("Measurement file contains invalid known measurement(s)."));
             throw e;
@@ -472,7 +472,7 @@ QSharedPointer<VMeasurements> MainWindow::OpenMeasurementFile(const QString &pat
                 qCCritical(vMainWindow, "%s\n\n%s", qUtf8Printable(tr("Wrong units.")),
                           qUtf8Printable(tr("Application doesn't support multisize table with inches.")));
                 measurements->clear();
-                if (not VApplication::IsGUIMode())
+                if (!VApplication::IsGUIMode())
                 {
                     qApp->exit(V_EX_DATAERR);
                 }
@@ -485,7 +485,7 @@ QSharedPointer<VMeasurements> MainWindow::OpenMeasurementFile(const QString &pat
         qCCritical(vMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("File error.")),
                    qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
         measurements->clear();
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             qApp->exit(V_EX_NOINPUT);
         }
@@ -521,7 +521,7 @@ bool MainWindow::LoadMeasurements(const QString &path)
     {
         qCCritical(vMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("File error.")),
                    qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             qApp->exit(V_EX_NOINPUT);
         }
@@ -559,7 +559,7 @@ bool MainWindow::UpdateMeasurements(const QString &path, int size, int height)
     if (qApp->patternType() != measurements->Type())
     {
         qCCritical(vMainWindow, "%s", qUtf8Printable(tr("Measurement files types have not match.")));
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             qApp->exit(V_EX_DATAERR);
         }
@@ -575,7 +575,7 @@ bool MainWindow::UpdateMeasurements(const QString &path, int size, int height)
     {
         qCCritical(vMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("File error.")),
                    qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             qApp->exit(V_EX_NOINPUT);
         }
@@ -605,7 +605,7 @@ void MainWindow::CheckRequiredMeasurements(const VMeasurements *measurements)
     auto docMeasurements = doc->ListMeasurements();
     const QSet<QString> match = QSet<QString>(docMeasurements.begin(), docMeasurements.end()).
                                     subtract(QSet<QString>(tempMeasurements.begin(), tempMeasurements.end()));
-    if (not match.isEmpty())
+    if (!match.isEmpty())
     {
 		QList<QString> list = match.values();
         for (int i = 0; i < list.size(); ++i)
@@ -725,7 +725,7 @@ void MainWindow::SetToolButtonWithApply(bool checked, Tool t, const QString &cur
 template <typename DrawTool>
 void MainWindow::ClosedDialog(int result)
 {
-    SCASSERT(not dialogTool.isNull())
+    SCASSERT(!dialogTool.isNull())
     if (result == QDialog::Accepted)
     {
         VMainGraphicsScene *scene = qobject_cast<VMainGraphicsScene *>(currentScene);
@@ -746,7 +746,7 @@ void MainWindow::ClosedDialog(int result)
 template <typename DrawTool>
 void MainWindow::ClosedDialogWithApply(int result, VMainGraphicsScene *scene)
 {
-    SCASSERT(not dialogTool.isNull())
+    SCASSERT(!dialogTool.isNull())
     if (result == QDialog::Accepted)
     {
         ApplyDialog<DrawTool>(scene);
@@ -779,7 +779,7 @@ void MainWindow::ClosedDialogWithApply(int result, VMainGraphicsScene *scene)
 template <typename DrawTool>
 void MainWindow::ApplyDialog(VMainGraphicsScene *scene)
 {
-    SCASSERT(not dialogTool.isNull())
+    SCASSERT(!dialogTool.isNull())
 
     // Only create tool if not already created with apply
     if (dialogTool->GetAssociatedTool() == nullptr)
@@ -1704,10 +1704,10 @@ void MainWindow::addSelectedItemsToGroup()
  * @brief showEvent handle after show window.
  * @param event show event.
  */
-void MainWindow::showEvent( QShowEvent *event )
+void MainWindow::showEvent(QShowEvent *event)
 {
-    QMainWindow::showEvent( event );
-    if ( event->spontaneous() )
+    QMainWindow::showEvent(event);
+    if (event->spontaneous())
     {
         return;
     }
@@ -1793,7 +1793,7 @@ void MainWindow::PrepareSceneList()
         ui->listWidget->addItem(item);
     }
 
-    if (not scenes.isEmpty())
+    if (!scenes.isEmpty())
     {
         ui->listWidget->setCurrentRow(0);
         SetLayoutModeActions();
@@ -1876,7 +1876,7 @@ void MainWindow::LoadIndividual()
 
     bool usedNotExistedDir = false;
     QDir directory(path);
-    if (not directory.exists())
+    if (!directory.exists())
     {
         usedNotExistedDir = directory.mkpath(".");
     }
@@ -1884,11 +1884,11 @@ void MainWindow::LoadIndividual()
     const QString mPath = QFileDialog::getOpenFileName(this, tr("Open file"), path, filter, nullptr,
                                                        QFileDialog::DontUseNativeDialog);
 
-    if (not mPath.isEmpty())
+    if (!mPath.isEmpty())
     {
         if (LoadMeasurements(mPath))
         {
-            if (not doc->MPath().isEmpty())
+            if (!doc->MPath().isEmpty())
             {
                 watcher->removePath(AbsoluteMPath(qApp->getFilePath(), doc->MPath()));
             }
@@ -1922,22 +1922,22 @@ void MainWindow::LoadMultisize()
     const QString mPath = QFileDialog::getOpenFileName(this, tr("Open file"), path, filter, nullptr,
                                                        QFileDialog::DontUseNativeDialog);
 
-    if (not mPath.isEmpty())
+    if (!mPath.isEmpty())
     {
         QString hText;
-        if (not gradationHeights.isNull())
+        if (!gradationHeights.isNull())
         {
             hText = gradationHeights->currentText();
         }
         QString sText;
-        if (not gradationSizes.isNull())
+        if (!gradationSizes.isNull())
         {
             sText = gradationSizes->currentText();
         }
 
         if(LoadMeasurements(mPath))
         {
-            if (not doc->MPath().isEmpty())
+            if (!doc->MPath().isEmpty())
             {
                 watcher->removePath(AbsoluteMPath(qApp->getFilePath(), doc->MPath()));
             }
@@ -1953,12 +1953,12 @@ void MainWindow::LoadMultisize()
 
             if (qApp->patternType() == MeasurementsType::Multisize)
             {
-                if (not hText.isEmpty() && not gradationHeights.isNull())
+                if (!hText.isEmpty() && not gradationHeights.isNull())
                 {
                     gradationHeights->setCurrentText(hText);
                 }
 
-                if (not sText.isEmpty() && not gradationSizes.isNull())
+                if (!sText.isEmpty() && not gradationSizes.isNull())
                 {
                     gradationSizes->setCurrentText(sText);
                 }
@@ -2003,7 +2003,7 @@ void MainWindow::UnloadMeasurements()
 //---------------------------------------------------------------------------------------------------------------------
 void MainWindow::ShowMeasurements()
 {
-    if (not doc->MPath().isEmpty())
+    if (!doc->MPath().isEmpty())
     {
         const QString absoluteMPath = AbsoluteMPath(qApp->getFilePath(), doc->MPath());
 
@@ -2080,7 +2080,7 @@ void MainWindow::SyncMeasurements()
         const QString path = AbsoluteMPath(qApp->getFilePath(), doc->MPath());
         if(UpdateMeasurements(path, static_cast<int>(VContainer::size()), static_cast<int>(VContainer::height())))
         {
-            if (not watcher->files().contains(path))
+            if (!watcher->files().contains(path))
             {
                 watcher->addPath(path);
             }
@@ -3140,7 +3140,7 @@ void MainWindow::CancelTool()
     ui->zoomToArea_Action->setChecked(false);      //Disable Zoom to Area
     ui->view->zoomToAreaEnabled(false);
 
-    switch ( currentTool )
+    switch (currentTool)
     {
         case Tool::Arrow:
             ui->arrowPointer_ToolButton->setChecked(false);
@@ -3473,8 +3473,8 @@ void MainWindow::showDraftMode(bool checked)
         draftBlockComboBox->setCurrentIndex(currentBlockIndex); //restore current draft block
         drawMode = true;
 
-        setEnableTools(true);
-        SetEnableWidgets(true);
+        setToolsEnabled(true);
+        setWidgetsEnabled(true);
 
         draftScene->enablePiecesMode(qApp->Seamly2DSettings()->getShowControlPoints());
         draftScene->setOriginsVisible(qApp->Settings()->getShowAxisOrigin());
@@ -3530,7 +3530,7 @@ void MainWindow::showPieceMode(bool checked)
         ui->pieceMode_Action->setChecked(true);
         ui->layoutMode_Action->setChecked(false);
 
-        if(not qApp->getOpeningPattern())
+        if(!qApp->getOpeningPattern())
         {
             if (pattern->DataPieces()->count() == 0)
             {
@@ -3557,8 +3557,8 @@ void MainWindow::showPieceMode(bool checked)
             currentToolBoxIndex = ui->piece_ToolBox->currentIndex();
         }
         mode = Draw::Modeling;
-        setEnableTools(true);
-        SetEnableWidgets(true);
+        setToolsEnabled(true);
+        setWidgetsEnabled(true);
 
         pieceScene->setOriginsVisible(qApp->Settings()->getShowAxisOrigin());
 
@@ -3611,7 +3611,7 @@ void MainWindow::showLayoutMode(bool checked)
         ui->layoutMode_Action->setChecked(true);
 
         QHash<quint32, VPiece> pieces;
-        if(not qApp->getOpeningPattern())
+        if(!qApp->getOpeningPattern())
         {
             const QHash<quint32, VPiece> *allPieces = pattern->DataPieces();
             if (allPieces->count() == 0)
@@ -3674,8 +3674,8 @@ void MainWindow::showLayoutMode(bool checked)
             currentToolBoxIndex = ui->layout_ToolBox->currentIndex();
         }
         mode = Draw::Layout;
-        setEnableTools(true);
-        SetEnableWidgets(true);
+        setToolsEnabled(true);
+        setWidgetsEnabled(true);
         ui->layout_ToolBox->setCurrentIndex(ui->layout_ToolBox->indexOf(ui->layout_Page));
 
         mouseCoordinates->updateCoordinates(QPointF());
@@ -3959,7 +3959,7 @@ void MainWindow::Clear()
     setCurrentFile(QString());
     pattern->Clear();
     qCDebug(vMainWindow, "Clearing pattern.");
-    if (not qApp->getFilePath().isEmpty() && not doc->MPath().isEmpty())
+    if (!qApp->getFilePath().isEmpty() && not doc->MPath().isEmpty())
     {
         watcher->removePath(AbsoluteMPath(qApp->getFilePath(), doc->MPath()));
     }
@@ -4017,7 +4017,7 @@ void MainWindow::Clear()
     ui->unloadMeasurements_Action->setEnabled(false);
     ui->editCurrent_Action->setEnabled(false);
 
-    setEnableTools(false);
+    setToolsEnabled(false);
     qApp->setPatternUnit(Unit::Cm);
     qApp->setPatternType(MeasurementsType::Unknown);
 
@@ -4074,7 +4074,7 @@ void MainWindow::fullParseFile()
         qCCritical(vMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error parsing file.")), //-V807
                                qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
         setGuiEnabled(false);
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             qApp->exit(V_EX_NOINPUT);
         }
@@ -4085,7 +4085,7 @@ void MainWindow::fullParseFile()
         qCCritical(vMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error can't convert value.")),
                                qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
         setGuiEnabled(false);
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             qApp->exit(V_EX_NOINPUT);
         }
@@ -4096,7 +4096,7 @@ void MainWindow::fullParseFile()
         qCCritical(vMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error empty parameter.")),
                                qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
         setGuiEnabled(false);
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             qApp->exit(V_EX_NOINPUT);
         }
@@ -4107,7 +4107,7 @@ void MainWindow::fullParseFile()
         qCCritical(vMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error wrong id.")),
                                qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
         setGuiEnabled(false);
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             qApp->exit(V_EX_NOINPUT);
         }
@@ -4118,7 +4118,7 @@ void MainWindow::fullParseFile()
         qCCritical(vMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error parsing file.")),
                                qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
         setGuiEnabled(false);
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             qApp->exit(V_EX_NOINPUT);
         }
@@ -4128,17 +4128,17 @@ void MainWindow::fullParseFile()
     {
         qCCritical(vMainWindow, "%s", qUtf8Printable(tr("Error parsing file (std::bad_alloc).")));
         setGuiEnabled(false);
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             qApp->exit(V_EX_NOINPUT);
         }
         return;
     }
 
-    QString patternPiece;
+    QString draftBlock;
     if (draftBlockComboBox->currentIndex() != -1)
     {
-        patternPiece = draftBlockComboBox->itemText(draftBlockComboBox->currentIndex());
+        draftBlock = draftBlockComboBox->itemText(draftBlockComboBox->currentIndex());
     }
     draftBlockComboBox->blockSignals(true);
     draftBlockComboBox->clear();
@@ -4147,14 +4147,14 @@ void MainWindow::fullParseFile()
     draftBlockNames.sort();
     draftBlockComboBox->addItems(draftBlockNames);
 
-    if (not drawMode)
+    if (!drawMode)
     {
         draftBlockComboBox->setCurrentIndex(draftBlockComboBox->count()-1);
     }
     else
     {
-        const qint32 index = draftBlockComboBox->findText(patternPiece);
-        if ( index != -1 )
+        const qint32 index = draftBlockComboBox->findText(draftBlock);
+        if (index != -1)
         {
             draftBlockComboBox->setCurrentIndex(index);
         }
@@ -4162,9 +4162,9 @@ void MainWindow::fullParseFile()
     draftBlockComboBox->blockSignals(false);
     ui->patternPreferences_Action->setEnabled(true);
 
-    globalDraftBlockChange(patternPiece);
+    changeDraftBlockGlobally(draftBlock);
 
-    setEnableTools(draftBlockComboBox->count() > 0);
+    setToolsEnabled(draftBlockComboBox->count() > 0);
     patternPiecesWidget->updateList();
 
     VMainGraphicsView::NewSceneRect(draftScene, qApp->getSceneView());
@@ -4172,14 +4172,17 @@ void MainWindow::fullParseFile()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void MainWindow::globalDraftBlockChange(const QString &patternPiece)
+void MainWindow::changeDraftBlockGlobally(const QString &draftBlock)
 {
-    const qint32 index = draftBlockComboBox->findText(patternPiece);
+    const qint32 index = draftBlockComboBox->findText(draftBlock);
     try
     {
-        if ( index != -1 )
+        if (index != -1)
         { // -1 for not found
             changeDraftBlock(index, false);
+            draftBlockComboBox->blockSignals(true);
+            draftBlockComboBox->setCurrentIndex(index);
+            draftBlockComboBox->blockSignals(false);
         }
         else
         {
@@ -4191,7 +4194,7 @@ void MainWindow::globalDraftBlockChange(const QString &patternPiece)
         qCCritical(vMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Bad id.")),
                    qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
         setGuiEnabled(false);
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             qApp->exit(V_EX_NOINPUT);
         }
@@ -4202,7 +4205,7 @@ void MainWindow::globalDraftBlockChange(const QString &patternPiece)
         qCCritical(vMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error empty parameter.")),
                    qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
         setGuiEnabled(false);
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             qApp->exit(V_EX_NOINPUT);
         }
@@ -4220,11 +4223,11 @@ void MainWindow::setGuiEnabled(bool enabled)
             handleArrowTool(true);
             qApp->getUndoStack()->clear();
         }
-        SetEnableWidgets(enabled);
+        setWidgetsEnabled(enabled);
 
         guiEnabled = enabled;
 
-        setEnableTools(enabled);
+        setToolsEnabled(enabled);
         ui->statusBar->setEnabled(enabled);
     #ifndef QT_NO_CURSOR
         QGuiApplication::setOverrideCursor(Qt::ArrowCursor);
@@ -4234,10 +4237,10 @@ void MainWindow::setGuiEnabled(bool enabled)
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief SetEnableWidgets enable action button.
+ * @brief setWidgetsEnabled enable action button.
  * @param enable enable value.
  */
-void MainWindow::SetEnableWidgets(bool enable)
+void MainWindow::setWidgetsEnabled(bool enable)
 {
     const bool draftStage = (mode == Draw::Calculation);
     const bool pieceStage = (mode == Draw::Modeling);
@@ -4316,7 +4319,7 @@ void MainWindow::SetEnableWidgets(bool enable)
     actionDockWidgetLayouts->setEnabled(enable && layoutStage);
 
     //Now we don't want allow user call context menu
-    draftScene->SetDisableTools(!enable, doc->getActiveDraftBlockName());
+    draftScene->setToolsDisabled(!enable, doc->getActiveDraftBlockName());
     ui->view->setEnabled(enable);
 }
 
@@ -4533,10 +4536,10 @@ void MainWindow::SetDefaultSize()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief setEnableTools enable button.
+ * @brief setToolsEnabled enable button.
  * @param enable enable value.
  */
-void MainWindow::setEnableTools(bool enable)
+void MainWindow::setToolsEnabled(bool enable)
 {
     bool draftTools = false;
     bool pieceTools = false;
@@ -4737,7 +4740,7 @@ bool MainWindow::SavePattern(const QString &fileName, QString &error)
     QFileInfo tempInfo(fileName);
 
     const QString mPath = AbsoluteMPath(qApp->getFilePath(), doc->MPath());
-    if (not mPath.isEmpty() && qApp->getFilePath() != fileName)
+    if (!mPath.isEmpty() && qApp->getFilePath() != fileName)
     {
         doc->SetMPath(RelativeMPath(fileName, mPath));
     }
@@ -4796,7 +4799,7 @@ void MainWindow::setCurrentFile(const QString &fileName)
     emit doc->UpdatePatternLabel();
     qApp->getUndoStack()->setClean();
 
-    if (not qApp->getFilePath().isEmpty() && VApplication::IsGUIMode())
+    if (!qApp->getFilePath().isEmpty() && VApplication::IsGUIMode())
     {
         qCDebug(vMainWindow, "Updating recent file list.");
         VSettings *settings = qApp->Seamly2DSettings();
@@ -5040,7 +5043,7 @@ void MainWindow::LastUsedTool()
         return;
     }
 
-    switch ( lastUsedTool )
+    switch (lastUsedTool)
     {
         case Tool::Arrow:
             ui->arrowPointer_ToolButton->setChecked(true);
@@ -5351,7 +5354,7 @@ void MainWindow::CreateActions()
             if (QAction *action = qobject_cast<QAction*>(sender()))
             {
                 const QString filePath = action->data().toString();
-                if (not filePath.isEmpty())
+                if (!filePath.isEmpty())
                 {
                     LoadPattern(filePath);
                 }
@@ -5936,7 +5939,7 @@ void MainWindow::InitAutoSave()
 QString MainWindow::createDraftBlockName(const QString &text)
 {
     QInputDialog *dialog = new QInputDialog(this);
-    dialog->setInputMode( QInputDialog::TextInput );
+    dialog->setInputMode(QInputDialog::TextInput);
     dialog->setLabelText(tr("Name:"));
     dialog->setTextEchoMode(QLineEdit::Normal);
     dialog->setWindowTitle(tr("Draft block."));
@@ -6044,7 +6047,7 @@ bool MainWindow::LoadPattern(const QString &fileName, const QString& customMeasu
         qCCritical(vMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("File error.")),
                    qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
         Clear();
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             qApp->exit(V_EX_NOINPUT);
         }
@@ -6060,7 +6063,7 @@ bool MainWindow::LoadPattern(const QString &fileName, const QString& customMeasu
     }
     else
     {
-        if (not IgnoreLocking(lock->GetLockError(), fileName))
+        if (!IgnoreLocking(lock->GetLockError(), fileName))
         {
             return false;
         }
@@ -6084,7 +6087,7 @@ bool MainWindow::LoadPattern(const QString &fileName, const QString& customMeasu
         qApp->setPatternUnit(doc->MUnit());
         const QString path = AbsoluteMPath(fileName, doc->MPath());
 
-        if (not path.isEmpty())
+        if (!path.isEmpty())
         {
             // Check if exist
             const QString newPath = CheckPathToMeasurements(fileName, path);
@@ -6094,20 +6097,20 @@ bool MainWindow::LoadPattern(const QString &fileName, const QString& customMeasu
                 Clear();
                 qCCritical(vMainWindow, "%s", qUtf8Printable(tr("The measurements file '%1' could not be found.")
                                                              .arg(path)));
-                if (not VApplication::IsGUIMode())
+                if (!VApplication::IsGUIMode())
                 {
                     qApp->exit(V_EX_NOINPUT);
                 }
                 return false;
             }
 
-            if (not LoadMeasurements(newPath))
+            if (!LoadMeasurements(newPath))
             {
                 qCCritical(vMainWindow, "%s", qUtf8Printable(tr("The measurements file '%1' could not be found.")
                                                              .arg(newPath)));
                 qApp->setOpeningPattern();// End opening file
                 Clear();
-                if (not VApplication::IsGUIMode())
+                if (!VApplication::IsGUIMode())
                 {
                     qApp->exit(V_EX_NOINPUT);
                 }
@@ -6132,7 +6135,7 @@ bool MainWindow::LoadPattern(const QString &fileName, const QString& customMeasu
                    qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
         qApp->setOpeningPattern();// End opening file
         Clear();
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             qApp->exit(V_EX_NOINPUT);
         }
@@ -6144,7 +6147,7 @@ bool MainWindow::LoadPattern(const QString &fileName, const QString& customMeasu
     if (guiEnabled)
     { // No errors occurred
         patternReadOnly = doc->IsReadOnly();
-        SetEnableWidgets(true);
+        setWidgetsEnabled(true);
         setCurrentFile(fileName);
         helpLabel->setText(tr("File loaded"));
         qCDebug(vMainWindow, "File loaded.");
@@ -6653,7 +6656,7 @@ QString MainWindow::CheckPathToMeasurements(const QString &patternPath, const QS
 
                     bool usedNotExistedDir = false;
                     QDir directory(path);
-                    if (not directory.exists())
+                    if (!directory.exists())
                     {
                         usedNotExistedDir = directory.mkpath(".");
                     }
@@ -6677,7 +6680,7 @@ QString MainWindow::CheckPathToMeasurements(const QString &patternPath, const QS
 
                     bool usedNotExistedDir = false;
                     QDir directory(path);
-                    if (not directory.exists())
+                    if (!directory.exists())
                     {
                         usedNotExistedDir = directory.mkpath(".");
                     }
@@ -6722,7 +6725,7 @@ QString MainWindow::CheckPathToMeasurements(const QString &patternPath, const QS
                         measurements->setXMLContent(converter.Convert());// Read again after conversion
                     }
 
-                    if (not measurements->IsDefinedKnownNamesValid())
+                    if (!measurements->IsDefinedKnownNamesValid())
                     {
                         VException e(tr("Measurement file contains invalid known measurement(s)."));
                         throw e;
@@ -6765,7 +6768,7 @@ void MainWindow::changeDraftBlock(int index, bool zoomBestFit)
 //---------------------------------------------------------------------------------------------------------------------
 void MainWindow::EndVisualization(bool click)
 {
-    if (not dialogTool.isNull())
+    if (!dialogTool.isNull())
     {
         dialogTool->ShowDialog(click);
     }
@@ -6785,7 +6788,7 @@ void MainWindow::zoomFirstShow()
         showPieceMode(true);
         ui->view->zoomToFit();
     }
-    if (not ui->showDraftMode->isChecked())
+    if (!ui->showDraftMode->isChecked())
     {
         showDraftMode(true);
     }
@@ -6800,7 +6803,7 @@ void MainWindow::zoomFirstShow()
         ui->view->zoomToFit();
     }
 
-    if (not ui->showDraftMode->isChecked())
+    if (!ui->showDraftMode->isChecked())
     {
         showDraftMode(true);
     }
@@ -6810,7 +6813,7 @@ void MainWindow::zoomFirstShow()
 void MainWindow::DoExport(const VCommandLinePtr &expParams)
 {
     const QHash<quint32, VPiece> *pieces = pattern->DataPieces();
-    if(not qApp->getOpeningPattern())
+    if(!qApp->getOpeningPattern())
     {
         if (pieces->count() == 0)
         {
@@ -6876,7 +6879,7 @@ void MainWindow::DoExport(const VCommandLinePtr &expParams)
 //---------------------------------------------------------------------------------------------------------------------
 bool MainWindow::SetSize(const QString &text)
 {
-    if (not VApplication::IsGUIMode())
+    if (!VApplication::IsGUIMode())
     {
         if (this->isWindowModified() || not qApp->getFilePath().isEmpty())
         {
@@ -6919,7 +6922,7 @@ bool MainWindow::SetSize(const QString &text)
 //---------------------------------------------------------------------------------------------------------------------
 bool MainWindow::SetHeight(const QString &text)
 {
-    if (not VApplication::IsGUIMode())
+    if (!VApplication::IsGUIMode())
     {
         if (this->isWindowModified() || not qApp->getFilePath().isEmpty())
         {
@@ -6985,7 +6988,7 @@ void MainWindow::ProcessCMD()
     {
         const bool loaded = LoadPattern(args.at(static_cast<int>(i)), cmd->OptMeasurePath());
 
-        if (not loaded && not VApplication::IsGUIMode())
+        if (!loaded && not VApplication::IsGUIMode())
         {
             return; // process only one input file
         }
@@ -7005,7 +7008,7 @@ void MainWindow::ProcessCMD()
             }
         }
 
-        if (not cmd->IsTestModeEnabled())
+        if (!cmd->IsTestModeEnabled())
         {
             if (cmd->IsExportEnabled())
             {
@@ -7024,7 +7027,7 @@ void MainWindow::ProcessCMD()
         }
     }
 
-    if (not VApplication::IsGUIMode())
+    if (!VApplication::IsGUIMode())
     {
         qApp->exit(V_EX_OK);// close program after processing in console mode
     }
@@ -7034,7 +7037,7 @@ void MainWindow::ProcessCMD()
 QString MainWindow::GetPatternFileName()
 {
     QString shownName = tr("untitled.val");
-    if(not qApp->getFilePath().isEmpty())
+    if(!qApp->getFilePath().isEmpty())
     {
         shownName = qApp->getFilePath();
     }
@@ -7161,20 +7164,20 @@ bool MainWindow::IgnoreLocking(int error, const QString &path)
             case QLockFile::LockFailedError:
                 answer = QMessageBox::warning(this, tr("Locking file"),
                                                tr("This file already opened in another window. Ignore if you want "
-                                                  "to continue (not recommended, can cause a data corruption)."),
+                                                  "to continue (!recommended, can cause a data corruption)."),
                                                QMessageBox::Abort|QMessageBox::Ignore, QMessageBox::Abort);
                 break;
             case QLockFile::PermissionError:
                 answer = QMessageBox::question(this, tr("Locking file"),
                                                tr("The lock file could not be created, for lack of permissions. "
-                                                  "Ignore if you want to continue (not recommended, can cause "
+                                                  "Ignore if you want to continue (!recommended, can cause "
                                                   "a data corruption)."),
                                                QMessageBox::Abort|QMessageBox::Ignore, QMessageBox::Abort);
                 break;
             case QLockFile::UnknownError:
                 answer = QMessageBox::question(this, tr("Locking file"),
                                                tr("Unknown error happened, for instance a full partition prevented "
-                                                  "writing out the lock file. Ignore if you want to continue (not "
+                                                  "writing out the lock file. Ignore if you want to continue (!"
                                                   "recommended, can cause a data corruption)."),
                                                QMessageBox::Abort|QMessageBox::Ignore, QMessageBox::Abort);
                 break;
@@ -7189,7 +7192,7 @@ bool MainWindow::IgnoreLocking(int error, const QString &path)
         qCDebug(vMainWindow, "Failed to lock %s", qUtf8Printable(path));
         qCDebug(vMainWindow, "Error type: %d", error);
         Clear();
-        if (not VApplication::IsGUIMode())
+        if (!VApplication::IsGUIMode())
         {
             switch(error)
             {

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -7177,7 +7177,7 @@ bool MainWindow::IgnoreLocking(int error, const QString &path)
             case QLockFile::UnknownError:
                 answer = QMessageBox::question(this, tr("Locking file"),
                                                tr("Unknown error happened, for instance a full partition prevented "
-                                                  "writing out the lock file. Ignore if you want to continue (not"
+                                                  "writing out the lock file. Ignore if you want to continue (not "
                                                   "recommended, can cause a data corruption)."),
                                                QMessageBox::Abort|QMessageBox::Ignore, QMessageBox::Abort);
                 break;

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -158,7 +158,7 @@ private slots:
     void LastUsedTool();
     void fullParseFile();
     void setGuiEnabled(bool enabled);
-    void globalDraftBlockChange(const QString &patternPiece);
+    void changeDraftBlockGlobally(const QString &patternPiece);
     void ToolBarStyles();
     void resetOrigins();
     void showLayoutPages(int index);
@@ -359,8 +359,8 @@ private:
 
     void                              CancelTool();
 
-    void               SetEnableWidgets(bool enable);
-    void               setEnableTools(bool enable);
+    void               setWidgetsEnabled(bool enable);
+    void               setToolsEnabled(bool enable);
     void               SetLayoutModeActions();
 
     void               SaveCurrentScene();

--- a/src/libs/vwidgets/vmaingraphicsscene.cpp
+++ b/src/libs/vwidgets/vmaingraphicsscene.cpp
@@ -296,7 +296,7 @@ void VMainGraphicsScene::swapTransforms()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VMainGraphicsScene::SetDisableTools(bool disable, const QString &draftBlockName)
+void VMainGraphicsScene::setToolsDisabled(bool disable, const QString &draftBlockName)
 {
     emit DisableItem(disable, draftBlockName);
 }

--- a/src/libs/vwidgets/vmaingraphicsscene.h
+++ b/src/libs/vwidgets/vmaingraphicsscene.h
@@ -81,7 +81,7 @@ public:
     QTransform    transform() const;
     void          setCurrentTransform(const QTransform &transform);
     void          swapTransforms();
-    void          SetDisableTools(bool disable, const QString &draftBlockName);
+    void          setToolsDisabled(bool disable, const QString &draftBlockName);
     QPointF       getScenePos() const;
 
     QRectF        visibleItemsBoundingRect() const;


### PR DESCRIPTION
This restores the starting draft block back to the first "A" block.  

Also cleans up some more naming style.

Closes issue #992 