### PR TITLE
Corrected the QT version used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,8 +198,8 @@ jobs:
       - name: install msvc
         uses: ilammy/msvc-dev-cmd@v1
         with:
-          # use Visual C++ 2022 latest, 14.34.xxxx
-          toolset: '14.34'
+          # use Visual C++ 2022 latest, 14.36.xxxx
+          toolset: '14.36'
 
       - uses: jurplel/install-qt-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
   contents: write
 
 env:
-  QT_VERSION: '6.2.4' # quotes required or YAML parser will interpret as float
+  QT_VERSION: '6.5.1' # quotes required or YAML parser will interpret as float
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: install build dependencies
         run: |
           # libgstreamer-plugins-base1.0-0 and libgstreamer-gl1.0-0 required to link against QtMultimedia
-          sudo apt update && sudo apt install -y libxerces-c-dev libgstreamer-plugins-base1.0-0 libgstreamer-gl1.0-0
+          sudo apt update && sudo apt install -y libxerces-c-dev libgstreamer-plugins-base1.0-0 libgstreamer-gl1.0-0 libxcb-cursor0
 
       - name: update version
         run: |


### PR DESCRIPTION
The QT version in the CI pipeline did not match what was used during porting to QT6. It should've been 6.5.