### PR TITLE
fix: excessive logging

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -48,6 +48,8 @@ win32 {
 # Source: https://stackoverflow.com/questions/48705747/how-utf-8-may-not-work-in-qt-5
 win32:!win32-g++: QMAKE_CXXFLAGS += /utf-8
 
+CONFIG(release, debug|release):DEFINES += QT_NO_DEBUG_OUTPUT
+
 CONFIG(debug, debug|release){
     # Debug mode, intentionally left empty
 } else {
@@ -137,7 +139,7 @@ CONFIG(debug, debug|release){
     DVCS_HESH=$$system("git rev-parse --short=12 HEAD") #get SHA1 commit hash
     message("common.pri: Latest commit hash:" $${DVCS_HESH})
 
-    isEmpty(DVCS_HESH){       
+    isEmpty(DVCS_HESH){
        DVCS_HESH = \\\"unknown\\\" # if we can't find build revision left unknown.
     } else {
        DVCS_HESH=\\\"Git:$${DVCS_HESH}\\\"

--- a/src/app/seamly2d/core/vapplication.cpp
+++ b/src/app/seamly2d/core/vapplication.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vapplication.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,28 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
- **  @file   vapplication.cpp
+ **  @file   vexceptionemptyparameter.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -157,35 +158,35 @@ inline void noisyFailureMsgHandler(QtMsgType type, const QMessageLogContext &con
             case QtDebugMsg:
                 debugdate += QString(":DEBUG:%1(%2)] %3: %4: %5").arg(context.file).arg(context.line)
                              .arg(context.function).arg(context.category).arg(msg);
-                vStdOut() << QApplication::translate("vNoisyHandler", "DEBUG:") << msg << "\n";
+                vStdOut()  <<  QApplication::translate("vNoisyHandler", "DEBUG:")  <<  msg  <<  "\n";
                 break;
             case QtWarningMsg:
                 debugdate += QString(":WARNING:%1(%2)] %3: %4: %5").arg(context.file).arg(context.line)
                              .arg(context.function).arg(context.category).arg(msg);
-                vStdErr() << QApplication::translate("vNoisyHandler", "WARNING:") << msg << "\n";
+                vStdErr()  <<  QApplication::translate("vNoisyHandler", "WARNING:")  <<  msg  <<  "\n";
                 break;
             case QtCriticalMsg:
                 debugdate += QString(":CRITICAL:%1(%2)] %3: %4: %5").arg(context.file).arg(context.line)
                              .arg(context.function).arg(context.category).arg(msg);
-                vStdErr() << QApplication::translate("vNoisyHandler", "CRITICAL:") << msg << "\n";
+                vStdErr()  <<  QApplication::translate("vNoisyHandler", "CRITICAL:")  <<  msg  <<  "\n";
                 break;
             case QtFatalMsg:
                 debugdate += QString(":FATAL:%1(%2)] %3: %4: %5").arg(context.file).arg(context.line)
                              .arg(context.function).arg(context.category).arg(msg);
-                vStdErr() << QApplication::translate("vNoisyHandler", "FATAL:") << msg << "\n";
+                vStdErr()  <<  QApplication::translate("vNoisyHandler", "FATAL:")  <<  msg  <<  "\n";
                 break;
             #if QT_VERSION > QT_VERSION_CHECK(5, 4, 2)
             case QtInfoMsg:
                 debugdate += QString(":INFO:%1(%2)] %3: %4: %5").arg(context.file).arg(context.line)
                              .arg(context.function).arg(context.category).arg(msg);
-                vStdOut() << QApplication::translate("vNoisyHandler", "INFO:") << msg << "\n";
+                vStdOut()  <<  QApplication::translate("vNoisyHandler", "INFO:")  <<  msg  <<  "\n";
                 break;
             #endif
             default:
                 break;
         }
 
-        (*qApp->LogFile()) << debugdate << Qt::endl;
+        (*qApp->LogFile())  <<  debugdate  <<  Qt::endl;
     }
 
     if (isGuiThread)
@@ -356,60 +357,60 @@ bool VApplication::notify(QObject *receiver, QEvent *event)
     {
         return QApplication::notify(receiver, event);
     }
-    catch (const VExceptionObjectError &e)
+    catch (const VExceptionObjectError &error)
     {
         qCCritical(vApp, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error parsing file. Program will be terminated.")), //-V807
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         exit(V_EX_DATAERR);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         qCCritical(vApp, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error bad id. Program will be terminated.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         exit(V_EX_DATAERR);
     }
-    catch (const VExceptionConversionError &e)
+    catch (const VExceptionConversionError &error)
     {
         qCCritical(vApp, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error can't convert value. Program will be terminated.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         exit(V_EX_DATAERR);
     }
-    catch (const VExceptionEmptyParameter &e)
+    catch (const VExceptionEmptyParameter &error)
     {
         qCCritical(vApp, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error empty parameter. Program will be terminated.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         exit(V_EX_DATAERR);
     }
-    catch (const VExceptionWrongId &e)
+    catch (const VExceptionWrongId &error)
     {
         qCCritical(vApp, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error wrong id. Program will be terminated.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         exit(V_EX_DATAERR);
     }
-    catch (const VExceptionToolWasDeleted &e)
+    catch (const VExceptionToolWasDeleted &error)
     {
         qCCritical(vApp, "%s\n\n%s\n\n%s",
                    qUtf8Printable("Unhadled deleting tool. Continue use object after deleting"),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         exit(V_EX_DATAERR);
     }
-    catch (const VException &e)
+    catch (const VException &error)
     {
         qCCritical(vApp, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Something's wrong!!")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         return true;
     }
     // These last two cases are special. I found that we can't show here a modal dialog with an error message.
     // Somehow program doesn't wait until an error dialog will be closed. But if ignore the exception the program will
     // hang.
-    catch (const qmu::QmuParserError &e)
+    catch (const qmu::QmuParserError &error)
     {
-        qCCritical(vApp, "%s", qUtf8Printable(tr("Parser error: %1. Program will be terminated.").arg(e.GetMsg())));
+        qCCritical(vApp, "%s", qUtf8Printable(tr("Parser error: %1. Program will be terminated.").arg(error.GetMsg())));
         exit(V_EX_DATAERR);
     }
-    catch (std::exception& e)
+    catch (std::exception &error)
     {
-        qCCritical(vApp, "%s", qUtf8Printable(tr("Exception thrown: %1. Program will be terminated.").arg(e.what())));
+        qCCritical(vApp, "%s", qUtf8Printable(tr("Exception thrown: %1. Program will be terminated.").arg(error.what())));
         exit(V_EX_SOFTWARE);
     }
     return false;
@@ -510,17 +511,17 @@ void VApplication::BeginLogging()
         {
             out.reset(new QTextStream(lockLog->GetProtected().get()));
             qInstallMessageHandler(noisyFailureMsgHandler);
-            qCDebug(vApp, "Log file %s was locked.", qUtf8Printable(LogPath()));
+            qCInfo(vApp, "Log file %s was locked.", qUtf8Printable(LogPath()));
         }
         else
         {
-            qCDebug(vApp, "Error opening log file \'%s\'. All debug output redirected to console.",
+            qCWarning(vApp, "Error opening log file \'%s\'. All debug output redirected to console.",
                     qUtf8Printable(LogPath()));
         }
     }
     else
     {
-        qCDebug(vApp, "Failed to lock %s", qUtf8Printable(LogPath()));
+        qCWarning(vApp, "Failed to lock %s", qUtf8Printable(LogPath()));
     }
 }
 
@@ -550,12 +551,12 @@ void VApplication::ClearOldLogs() const
                     }
                     else
                     {
-                        qCDebug(vApp, "Could not delete %s", qUtf8Printable(info.absoluteFilePath()));
+                        qCWarning(vApp, "Could not delete %s", qUtf8Printable(info.absoluteFilePath()));
                     }
                 }
                 else
                 {
-                    qCDebug(vApp, "Failed to lock %s", qUtf8Printable(info.absoluteFilePath()));
+                    qCWarning(vApp, "Failed to lock %s", qUtf8Printable(info.absoluteFilePath()));
                 }
             }
         }
@@ -578,12 +579,12 @@ void VApplication::InitOptions()
     // Run creation log after sending crash report
     StartLogging();
 
-    qDebug()<<"Version:"<<APP_VERSION_STR;
-    qDebug()<<"Build revision:"<<BUILD_REVISION;
-    qDebug()<<buildCompatibilityString();
-    qDebug()<<"Built on"<<__DATE__<<"at"<<__TIME__;
-    qDebug()<<"Command-line arguments:"<<arguments();
-    qDebug()<<"Process ID:"<<applicationPid();
+    qInfo() << "Version:" << APP_VERSION_STR;
+    qInfo() << "Build revision:" << BUILD_REVISION;
+    qInfo() << buildCompatibilityString();
+    qInfo() << "Built on" << __DATE__ << "at" << __TIME__;
+    qInfo() << "Command-line arguments:" << arguments();
+    qInfo() << "Process ID:" << applicationPid();
 
     if (VApplication::IsGUIMode())// By default console version uses system locale
     {
@@ -613,14 +614,14 @@ void VApplication::InitOptions()
 //---------------------------------------------------------------------------------------------------------------------
 QStringList VApplication::LabelLanguages()
 {
-    QStringList list = QStringList() << "de" // German
-                                     << "en" // English
-                                     << "fr" // French
-                                     << "ru" // Russian
-                                     << "uk" // Ukrainian
-                                     << "hr" // Croatian
-                                     << "sr" // Serbian
-                                     << "bs"; // Bosnian
+    QStringList list = QStringList()  <<  "de" // German
+                                      <<  "en" // English
+                                      <<  "fr" // French
+                                      <<  "ru" // Russian
+                                      <<  "uk" // Ukrainian
+                                      <<  "hr" // Croatian
+                                      <<  "sr" // Serbian
+                                      <<  "bs"; // Bosnian
     return list;
 }
 
@@ -659,15 +660,15 @@ void VApplication::InitTrVars()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-bool VApplication::event(QEvent *e)
+bool VApplication::event(QEvent *event)
 {
-    switch(e->type())
+    switch(event->type())
     {
         // In Mac OS X the QFileOpenEvent event is generated when user perform "Open With" from Finder (this event is
         // Mac specific).
         case QEvent::FileOpen:
         {
-            QFileOpenEvent *fileOpenEvent = static_cast<QFileOpenEvent *>(e);
+            QFileOpenEvent *fileOpenEvent = static_cast<QFileOpenEvent *>(event);
             const QString macFileOpen = fileOpenEvent->file();
             if(not macFileOpen.isEmpty())
             {
@@ -691,9 +692,9 @@ bool VApplication::event(QEvent *e)
         }
 #endif //defined(Q_OS_MAC)
         default:
-            return VAbstractApplication::event(e);
+            return VAbstractApplication::event(event);
     }
-    return VAbstractApplication::event(e);
+    return VAbstractApplication::event(event);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -796,30 +797,30 @@ void VApplication::GatherLogs() const
 
                 if (tmp.IsLocked())
                 {
-                    *out <<"--------------------------" << Qt::endl;
+                    *out  << "--------------------------"  <<  Qt::endl;
                     if (tmp.GetProtected()->open(QIODevice::ReadOnly | QIODevice::Text))
                     {
                         QTextStream in(tmp.GetProtected().get());
                         while (!in.atEnd())
                         {
-                            *out << in.readLine() << Qt::endl;
+                            *out  <<  in.readLine()  <<  Qt::endl;
                         }
                         tmp.GetProtected()->close();
                     }
                     else
                     {
-                        *out << "Log file error:" + tmp.GetProtected()->errorString() << Qt::endl;
+                        *out  <<  "Log file error:" + tmp.GetProtected()->errorString()  <<  Qt::endl;
                     }
                 }
                 else
                 {
-                    qCDebug(vApp, "Failed to lock %s", qUtf8Printable(info.absoluteFilePath()));
+                    qCWarning(vApp, "Failed to lock %s", qUtf8Printable(info.absoluteFilePath()));
                 }
             }
         }
         else
         {
-            *out << "Could not find logs.";
+            *out  <<  "Could not find logs.";
         }
         log->close();
     }
@@ -994,8 +995,8 @@ void VApplication::SendReport(const QString &reportName) const
     if (curlFile.exists())
     {// Trying send report
         // Change token if need
-        const QStringList token = QStringList()<<"eb"<<"78"<<"63"<<"4e"<<"de"<<"77"<<"f7"<<"e6"<<"01"<<"4a"<<"c3"<<"60"
-                                               <<"96"<<"b0"<<"2d"<<"54"<<"fb"<<"8e"<<"af"<<"ec";
+        const QStringList token = QStringList() << "eb" << "78" << "63" << "4e" << "de" << "77" << "f7" << "e6" << "01" << "4a" << "c3" << "60"
+                                                << "96" << "b0" << "2d" << "54" << "fb" << "8e" << "af" << "ec";
 
         const QString arg = QString("curl.exe -k -H \"Authorization: bearer ")+token.join("")+
                             QString("\" -H \"Accept: application/json\" -H \"Content-type: application/json\" -X POST "

--- a/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
+++ b/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
 *   @file   vtooloptionspropertybrowser.cpp
 **  @author Douglas S Caskey
-**  @date   30 Apr, 2023
+**  @date   17 Sep, 2023
 **
 **  @brief
 **  @copyright
@@ -637,7 +637,7 @@ template<class Tool>
 void VToolOptionsPropertyBrowser::addPropertyCrossPoint(Tool *tool, const QString &propertyName)
 {
     VPE::VEnumProperty* itemProperty = new VPE::VEnumProperty(propertyName);
-    itemProperty->setLiterals(QStringList()<< tr("First point") << tr("Second point"));
+    itemProperty->setLiterals(QStringList() <<  tr("First point") << tr("Second point"));
     itemProperty->setValue(static_cast<int>(tool->GetCrossCirclesPoint())-1);
     addProperty(itemProperty, AttrCrossPoint);
 }
@@ -647,7 +647,7 @@ template<class Tool>
 void VToolOptionsPropertyBrowser::addPropertyVCrossPoint(Tool *tool, const QString &propertyName)
 {
     auto *itemProperty = new VPE::VEnumProperty(propertyName);
-    itemProperty->setLiterals(QStringList()<< tr("Highest point") << tr("Lowest point"));
+    itemProperty->setLiterals(QStringList() <<  tr("Highest point") << tr("Lowest point"));
     itemProperty->setValue(static_cast<int>(tool->GetVCrossPoint())-1);
     addProperty(itemProperty, AttrVCrossPoint);
 }
@@ -657,7 +657,7 @@ template<class Tool>
 void VToolOptionsPropertyBrowser::addPropertyHCrossPoint(Tool *tool, const QString &propertyName)
 {
     auto *itemProperty = new VPE::VEnumProperty(propertyName);
-    itemProperty->setLiterals(QStringList()<< tr("Leftmost point") << tr("Rightmost point"));
+    itemProperty->setLiterals(QStringList() <<  tr("Leftmost point") << tr("Rightmost point"));
     itemProperty->setValue(static_cast<int>(tool->GetHCrossPoint())-1);
     addProperty(itemProperty, AttrHCrossPoint);
 }
@@ -667,7 +667,7 @@ template<class Tool>
 void VToolOptionsPropertyBrowser::addPropertyAxisType(Tool *tool, const QString &propertyName)
 {
     auto *itemProperty = new VPE::VEnumProperty(propertyName);
-    itemProperty->setLiterals(QStringList()<< tr("Vertical axis") << tr("Horizontal axis"));
+    itemProperty->setLiterals(QStringList() <<  tr("Vertical axis") << tr("Horizontal axis"));
     itemProperty->setValue(static_cast<int>(tool->getAxisType())-1);
     addProperty(itemProperty, AttrAxisType);
 }
@@ -688,7 +688,7 @@ void VToolOptionsPropertyBrowser::addPropertyLineType(Tool *tool, const QString 
     const qint32 index = VPE::LineTypeProperty::indexOfLineType(lineTypes, tool->getLineType());
     if (index == -1)
     {
-        qWarning()<<"Can't find line type" << tool->getLineType()<<"in list";
+        qWarning() << "Can't find line type" << tool->getLineType() << "in list";
     }
     lineTypeProperty->setValue(index);
     addProperty(lineTypeProperty, AttrLineType);
@@ -703,7 +703,7 @@ void VToolOptionsPropertyBrowser::addPropertyCurveLineType(Tool *tool, const QSt
     const qint32 index = VPE::LineTypeProperty::indexOfLineType(curveLineTypeList(), tool->GetPenStyle());
     if (index == -1)
     {
-        qWarning()<<"Can't find line type" << tool->getLineType()<<"in list";
+        qWarning() << "Can't find line type" << tool->getLineType() <<  "in list";
     }
     penStyleProperty->setValue(index);
     addProperty(penStyleProperty, AttrPenStyle);
@@ -718,7 +718,7 @@ void VToolOptionsPropertyBrowser::addPropertyLineWeight(Tool *tool, const QStrin
     const qint32 index = VPE::LineWeightProperty::indexOfLineWeight(lineWeightList(), tool->getLineWeight());
     if (index == -1)
     {
-        qWarning()<<"Can't find line weight" << tool->getLineWeight()<<"in list";
+        qWarning() << "Can't find line weight" << tool->getLineWeight() <<  "in list";
     }
     lineWeightProperty->setValue(index);
     addProperty(lineWeightProperty, AttrLineWeight);
@@ -733,7 +733,7 @@ void VToolOptionsPropertyBrowser::addPropertyLineColor(Tool *tool, const QString
     const qint32 index = VPE::VLineColorProperty::indexOfColor(VAbstractTool::ColorsList(), tool->getLineColor());
     if (index == -1)
     {
-        qWarning()<<"Can't find line color" << tool->getLineColor()<<"in list";
+        qWarning() << "Can't find line color" << tool->getLineColor() <<  "in list";
     }
     lineColorProperty->setValue(index);
     addProperty(lineColorProperty, id);
@@ -750,7 +750,7 @@ void VToolOptionsPropertyBrowser::addObjectProperty(Tool *tool, const QString &p
     const qint32 index = VPE::VObjectProperty::indexOfObject(list, pointName);
     if (index == -1)
     {
-        qWarning()<<"Can't find point" << pointName << "in list";
+        qWarning() << "Can't find point" << pointName << "in list";
     }
     pointsProperty->setValue(index);
     addProperty(pointsProperty, id);
@@ -916,7 +916,7 @@ void VToolOptionsPropertyBrowser::setPointName(const QString &name)
     }
     else
     {
-        qWarning()<<"Can't cast item";
+        qWarning() << "Can't cast item";
     }
 }
 
@@ -943,7 +943,7 @@ void VToolOptionsPropertyBrowser::setPointName1(const QString &name)
     }
     else
     {
-        qWarning()<<"Can't cast item";
+        qWarning() << "Can't cast item";
     }
 }
 
@@ -970,7 +970,7 @@ void VToolOptionsPropertyBrowser::setPointName2(const QString &name)
     }
     else
     {
-        qWarning()<<"Can't cast item";
+        qWarning() << "Can't cast item";
     }
 }
 
@@ -1007,7 +1007,7 @@ void VToolOptionsPropertyBrowser::setOperationSuffix(const QString &suffix)
     }
     else
     {
-        qWarning()<<"Can't cast item";
+        qWarning() << "Can't cast item";
     }
 }
 
@@ -1045,7 +1045,7 @@ void VToolOptionsPropertyBrowser::setCirclesCrossPoint(const QVariant &value)
     }
     else
     {
-        qWarning()<<"Can't cast item";
+        qWarning() << "Can't cast item";
     }
 }
 
@@ -1059,7 +1059,7 @@ void VToolOptionsPropertyBrowser::setCurveVCrossPoint(const QVariant &value)
     }
     else
     {
-        qWarning()<<"Can't cast item";
+        qWarning() << "Can't cast item";
     }
 }
 
@@ -1073,7 +1073,7 @@ void VToolOptionsPropertyBrowser::setCurveHCrossPoint(const QVariant &value)
     }
     else
     {
-        qWarning()<<"Can't cast item";
+        qWarning() << "Can't cast item";
     }
 }
 
@@ -1087,7 +1087,7 @@ void VToolOptionsPropertyBrowser::setAxisType(const QVariant &value)
     }
     else
     {
-        qWarning()<<"Can't cast item";
+        qWarning() << "Can't cast item";
     }
 }
 
@@ -1118,7 +1118,7 @@ void VToolOptionsPropertyBrowser::changeDataToolSinglePoint(VPE::VProperty *prop
             tool->SetBasePointPos(value.toPointF());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1157,7 +1157,7 @@ void VToolOptionsPropertyBrowser::changeDataToolEndLine(VPE::VProperty *property
             tool->SetBasePointId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1196,7 +1196,7 @@ void VToolOptionsPropertyBrowser::changeDataToolAlongLine(VPE::VProperty *proper
             tool->SetSecondPointId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1239,7 +1239,7 @@ void VToolOptionsPropertyBrowser::changeDataToolArc(VPE::VProperty *property)
             tool->SetPenStyle(value.toString());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1281,7 +1281,7 @@ void VToolOptionsPropertyBrowser::changeDataToolArcWithLength(VPE::VProperty *pr
             tool->SetPenStyle(value.toString());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1323,7 +1323,7 @@ void VToolOptionsPropertyBrowser::changeDataToolBisector(VPE::VProperty *propert
             tool->SetThirdPointId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1362,7 +1362,7 @@ void VToolOptionsPropertyBrowser::changeDataToolTrueDarts(VPE::VProperty *proper
             tool->SetDartP3Id(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1389,7 +1389,7 @@ void VToolOptionsPropertyBrowser::changeDataToolCutArc(VPE::VProperty *property)
             tool->setCurveCutId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1416,7 +1416,7 @@ void VToolOptionsPropertyBrowser::changeDataToolCutSpline(VPE::VProperty *proper
             tool->setCurveCutId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1443,7 +1443,7 @@ void VToolOptionsPropertyBrowser::changeDataToolCutSplinePath(VPE::VProperty *pr
             tool->setCurveCutId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1482,7 +1482,7 @@ void VToolOptionsPropertyBrowser::changeDataToolHeight(VPE::VProperty *property)
             tool->SetP2LineId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1515,7 +1515,7 @@ void VToolOptionsPropertyBrowser::changeDataToolLine(VPE::VProperty *property)
             tool->SetSecondPoint(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1548,7 +1548,7 @@ void VToolOptionsPropertyBrowser::changeDataToolLineIntersect(VPE::VProperty *pr
             tool->SetP2Line2(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1590,7 +1590,7 @@ void VToolOptionsPropertyBrowser::changeDataToolNormal(VPE::VProperty *property)
             tool->SetSecondPointId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1623,7 +1623,7 @@ void VToolOptionsPropertyBrowser::changeDataToolPointOfContact(VPE::VProperty *p
             tool->SetSecondPointId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1659,7 +1659,7 @@ void VToolOptionsPropertyBrowser::changeDataToolPointOfIntersection(VPE::VProper
             tool->setLineWeight(value.toString());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1692,7 +1692,7 @@ void VToolOptionsPropertyBrowser::changeDataToolPointOfIntersectionArcs(VPE::VPr
             tool->SetSecondArcId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1731,7 +1731,7 @@ void VToolOptionsPropertyBrowser::changeDataToolPointOfIntersectionCircles(VPE::
             tool->SetSecondCircleCenterId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1770,7 +1770,7 @@ void VToolOptionsPropertyBrowser::changeDataToolPointOfIntersectionCurves(VPE::V
             tool->SetSecondCurveId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1806,7 +1806,7 @@ void VToolOptionsPropertyBrowser::changeDataToolPointFromCircleAndTangent(VPE::V
             tool->SetTangentPointId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1839,7 +1839,7 @@ void VToolOptionsPropertyBrowser::changeDataToolPointFromArcAndTangent(VPE::VPro
             tool->SetArcId(value.toInt());
             break;;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1881,7 +1881,7 @@ void VToolOptionsPropertyBrowser::changeDataToolShoulderPoint(VPE::VProperty *pr
             tool->setPShoulder(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -1955,7 +1955,7 @@ void VToolOptionsPropertyBrowser::changeDataToolSpline(VPE::VProperty *property)
             tool->setLineWeight(value.toString());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -2009,7 +2009,7 @@ void VToolOptionsPropertyBrowser::changeDataToolCubicBezier(VPE::VProperty *prop
             tool->setSpline(spline);
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -2039,7 +2039,7 @@ void VToolOptionsPropertyBrowser::changeDataToolSplinePath(VPE::VProperty *prope
             tool->setLineWeight(value.toString());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -2069,7 +2069,7 @@ void VToolOptionsPropertyBrowser::changeDataToolCubicBezierPath(VPE::VProperty *
             tool->setLineWeight(value.toString());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -2102,7 +2102,7 @@ void VToolOptionsPropertyBrowser::changeDataToolTriangle(VPE::VProperty *propert
             tool->SetSecondPointId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -2144,7 +2144,7 @@ void VToolOptionsPropertyBrowser::changeDataToolLineIntersectAxis(VPE::VProperty
             tool->SetSecondPointId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -2183,7 +2183,7 @@ void VToolOptionsPropertyBrowser::changeDataToolCurveIntersectAxis(VPE::VPropert
             tool->setCurveId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -2210,7 +2210,7 @@ void VToolOptionsPropertyBrowser::changeDataToolRotation(VPE::VProperty *propert
             tool->setOriginPointId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -2243,7 +2243,7 @@ void VToolOptionsPropertyBrowser::changeDataToolMove(VPE::VProperty *property)
             tool->setOriginPointId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -2270,7 +2270,7 @@ void VToolOptionsPropertyBrowser::changeDataToolMirrorByLine(VPE::VProperty *pro
             tool->setSecondLinePointId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -2300,7 +2300,7 @@ void VToolOptionsPropertyBrowser::changeDataToolMirrorByAxis(VPE::VProperty *pro
             tool->setOriginPointId(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }
@@ -2348,7 +2348,7 @@ void VToolOptionsPropertyBrowser::changeDataToolEllipticalArc(VPE::VProperty *pr
             tool->setCenter(value.toInt());
             break;
         default:
-            qWarning()<<"Unknown property type. id = "<<id;
+            qWarning() << "Unknown property type. id = "<<id;
             break;
     }
 }

--- a/src/app/seamly2d/dialogs/dialoghistory.cpp
+++ b/src/app/seamly2d/dialogs/dialoghistory.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   dialoghistory.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   dialoghistory.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -253,7 +253,7 @@ QString DialogHistory::Record(const VToolRecord &tool)
     const QDomElement domElem = doc->elementById(tool.getId());
     if (domElem.isElement() == false)
     {
-        qDebug()<<"Can't find element by id"<<Q_FUNC_INFO;
+        qWarning() << "Can't find element by id" << Q_FUNC_INFO;
         return QString();
     }
     try
@@ -460,12 +460,12 @@ QString DialogHistory::Record(const VToolRecord &tool)
                 return QString();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
-        qDebug()<<e.ErrorMessage()<<Q_FUNC_INFO;
+        qWarning() << error.ErrorMessage() << Q_FUNC_INFO;
         return QString();
     }
-    qDebug()<<"Can't create history record for the tool.";
+    qWarning() << "Can't create history record for the tool.";
     return QString();
 }
 

--- a/src/app/seamly2d/dialogs/dialogvariables.cpp
+++ b/src/app/seamly2d/dialogs/dialogvariables.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   dialogvariables.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   dialogvariables.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -216,9 +216,9 @@ void DialogVariables::fillCustomVariables(bool freshCall)
         {
             formula = qApp->TrVars()->FormulaToUser(variable->GetFormula(), qApp->Settings()->GetOsSeparator());
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             formula = variable->GetFormula();
         }
 
@@ -419,10 +419,10 @@ bool DialogVariables::evalVariableFormula(const QString &formula, bool fromUser,
             label->setToolTip(tr("Value"));
             return true;
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
-            label->setText(tr("Error") + " (" + postfix + "). " + tr("Parser error: %1").arg(e.GetMsg()));
-            label->setToolTip(tr("Parser error: %1").arg(e.GetMsg()));
+            label->setText(tr("Error") + " (" + postfix + "). " + tr("Parser error: %1").arg(error.GetMsg()));
+            label->setToolTip(tr("Parser error: %1").arg(error.GetMsg()));
             return false;
         }
     }
@@ -816,9 +816,9 @@ void DialogVariables::saveCustomVariableFormula()
         const QString formula = qApp->TrVars()->FormulaFromUser(text, qApp->Settings()->GetOsSeparator());
         doc->SetIncrementFormula(name->text(), formula);
     }
-    catch (qmu::QmuParserError &e) // Just in case something bad will happen
+    catch (qmu::QmuParserError &error) // Just in case something bad will happen
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;
     }
 
@@ -976,9 +976,9 @@ void DialogVariables::showCustomVariableDetails()
         {
             variable = data->GetVariable<VIncrement>(name->text());
         }
-        catch(const VExceptionBadId &e)
+        catch(const VExceptionBadId &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             enablePieces(false);
             return;
         }
@@ -999,9 +999,9 @@ void DialogVariables::showCustomVariableDetails()
         {
             formula = qApp->TrVars()->FormulaToUser(variable->GetFormula(), qApp->Settings()->GetOsSeparator());
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             formula = variable->GetFormula();
         }
 

--- a/src/app/seamly2d/dialogs/groups_widget.cpp
+++ b/src/app/seamly2d/dialogs/groups_widget.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   groups_widget.cpp
  **  @author Douglas S Caskey
- **  @date   11 Jun, 2023
+ **  @date   17 Sep, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2023 Seamly, LLC
@@ -763,7 +763,7 @@ void GroupsWidget::addGroupItem(const quint32 &toolId, const quint32 &objId, con
     const QDomElement domElement = m_doc->elementById(toolId);
     if (domElement.isElement() == false)
     {
-        qDebug()<<"Can't find element by id"<<Q_FUNC_INFO;
+        qWarning() << "Can't find element by id" << Q_FUNC_INFO;
         return;
     }
         try
@@ -1041,13 +1041,13 @@ void GroupsWidget::addGroupItem(const quint32 &toolId, const quint32 &objId, con
             return;
         }
 
-        catch (const VExceptionBadId &e)
+        catch (const VExceptionBadId &error)
         {
             QList<quint32>itemData;
             itemData.append(objId);
             itemData.append(toolId);
 
-            qDebug()<<e.ErrorMessage()<<Q_FUNC_INFO;
+            qWarning() << error.ErrorMessage() << Q_FUNC_INFO;
             QListWidgetItem *item = new QListWidgetItem(objName);
             item->setIcon(QIcon(":/icons/win.icon.theme/16x16/status/dialog-warning.png"));
             item->setData(Qt::UserRole,  QVariant::fromValue(itemData));
@@ -1094,11 +1094,11 @@ QString GroupsWidget::getObjName(quint32 toolId)
         const auto obj = m_data->GetGObject(toolId);
         return obj->name();
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
-        qCDebug(WidgetGroups, "Error! Couldn't get object name by id = %s. %s %s", qUtf8Printable(QString().setNum(toolId)),
-            qUtf8Printable(e.ErrorMessage()),
-            qUtf8Printable(e.DetailedInformation()));
+        qWarning(WidgetGroups, "Error! Couldn't get object name by id = %s. %s %s", qUtf8Printable(QString().setNum(toolId)),
+            qUtf8Printable(error.ErrorMessage()),
+            qUtf8Printable(error.DetailedInformation()));
         return QString("Unknown Object");// Return Unknown string
     }
 }

--- a/src/app/seamly2d/dialogs/history_dialog.cpp
+++ b/src/app/seamly2d/dialogs/history_dialog.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   historyDialog.cpp
  **  @author Douglas S Caskey
- **  @date   Mar 11, 2023
+ **  @date   17 Sep, 2023
  **
  **  @copyright
  **  Copyright (C) 2015 - 2023 Seamly, LLC
@@ -273,7 +273,7 @@ RowData HistoryDialog::record(const VToolRecord &tool)
     const QDomElement domElement = m_doc->elementById(toolId);
     if (domElement.isElement() == false)
     {
-        qDebug()<<"Can't find element by id"<<Q_FUNC_INFO;
+        qWarning() << "Can't find element by id" << Q_FUNC_INFO;
         return rowData;
     }
     try
@@ -600,12 +600,12 @@ RowData HistoryDialog::record(const VToolRecord &tool)
         }
         return rowData;
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
-        qDebug()<<e.ErrorMessage()<<Q_FUNC_INFO;
+        qWarning() << error.ErrorMessage() << Q_FUNC_INFO;
         return rowData;
     }
-    qDebug()<<"Can't create history record for the tool.";
+    qWarning() << "Can't create history record for the tool.";
     return rowData;
 }
 

--- a/src/app/seamly2d/mainwindowsnogui.cpp
+++ b/src/app/seamly2d/mainwindowsnogui.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   mainwindowsnogui.cpp
  **  @author Douglas S Caskey
- **  @date   Dec 31, 2022
+ **  @date   17 Sep, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2022 Seamly, LLC
@@ -449,7 +449,7 @@ void MainWindowsNoGUI::ExportApparelLayout(const ExportLayoutDialog &dialog, con
             AAMADxfFile(name, DRW::AC1027, dialog.isBinaryDXFFormat(), size, pieces);
             break;
         default:
-            qDebug() << "Can't recognize file type." << Q_FUNC_INFO;
+            qWarning() << "Can't recognize file type." << Q_FUNC_INFO;
             break;
     }
 
@@ -680,7 +680,7 @@ void MainWindowsNoGUI::PrintPreviewOrigin()
 {
     if (not isPagesUniform())
     {
-        qCritical()<<tr("For previewing multipage document all sheet should have the same size.");
+        qCritical() << tr("For previewing multipage document all sheet should have the same size.");
         return;
     }
 
@@ -700,7 +700,7 @@ void MainWindowsNoGUI::PrintOrigin()
 {
     if (not isPagesUniform())
     {
-        qCritical()<<tr("For printing multipages document all sheet should have the same size.");
+        qCritical() << tr("For printing multipages document all sheet should have the same size.");
         return;
     }
 
@@ -820,7 +820,7 @@ QIcon MainWindowsNoGUI::ScenePreview(int i) const
         }
         else
         {
-            qWarning()<<"Cannot create image. Size too big";
+            qWarning() << "Cannot create image. Size too big";
         }
     }
     else
@@ -1016,7 +1016,7 @@ void MainWindowsNoGUI::exportPDF(const QString &name, QGraphicsRectItem *paper, 
     const QRectF sourceRect = paper->rect();
     const QRectF targetRect = QRectF(QPoint(0,0), QPoint(sourceRect.width(),sourceRect.height()));
     QSizeF size(FromPixel(sourceRect.width() + margins.left() + margins.right(), Unit::Mm),
-                FromPixel(sourceRect.height() + margins.top() + margins.bottom(), Unit::Mm));    
+                FromPixel(sourceRect.height() + margins.top() + margins.bottom(), Unit::Mm));
     QPageSize pageSize(size, QPageSize::Unit::Millimeter);
     printer.setPageSize(pageSize);
 
@@ -1066,7 +1066,7 @@ void MainWindowsNoGUI::PdfTiledFile(const QString &name)
     // Call IsPagesFit after setting a printer settings and check if pages is not bigger than printer's paper size
     if (not isTiled && not IsPagesFit(printer.pageLayout().fullRectPixels(printer.resolution()).size()))
     {
-        qWarning()<<tr("Pages will be cropped because they do not fit printer paper size.");
+        qWarning() << tr("Pages will be cropped because they do not fit printer paper size.");
     }
 
     printer.setOutputFileName(name);
@@ -1711,7 +1711,7 @@ void MainWindowsNoGUI::ExportScene(const ExportLayoutDialog &dialog, const QList
                     paper->setVisible(true);
                     break;
                 default:
-                    qDebug() << "Can't recognize file type." << Q_FUNC_INFO;
+                    qWarning() << "Can't recognize file type." << Q_FUNC_INFO;
                     break;
             }
             paper->setPen(QPen(Qt::black, 1));

--- a/src/app/seamly2d/xml/vpattern.cpp
+++ b/src/app/seamly2d/xml/vpattern.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   vpattern.cpp
  **  @author Douglas S Caskey
- **  @date   Dec 31, 2022
+ **  @date   17 Sep, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2022 Seamly, LLC
@@ -316,9 +316,9 @@ void VPattern::setCurrentData()
                 {
                     ToolExists(id);
                 }
-                catch (VExceptionBadId &e)
+                catch (VExceptionBadId &error)
                 {
-                    Q_UNUSED(e)
+                    Q_UNUSED(error)
                     qCDebug(vXML, "List of tools doesn't contain id= %u", id);
                     return;
                 }
@@ -413,10 +413,10 @@ bool VPattern::SaveDocument(const QString &fileName, QString &error)
     {
         TestUniqueId();
     }
-    catch (const VExceptionWrongId &e)
+    catch (const VExceptionWrongId &error)
     {
         qCCritical(vXML, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error not unique id.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         return false;
     }
 
@@ -457,46 +457,46 @@ void VPattern::LiteParseIncrements()
             }
         }
     }
-    catch (const VExceptionUndo &e)
+    catch (const VExceptionUndo &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         /* If user want undo last operation before undo we need finish broken redo operation. For those we post event
          * myself. Later in method customEvent call undo.*/
         QApplication::postEvent(this, new UndoEvent());
         return;
     }
-    catch (const VExceptionObjectError &e)
+    catch (const VExceptionObjectError &error)
     {
         qCCritical(vXML, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error parsing file.")), //-V807
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         emit setGuiEnabled(false);
         return;
     }
-    catch (const VExceptionConversionError &e)
+    catch (const VExceptionConversionError &error)
     {
         qCCritical(vXML, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error can't convert value.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         emit setGuiEnabled(false);
         return;
     }
-    catch (const VExceptionEmptyParameter &e)
+    catch (const VExceptionEmptyParameter &error)
     {
         qCCritical(vXML, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error empty parameter.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         emit setGuiEnabled(false);
         return;
     }
-    catch (const VExceptionWrongId &e)
+    catch (const VExceptionWrongId &error)
     {
         qCCritical(vXML, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error wrong id.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         emit setGuiEnabled(false);
         return;
     }
-    catch (VException &e)
+    catch (VException &error)
     {
         qCCritical(vXML, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error parsing file.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         emit setGuiEnabled(false);
         return;
     }
@@ -535,18 +535,18 @@ void VPattern::LiteParseTree(const Document &parse)
                 break;
         }
     }
-    catch (const VExceptionUndo &e)
+    catch (const VExceptionUndo &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         /* If user want undo last operation before undo we need finish broken redo operation. For those we post event
          * myself. Later in method customEvent call undo.*/
         QApplication::postEvent(this, new UndoEvent());
         return;
     }
-    catch (const VExceptionObjectError &e)
+    catch (const VExceptionObjectError &error)
     {
         qCCritical(vXML, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error parsing file.")), //-V807
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         emit setGuiEnabled(false);
         if (not VApplication::IsGUIMode())
         {
@@ -554,10 +554,10 @@ void VPattern::LiteParseTree(const Document &parse)
         }
         return;
     }
-    catch (const VExceptionConversionError &e)
+    catch (const VExceptionConversionError &error)
     {
         qCCritical(vXML, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error can't convert value.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         emit setGuiEnabled(false);
         if (not VApplication::IsGUIMode())
         {
@@ -565,10 +565,10 @@ void VPattern::LiteParseTree(const Document &parse)
         }
         return;
     }
-    catch (const VExceptionEmptyParameter &e)
+    catch (const VExceptionEmptyParameter &error)
     {
         qCCritical(vXML, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error empty parameter.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         emit setGuiEnabled(false);
         if (not VApplication::IsGUIMode())
         {
@@ -576,10 +576,10 @@ void VPattern::LiteParseTree(const Document &parse)
         }
         return;
     }
-    catch (const VExceptionWrongId &e)
+    catch (const VExceptionWrongId &error)
     {
         qCCritical(vXML, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error wrong id.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         emit setGuiEnabled(false);
         if (not VApplication::IsGUIMode())
         {
@@ -587,10 +587,10 @@ void VPattern::LiteParseTree(const Document &parse)
         }
         return;
     }
-    catch (VException &e)
+    catch (VException &error)
     {
         qCCritical(vXML, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error parsing file.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         emit setGuiEnabled(false);
         if (not VApplication::IsGUIMode())
         {
@@ -895,10 +895,10 @@ void VPattern::parsePieceElement(QDomElement &domElement, const Document &parse)
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating piece"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -1172,10 +1172,10 @@ void VPattern::ParseLineElement(VMainGraphicsScene *scene, const QDomElement &do
 
         VToolLine::Create(id, firstPoint, secondPoint, lineType, lineWeight, lineColor, scene, this, data, parse, Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating line"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -1287,10 +1287,10 @@ void VPattern::ParseToolBasePoint(VMainGraphicsScene *scene, const QDomElement &
         point->setShowPointName(showPointName);
         spoint = VToolBasePoint::Create(id, activeDraftBlock, point, scene, this, data, parse, Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating single point"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         scene->removeItem(spoint);
         delete spoint;
         throw excep;
@@ -1335,16 +1335,16 @@ void VPattern::ParseToolEndLine(VMainGraphicsScene *scene, QDomElement &domEleme
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of end line"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of end line"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -1382,16 +1382,16 @@ void VPattern::ParseToolAlongLine(VMainGraphicsScene *scene, QDomElement &domEle
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point along line"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point along line"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -1430,16 +1430,16 @@ void VPattern::ParseToolShoulderPoint(VMainGraphicsScene *scene, QDomElement &do
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of shoulder"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of shoulder"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -1478,16 +1478,16 @@ void VPattern::ParseToolNormal(VMainGraphicsScene *scene, QDomElement &domElemen
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of normal"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of normal"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -1526,16 +1526,16 @@ void VPattern::ParseToolBisector(VMainGraphicsScene *scene, QDomElement &domElem
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of bisector"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of bisector"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -1563,10 +1563,10 @@ void VPattern::ParseToolLineIntersect(VMainGraphicsScene *scene, const QDomEleme
         VToolLineIntersect::Create(id, p1Line1Id, p2Line1Id, p1Line2Id, p2Line2Id, name,
                                    mx, my, showPointName, scene, this, data, parse, Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of line intersection"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -1602,16 +1602,16 @@ void VPattern::ParseToolPointOfContact(VMainGraphicsScene *scene, QDomElement &d
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of contact"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of contact"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -1635,9 +1635,9 @@ void VPattern::ParseNodePoint(const QDomElement &domElement, const Document &par
         {
             point = data->GeometricObject<VPointF>(idObject);
         }
-        catch (const VExceptionBadId &e)
+        catch (const VExceptionBadId &error)
         { // Possible case. Parent was deleted, but the node object is still here.
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             return;// Just ignore
         }
 
@@ -1647,10 +1647,10 @@ void VPattern::ParseNodePoint(const QDomElement &domElement, const Document &par
         data->UpdateGObject(id, nodePoint);
         VNodePoint::Create(this, data, pieceScene, id, idObject, parse, Source::FromFile, "", idTool);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating modeling point"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -1669,10 +1669,10 @@ void VPattern::ParseAnchorPoint(const QDomElement &domElement, const Document &p
         const quint32 idTool = GetParametrUInt(domElement, VAbstractNode::AttrIdTool, NULL_ID_STR);
         AnchorPointTool::Create(id, idObject, NULL_ID, this, data, parse, Source::FromFile, "", idTool);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating anchor point"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -1702,10 +1702,10 @@ void VPattern::ParseToolHeight(VMainGraphicsScene *scene, const QDomElement &dom
         VToolHeight::Create(id, name, lineType, lineWeight, lineColor, basePointId, p1LineId, p2LineId,
                             mx, my, showPointName, scene, this, data, parse, Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating height"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -1733,10 +1733,10 @@ void VPattern::ParseToolTriangle(VMainGraphicsScene *scene, const QDomElement &d
         VToolTriangle::Create(id, name, axisP1Id, axisP2Id, firstPointId, secondPointId, mx, my, showPointName, scene, this,
                               data, parse, Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating triangle"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -1766,10 +1766,10 @@ void VPattern::parseIntersectXYTool(VMainGraphicsScene *scene, const QDomElement
         PointIntersectXYTool::Create(id, name, lineType, lineWeight, lineColor, firstPointId, secondPointId,
                                      mx, my, showPointName, scene, this, data, parse, Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating Intersect XY tool"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -1802,16 +1802,16 @@ void VPattern::ParseToolCutSpline(VMainGraphicsScene *scene, QDomElement &domEle
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating cut spline point"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating cut spline point"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -1845,16 +1845,16 @@ void VPattern::ParseToolCutSplinePath(VMainGraphicsScene *scene, QDomElement &do
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating cut spline path point"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating cut spline path point"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -1887,16 +1887,16 @@ void VPattern::ParseToolCutArc(VMainGraphicsScene *scene, QDomElement &domElemen
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating cut arc point"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating cut arc point"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -1938,18 +1938,18 @@ void VPattern::ParseToolLineIntersectAxis(VMainGraphicsScene *scene, QDomElement
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of intersection line and axis"),
                                     domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of intersection line and axis"),
                                     domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -1989,18 +1989,18 @@ void VPattern::ParseToolCurveIntersectAxis(VMainGraphicsScene *scene, QDomElemen
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of intersection curve and axis"),
                                     domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of intersection curve and axis"),
                                     domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -2030,10 +2030,10 @@ void VPattern::ParseToolPointOfIntersectionArcs(VMainGraphicsScene *scene, const
         VToolPointOfIntersectionArcs::Create(id, name, firstArcId, secondArcId, crossPoint, mx, my, scene, this,
                                              data, parse, Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of intersection arcs"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2074,10 +2074,10 @@ void VPattern::ParseToolPointOfIntersectionCircles(VMainGraphicsScene *scene, QD
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of intersection circles"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2106,10 +2106,10 @@ void VPattern::ParseToolPointOfIntersectionCurves(VMainGraphicsScene *scene, QDo
         VToolPointOfIntersectionCurves::Create(id, name, curve1Id, curve2Id, vCrossPoint, hCrossPoint, mx, my,
                                                showPointName, scene, this, data, parse, Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point of intersection curves"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2148,10 +2148,10 @@ void VPattern::ParseToolPointFromCircleAndTangent(VMainGraphicsScene *scene, QDo
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point from circle and tangent"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2181,10 +2181,10 @@ void VPattern::ParseToolPointFromArcAndTangent(VMainGraphicsScene *scene, const 
         VToolPointFromArcAndTangent::Create(id, name, arcId, tangentId, crossPoint, mx, my,
                                             showPointName, scene, this, data, parse, Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating point from arc and tangent"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2226,10 +2226,10 @@ void VPattern::ParseToolTrueDarts(VMainGraphicsScene *scene, const QDomElement &
                                name1, mx1, my1, showPointName1, name2, mx2, my2, showPointName2,
                                scene, this, data, parse, Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating true darts"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2268,10 +2268,10 @@ void VPattern::ParseOldToolSpline(VMainGraphicsScene *scene, const QDomElement &
 
         VToolSpline::Create(id, spline, scene, this, data, parse, Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating simple curve"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2328,16 +2328,16 @@ void VPattern::ParseToolSpline(VMainGraphicsScene *scene, QDomElement &domElemen
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating simple curve"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating simple interactive spline"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -2379,10 +2379,10 @@ void VPattern::ParseToolCubicBezier(VMainGraphicsScene *scene, const QDomElement
 
         VToolCubicBezier::Create(id, spline, scene, this, data, parse, Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating cubic bezier curve"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2441,10 +2441,10 @@ void VPattern::ParseOldToolSplinePath(VMainGraphicsScene *scene, const QDomEleme
 
         VToolSplinePath::Create(id, path, scene, this, data, parse, Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating curve path"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2529,16 +2529,16 @@ void VPattern::ParseToolSplinePath(VMainGraphicsScene *scene, const QDomElement 
             }
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating curve path"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating interactive spline path"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -2592,10 +2592,10 @@ void VPattern::ParseToolCubicBezierPath(VMainGraphicsScene *scene, const QDomEle
 
         VToolCubicBezierPath::Create(id, path, scene, this, data, parse, Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating cubic bezier path curve"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2630,18 +2630,18 @@ void VPattern::ParseNodeSpline(const QDomElement &domElement, const Document &pa
                 data->UpdateGObject(id, spl);
             }
         }
-        catch (const VExceptionBadId &e)
+        catch (const VExceptionBadId &error)
         { // Possible case. Parent was deleted, but the node object is still here.
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             return;// Just ignore
         }
 
         VNodeSpline::Create(this, data, id, idObject, parse, Source::FromFile, "", idTool);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating modeling simple curve"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2676,17 +2676,17 @@ void VPattern::ParseNodeSplinePath(const QDomElement &domElement, const Document
                 data->UpdateGObject(id, spl);
             }
         }
-        catch (const VExceptionBadId &e)
+        catch (const VExceptionBadId &error)
         { // Possible case. Parent was deleted, but the node object is still here.
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             return;// Just ignore
         }
         VNodeSplinePath::Create(this, data, id, idObject, parse, Source::FromFile, "", idTool);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating modeling curve path"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2725,16 +2725,16 @@ void VPattern::ParseToolArc(VMainGraphicsScene *scene, QDomElement &domElement, 
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating simple arc"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating simple arc"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -2780,16 +2780,16 @@ void VPattern::ParseToolEllipticalArc(VMainGraphicsScene *scene, QDomElement &do
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating simple elliptical arc"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating simple elliptical arc"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -2811,9 +2811,9 @@ void VPattern::ParseNodeEllipticalArc(const QDomElement &domElement, const Docum
         {
             arc = new VEllipticalArc(*data->GeometricObject<VEllipticalArc>(idObject));
         }
-        catch (const VExceptionBadId &e)
+        catch (const VExceptionBadId &error)
         { // Possible case. Parent was deleted, but the node object is still here.
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             return;// Just ignore
         }
         arc->setIdObject(idObject);
@@ -2821,10 +2821,10 @@ void VPattern::ParseNodeEllipticalArc(const QDomElement &domElement, const Docum
         data->UpdateGObject(id, arc);
         VNodeEllipticalArc::Create(this, data, id, idObject, parse, Source::FromFile, "", idTool);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating modeling elliptical arc"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2846,9 +2846,9 @@ void VPattern::ParseNodeArc(const QDomElement &domElement, const Document &parse
         {
             arc = new VArc(*data->GeometricObject<VArc>(idObject));
         }
-        catch (const VExceptionBadId &e)
+        catch (const VExceptionBadId &error)
         { // Possible case. Parent was deleted, but the node object is still here.
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             return;// Just ignore
         }
         arc->setIdObject(idObject);
@@ -2856,10 +2856,10 @@ void VPattern::ParseNodeArc(const QDomElement &domElement, const Document &parse
         data->UpdateGObject(id, arc);
         VNodeArc::Create(this, data, id, idObject, parse, Source::FromFile, "", idTool);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating modeling arc"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2899,16 +2899,16 @@ void VPattern::ParseToolArcWithLength(VMainGraphicsScene *scene, QDomElement &do
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating simple arc"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating simple arc"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -2942,16 +2942,16 @@ void VPattern::ParseToolRotation(VMainGraphicsScene *scene, QDomElement &domElem
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating operation of rotation"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating operation of rotation"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -2978,10 +2978,10 @@ void VPattern::ParseToolMirrorByLine(VMainGraphicsScene *scene, QDomElement &dom
         VToolMirrorByLine::Create(id, p1, p2, suffix, source, destination, scene, this, data, parse,
                                     Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating operation of mirror by line"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -3008,10 +3008,10 @@ void VPattern::ParseToolMirrorByAxis(VMainGraphicsScene *scene, QDomElement &dom
         VToolMirrorByAxis::Create(id, origin, axisType, suffix, source, destination, scene, this, data, parse,
                                     Source::FromFile);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating operation of mirror by axis"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -3054,16 +3054,16 @@ void VPattern::ParseToolMove(VMainGraphicsScene *scene, QDomElement &domElement,
             haveLiteChange();
         }
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating operation of moving"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating operation of moving"), domElement);
-        excep.AddMoreInformation(QString("Message:     " + e.GetMsg() + "\n"+ "Expression:  " + e.GetExpr()));
+        excep.AddMoreInformation(QString("Message:     " + error.GetMsg() + "\n"+ "Expression:  " + error.GetExpr()));
         throw excep;
     }
 }
@@ -3089,9 +3089,9 @@ qreal VPattern::EvalFormula(VContainer *data, const QString &formula, bool *ok) 
             (qIsInf(result) || qIsNaN(result)) ? *ok = false : *ok = true;
             return result;
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             *ok = false;
             return 0;
         }
@@ -3333,10 +3333,10 @@ void VPattern::ParseToolsElement(VMainGraphicsScene *scene, const QDomElement &d
 
                 UnionTool::Create(id, initData);
             }
-            catch (const VExceptionBadId &e)
+            catch (const VExceptionBadId &error)
             {
                 VExceptionObjectError excep(tr("Error creating or updating union pieces"), domElement);
-                excep.AddMoreInformation(e.ErrorMessage());
+                excep.AddMoreInformation(error.ErrorMessage());
                 throw excep;
             }
             break;
@@ -3409,10 +3409,10 @@ void VPattern::ParsePathElement(VMainGraphicsScene *scene, QDomElement &domEleme
 
         VToolInternalPath::Create(id, path, 0, scene, this, data, parse, Source::FromFile, "", idTool);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating a piece path"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -3442,9 +3442,9 @@ void VPattern::ParseIncrementsElement(const QDomNode &node)
                     {
                         desc = GetParametrString(domElement, IncrementDescription);
                     }
-                    catch (VExceptionEmptyParameter &e)
+                    catch (VExceptionEmptyParameter &error)
                     {
-                        Q_UNUSED(e)
+                        Q_UNUSED(error)
                     }
 
                     const QString formula = GetParametrString(domElement, IncrementFormula, "0");
@@ -3734,7 +3734,7 @@ void VPattern::SetDefCustom(bool value)
     QDomNodeList tags = elementsByTagName(TagGradation);
     if (tags.isEmpty())
     {
-        qDebug()<<"Can't save attribute "<<AttrCustom<<Q_FUNC_INFO;
+        qWarning() << "Can't save attribute " << AttrCustom << Q_FUNC_INFO;
         return;
     }
 
@@ -3756,7 +3756,7 @@ void VPattern::SetDefCustom(bool value)
     }
     else
     {
-        qDebug()<<"Can't save attribute "<<AttrCustom<<Q_FUNC_INFO;
+        qWarning() << "Can't save attribute " << AttrCustom << Q_FUNC_INFO;
     }
 }
 
@@ -3795,7 +3795,7 @@ void VPattern::SetDefCustomHeight(int value)
     QDomNodeList tags = elementsByTagName(TagGradation);
     if (tags.isEmpty())
     {
-        qDebug()<<"Can't save attribute "<<AttrDefHeight<<Q_FUNC_INFO;
+        qWarning() << "Can't save attribute " << AttrDefHeight << Q_FUNC_INFO;
         return;
     }
 
@@ -3815,7 +3815,7 @@ void VPattern::SetDefCustomHeight(int value)
     }
     else
     {
-        qDebug()<<"Can't save attribute "<<AttrDefHeight<<Q_FUNC_INFO;
+        qWarning() << "Can't save attribute " << AttrDefHeight << Q_FUNC_INFO;
     }
 }
 
@@ -3854,7 +3854,7 @@ void VPattern::SetDefCustomSize(int value)
     QDomNodeList tags = elementsByTagName(TagGradation);
     if (tags.isEmpty())
     {
-        qDebug()<<"Can't save attribute "<<AttrDefSize<<Q_FUNC_INFO;
+        qWarning() << "Can't save attribute " << AttrDefSize << Q_FUNC_INFO;
         return;
     }
 
@@ -3874,7 +3874,7 @@ void VPattern::SetDefCustomSize(int value)
     }
     else
     {
-        qDebug()<<"Can't save attribute "<<AttrDefSize<<Q_FUNC_INFO;
+        qWarning() << "Can't save attribute " << AttrDefSize << Q_FUNC_INFO;
     }
 }
 
@@ -4067,7 +4067,7 @@ QRectF VPattern::ToolBoundingRect(const QRectF &rect, const quint32 &id) const
     }
     else
     {
-        qDebug()<<"Can't find tool with id="<<id;
+        qWarning() << "Can't find tool with id=" << id;
     }
     return toolRect;
 }

--- a/src/app/seamlyme/mapplication.cpp
+++ b/src/app/seamlyme/mapplication.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   mapplication.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   mapplication.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   8 7, 2015
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -296,59 +296,59 @@ bool MApplication::notify(QObject *receiver, QEvent *event)
     {
         return QApplication::notify(receiver, event);
     }
-    catch (const VExceptionObjectError &e)
+    catch (const VExceptionObjectError &error)
     {
         qCCritical(mApp, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error parsing file. Program will be terminated.")), //-V807
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         exit(V_EX_DATAERR);
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         qCCritical(mApp, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error bad id. Program will be terminated.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         exit(V_EX_DATAERR);
     }
-    catch (const VExceptionConversionError &e)
+    catch (const VExceptionConversionError &error)
     {
         qCCritical(mApp, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error can't convert value. Program will be terminated.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         exit(V_EX_DATAERR);
     }
-    catch (const VExceptionEmptyParameter &e)
+    catch (const VExceptionEmptyParameter &error)
     {
         qCCritical(mApp, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error empty parameter. Program will be terminated.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         exit(V_EX_DATAERR);
     }
-    catch (const VExceptionWrongId &e)
+    catch (const VExceptionWrongId &error)
     {
         qCCritical(mApp, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Error wrong id. Program will be terminated.")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         exit(V_EX_DATAERR);
     }
-    catch (const VExceptionToolWasDeleted &e)
+    catch (const VExceptionToolWasDeleted &error)
     {
         qCCritical(mApp, "%s\n\n%s\n\n%s",
                    qUtf8Printable("Unhadled deleting tool. Continue use object after deleting!"),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         exit(V_EX_DATAERR);
     }
-    catch (const VException &e)
+    catch (const VException &error)
     {
         qCCritical(mApp, "%s\n\n%s\n\n%s", qUtf8Printable(tr("Something's wrong!!")),
-                   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         return true;
     }
     // These last two cases special. I found that we can't show here modal dialog with error message.
     // Somehow program doesn't waite untile an error dialog will be closed. But if ignore this program will hang.
-    catch (const qmu::QmuParserError &e)
+    catch (const qmu::QmuParserError &error)
     {
-        qCCritical(mApp, "%s", qUtf8Printable(tr("Parser error: %1. Program will be terminated.").arg(e.GetMsg())));
+        qCCritical(mApp, "%s", qUtf8Printable(tr("Parser error: %1. Program will be terminated.").arg(error.GetMsg())));
         exit(V_EX_DATAERR);
     }
-    catch (std::exception &e)
+    catch (std::exception &error)
     {
-        qCCritical(mApp, "%s", qUtf8Printable(tr("Exception thrown: %1. Program will be terminated.").arg(e.what())));
+        qCCritical(mApp, "%s", qUtf8Printable(tr("Exception thrown: %1. Program will be terminated.").arg(error.what())));
         exit(V_EX_SOFTWARE);
     }
     return false;
@@ -404,12 +404,12 @@ void MApplication::InitOptions()
     QDir().mkpath(settings->GetDefPathMultisizeMeasurements());
     QDir().mkpath(settings->GetDefPathLabelTemplate());
 
-    qCDebug(mApp, "Version: %s", qUtf8Printable(APP_VERSION_STR));
-    qCDebug(mApp, "Build revision: %s", BUILD_REVISION);
-    qCDebug(mApp, "%s", qUtf8Printable(buildCompatibilityString()));
-    qCDebug(mApp, "Built on %s at %s", __DATE__, __TIME__);
-    qCDebug(mApp, "Command-line arguments: %s", qUtf8Printable(arguments().join(", ")));
-    qCDebug(mApp, "Process ID: %s", qUtf8Printable(QString().setNum(applicationPid())));
+    qCInfo(mApp, "Version: %s", qUtf8Printable(APP_VERSION_STR));
+    qCInfo(mApp, "Build revision: %s", BUILD_REVISION);
+    qCInfo(mApp, "%s", qUtf8Printable(buildCompatibilityString()));
+    qCInfo(mApp, "Built on %s at %s", __DATE__, __TIME__);
+    qCInfo(mApp, "Command-line arguments: %s", qUtf8Printable(arguments().join(", ")));
+    qCInfo(mApp, "Process ID: %s", qUtf8Printable(QString().setNum(applicationPid())));
 
     loadTranslations(QLocale().name());// By default the console version uses system locale
 
@@ -444,15 +444,15 @@ void MApplication::InitTrVars()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-bool MApplication::event(QEvent *e)
+bool MApplication::event(QEvent *event)
 {
-    switch(e->type())
+    switch(event->type())
     {
         // In Mac OS X the QFileOpenEvent event is generated when user perform "Open With" from Finder (this event is
         // Mac specific).
         case QEvent::FileOpen:
         {
-            QFileOpenEvent *fileOpenEvent = static_cast<QFileOpenEvent *>(e);
+            QFileOpenEvent *fileOpenEvent = static_cast<QFileOpenEvent *>(event);
             const QString macFileOpen = fileOpenEvent->file();
             if(not macFileOpen.isEmpty())
             {
@@ -478,9 +478,9 @@ bool MApplication::event(QEvent *e)
         }
 #endif //defined(Q_OS_MAC)
         default:
-            return VAbstractApplication::event(e);
+            return VAbstractApplication::event(event);
     }
-    return VAbstractApplication::event(e);
+    return VAbstractApplication::event(event);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -638,7 +638,7 @@ void MApplication::ParseCommandLine(const SocketConnection &connection, const QS
         socket.connectToServer(serverName);
         if (socket.waitForConnected(1000))
         {
-            qCDebug(mApp, "Connected to the server '%s'", qUtf8Printable(serverName));
+            qCInfo(mApp, "Connected to the server '%s'", qUtf8Printable(serverName));
             QTextStream stream(&socket);
             stream << QCoreApplication::arguments().join(";;");
             stream.flush();
@@ -647,13 +647,13 @@ void MApplication::ParseCommandLine(const SocketConnection &connection, const QS
             return;
         }
 
-        qCDebug(mApp, "Can't establish connection to the server '%s'", qUtf8Printable(serverName));
+        qCWarning(mApp, "Can't establish connection to the server '%s'", qUtf8Printable(serverName));
 
         localServer = new QLocalServer(this);
         connect(localServer, &QLocalServer::newConnection, this, &MApplication::NewLocalSocketConnection);
         if (not localServer->listen(serverName))
         {
-            qCDebug(mApp, "Can't begin to listen for incoming connections on name '%s'",
+            qCWarning(mApp, "Can't begin to listen for incoming connections on name '%s'",
                     qUtf8Printable(serverName));
             if (localServer->serverError() == QAbstractSocket::AddressInUseError)
             {

--- a/src/app/seamlyme/tmainwindow.cpp
+++ b/src/app/seamlyme/tmainwindow.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *   @file   tmainwindow.cpp
  **  @author Douglas S Caskey
- **  @date   13 May, 2023
+ **  @date   17 Sep, 2023
  **
  **  @brief
  **  @copyright
@@ -343,10 +343,10 @@ bool TMainWindow::LoadFile(const QString &path)
 
 			MeasurementGUI();
 		}
-		catch (VException &e)
+		catch (VException &error)
 		{
 			qCCritical(tMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("File error.")),
-					   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+					   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
 			ui->labelToolTip->setVisible(true);
 			ui->tabWidget->setVisible(false);
 			delete individualMeasurements;
@@ -1427,11 +1427,11 @@ void TMainWindow::Fx()
 	   // Translate to internal look.
 	   meash = data->GetVariable<VMeasurement>(nameField->data(Qt::UserRole).toString());
 	}
-	catch(const VExceptionBadId & e)
+    catch(const VExceptionBadId &error)
 	{
 		qCCritical(tMainWindow, "%s\n\n%s\n\n%s",
 				   qUtf8Printable(tr("Can't find measurement '%1'.").arg(nameField->text())),
-				   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+				   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
 		return;
 	}
 
@@ -1579,10 +1579,10 @@ void TMainWindow::ImportFromPattern()
 		doc->setXMLContent(converter.Convert());
 		measurements = doc->ListMeasurements();
 	}
-	catch (VException &e)
+	catch (VException &error)
 	{
 		qCCritical(tMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("File error.")),
-				   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+				   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
 		return;
 	}
 
@@ -1660,9 +1660,9 @@ void TMainWindow::ShowNewMData(bool fresh)
 			// Translate to internal look.
 			meash = data->GetVariable<VMeasurement>(nameField->data(Qt::UserRole).toString());
 		}
-		catch(const VExceptionBadId &e)
+		catch(const VExceptionBadId &error)
 		{
-			Q_UNUSED(e)
+			Q_UNUSED(error)
 			MFields(false);
 			return;
 		}
@@ -1723,9 +1723,9 @@ void TMainWindow::ShowNewMData(bool fresh)
 			{
 				formula = qApp->TrVars()->FormulaToUser(meash->GetFormula(), qApp->Settings()->GetOsSeparator());
 			}
-			catch (qmu::QmuParserError &e)
+			catch (qmu::QmuParserError &error)
 			{
-				Q_UNUSED(e)
+				Q_UNUSED(error)
 				formula = meash->GetFormula();
 			}
 
@@ -1823,11 +1823,11 @@ void TMainWindow::SaveMName(const QString &text)
 		// Translate to internal look.
 		meash = data->GetVariable<VMeasurement>(nameField->data(Qt::UserRole).toString());
 	}
-	catch(const VExceptionBadId &e)
+	catch(const VExceptionBadId &error)
 	{
 		qCWarning(tMainWindow, "%s\n\n%s\n\n%s",
 				  qUtf8Printable(tr("Can't find measurement '%1'.").arg(nameField->text())),
-				  qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+				  qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
 		return;
 	}
 
@@ -1902,15 +1902,15 @@ void TMainWindow::SaveMValue()
 		// Translate to internal look.
 		meash = data->GetVariable<VMeasurement>(nameField->data(Qt::UserRole).toString());
 	}
-	catch(const VExceptionBadId & e)
+    catch(const VExceptionBadId &error)
 	{
 		qCWarning(tMainWindow, "%s\n\n%s\n\n%s",
 				  qUtf8Printable(tr("Can't find measurement '%1'.").arg(nameField->text())),
-				  qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+				  qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
 		return;
 	}
 
-	if (not EvalFormula(text, true, meash->GetData(), ui->labelCalculatedValue))
+    if (!EvalFormula(text, true, meash->GetData(), ui->labelCalculatedValue))
 	{
 		return;
 	}
@@ -1920,9 +1920,9 @@ void TMainWindow::SaveMValue()
 		const QString formula = qApp->TrVars()->FormulaFromUser(text, qApp->Settings()->GetOsSeparator());
 		individualMeasurements->SetMValue(nameField->data(Qt::UserRole).toString(), formula);
 	}
-	catch (qmu::QmuParserError &e) // Just in case something bad will happen
+	catch (qmu::QmuParserError &error) // Just in case something bad will happen
 	{
-		Q_UNUSED(e)
+		Q_UNUSED(error)
 		return;
 	}
 
@@ -2061,11 +2061,11 @@ void TMainWindow::SaveMFullName()
 		// Translate to internal look.
 		meash = data->GetVariable<VMeasurement>(nameField->data(Qt::UserRole).toString());
 	}
-	catch(const VExceptionBadId &e)
+	catch(const VExceptionBadId &error)
 	{
 		qCWarning(tMainWindow, "%s\n\n%s\n\n%s",
 				  qUtf8Printable(tr("Can't find measurement '%1'.").arg(nameField->text())),
-				  qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+				  qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
 		return;
 	}
 
@@ -2647,9 +2647,9 @@ void TMainWindow::RefreshTable(bool freshCall)
 			{
 				formula = qApp->TrVars()->FormulaToUser(meash->GetFormula(), qApp->Settings()->GetOsSeparator());
 			}
-			catch (qmu::QmuParserError &e)
+			catch (qmu::QmuParserError &error)
 			{
-				Q_UNUSED(e)
+				Q_UNUSED(error)
 				formula = meash->GetFormula();
 			}
 
@@ -2904,10 +2904,10 @@ bool TMainWindow::EvalFormula(const QString &formula, bool fromUser, VContainer 
 			label->setToolTip(tr("Value"));
 			return true;
 		}
-		catch (qmu::QmuParserError &e)
+		catch (qmu::QmuParserError &error)
 		{
-			label->setText(tr("Error") + " (" + postfix + "). " + tr("Parser error: %1").arg(e.GetMsg()));
-			label->setToolTip(tr("Parser error: %1").arg(e.GetMsg()));
+			label->setText(tr("Error") + " (" + postfix + "). " + tr("Parser error: %1").arg(error.GetMsg()));
+			label->setToolTip(tr("Parser error: %1").arg(error.GetMsg()));
 			return false;
 		}
 	}
@@ -3112,10 +3112,10 @@ bool TMainWindow::LoadFromExistingFile(const QString &path)
 			UpdatePadlock(mIsReadOnly);
 			MeasurementGUI();
 		}
-		catch (VException &e)
+		catch (VException &error)
 		{
 			qCCritical(tMainWindow, "%s\n\n%s\n\n%s", qUtf8Printable(tr("File error.")),
-					   qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+					   qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
 			ui->labelToolTip->setVisible(true);
 			ui->tabWidget->setVisible(false);
 			delete individualMeasurements;
@@ -3237,8 +3237,8 @@ bool TMainWindow::IgnoreLocking(int error, const QString &path)
 
 	if (answer == QMessageBox::Abort)
 	{
-		qCDebug(tMainWindow, "Failed to lock %s", qUtf8Printable(path));
-		qCDebug(tMainWindow, "Error type: %d", error);
+		qCWarning(tMainWindow, "Failed to lock %s", qUtf8Printable(path));
+		qCWarning(tMainWindow, "Error type: %d", error);
 		if (qApp->IsTestMode())
 		{
 			switch(error)

--- a/src/libs/fervor/fvupdater.cpp
+++ b/src/libs/fervor/fvupdater.cpp
@@ -1,3 +1,27 @@
+/***************************************************************************
+ **  @file   fvupdater.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
 /***************************************************************************************************
  **
  **  Copyright (c) 2012 Linas Valiukas and others.
@@ -265,7 +289,7 @@ void FvUpdater::fileDownloadFinished(QFile *downloadedFile, QString name) {
 		QProcess proc;
 		auto	 res = proc.startDetached(QDir::toNativeSeparators(fileInfo.absoluteFilePath()), QStringList());
 		auto	 err = proc.error();
-		qDebug() << res << " " << err;
+		qWarning() << res << " " << err;
 #else
 
 		QDesktopServices::openUrl(QUrl::fromLocalFile(fileInfo.absoluteFilePath()));

--- a/src/libs/ifc/exception/vexception.cpp
+++ b/src/libs/ifc/exception/vexception.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vexception.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vexception.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -64,7 +64,9 @@
  * @param error string with error
  */
 VException::VException(const QString &error)
-    :QException(), error(error), moreInfo(QString())
+    : QException()
+    , error(error)
+    , moreInfo(QString())
 {
     Q_ASSERT_X(not error.isEmpty(), Q_FUNC_INFO, "Error message is empty");
 }
@@ -74,18 +76,18 @@ VException::VException(const QString &error)
  * @brief VException copy constructor
  * @param e exception
  */
-VException::VException(const VException &e):error(e.WhatUtf8()), moreInfo(e.MoreInformation())
+VException::VException(const VException &error):error(error.WhatUtf8()), moreInfo(error.MoreInformation())
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
-VException &VException::operator=(const VException &e)
+VException &VException::operator=(const VException &error)
 {
-    if ( &e == this )
+    if (&error == this)
     {
         return *this;
     }
-    this->error = e.WhatUtf8();
-    this->moreInfo = e.MoreInformation();
+    this->error = error.WhatUtf8();
+    this->moreInfo = error.MoreInformation();
     return *this;
 }
 
@@ -165,24 +167,24 @@ const char* VException::what() const V_NOEXCEPT_EXPR (true)
 
 //-----------------------------------------VExceptionToolWasDeleted----------------------------------------------------
 VExceptionToolWasDeleted::VExceptionToolWasDeleted(const QString &error)
-    :VException(error)
+    : VException(error)
 {
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-VExceptionToolWasDeleted::VExceptionToolWasDeleted(const VExceptionToolWasDeleted &e)
-    :VException(e)
+VExceptionToolWasDeleted::VExceptionToolWasDeleted(const VExceptionToolWasDeleted &error)
+    : VException(error)
 {
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-VExceptionToolWasDeleted &VExceptionToolWasDeleted::operator=(const VExceptionToolWasDeleted &e)
+VExceptionToolWasDeleted &VExceptionToolWasDeleted::operator=(const VExceptionToolWasDeleted &error)
 {
-    if ( &e == this )
+    if (&error == this)
     {
         return *this;
     }
-    VException::operator=(e);
+    VException::operator = (error);
     return *this;
 }
 

--- a/src/libs/ifc/exception/vexception.h
+++ b/src/libs/ifc/exception/vexception.h
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vexception.h
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vexception.h
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -67,8 +67,8 @@ class VException : public QException
     Q_DECLARE_TR_FUNCTIONS(VException)
 public:
     explicit VException(const QString &error);
-    VException(const VException &e);
-    VException &operator=(const VException &e);
+    VException(const VException &error);
+    VException &operator=(const VException &error);
     virtual ~VException() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
 
     Q_NORETURN virtual void raise() const Q_DECL_OVERRIDE;
@@ -119,8 +119,8 @@ class VExceptionToolWasDeleted : public VException
     Q_DECLARE_TR_FUNCTIONS(VExceptionToolDeleted)
 public:
     explicit VExceptionToolWasDeleted(const QString &error);
-    VExceptionToolWasDeleted(const VExceptionToolWasDeleted &e);
-    VExceptionToolWasDeleted &operator=(const VExceptionToolWasDeleted &e);
+    VExceptionToolWasDeleted(const VExceptionToolWasDeleted &error);
+    VExceptionToolWasDeleted &operator=(const VExceptionToolWasDeleted &error);
     virtual ~VExceptionToolWasDeleted() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
 
     Q_NORETURN virtual void raise() const Q_DECL_OVERRIDE;

--- a/src/libs/ifc/exception/vexceptionbadid.cpp
+++ b/src/libs/ifc/exception/vexceptionbadid.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vexceptionbadid.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vexceptionbadid.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -60,7 +60,9 @@
  * @param id id
  */
 VExceptionBadId::VExceptionBadId(const QString &error, const quint32 &id)
-    :VException(error), id(id), key(QString()){}
+    : VException(error)
+    , id(id)
+    , key(QString()){}
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
@@ -69,26 +71,28 @@ VExceptionBadId::VExceptionBadId(const QString &error, const quint32 &id)
  * @param key string key
  */
 VExceptionBadId::VExceptionBadId(const QString &error, const QString &key)
-    :VException(error), id(NULL_ID), key(key){}
+    : VException(error), id(NULL_ID), key(key){}
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
  * @brief VExceptionBadId copy constructor
  * @param e exception
  */
-VExceptionBadId::VExceptionBadId(const VExceptionBadId &e)
-    :VException(e), id(e.BadId()), key(e.BadKey()){}
+VExceptionBadId::VExceptionBadId(const VExceptionBadId &error)
+    : VException(error)
+    , id(error.BadId())
+    , key(error.BadKey()){}
 
 //---------------------------------------------------------------------------------------------------------------------
-VExceptionBadId &VExceptionBadId::operator=(const VExceptionBadId &e)
+VExceptionBadId &VExceptionBadId::operator=(const VExceptionBadId &error)
 {
-    if ( &e == this )
+    if ( &error == this )
     {
         return *this;
     }
-    VException::operator=(e);
-    this->id = e.BadId();
-    this->key = e.BadKey();
+    VException::operator=(error);
+    this->id = error.BadId();
+    this->key = error.BadKey();
     return *this;
 }
 

--- a/src/libs/ifc/exception/vexceptionbadid.h
+++ b/src/libs/ifc/exception/vexceptionbadid.h
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vexceptionbadid.h
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vexceptionbadid.h
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -67,8 +67,8 @@ class VExceptionBadId : public VException
 public:
     VExceptionBadId(const QString &error, const quint32 &id);
     VExceptionBadId(const QString &error, const QString &key);
-    VExceptionBadId(const VExceptionBadId &e);
-    VExceptionBadId &operator=(const VExceptionBadId &e);
+    VExceptionBadId(const VExceptionBadId &error);
+    VExceptionBadId &operator=(const VExceptionBadId &error);
     virtual         ~VExceptionBadId() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
     virtual QString ErrorMessage() const Q_DECL_OVERRIDE;
     quint32         BadId() const;

--- a/src/libs/ifc/exception/vexceptionconversionerror.cpp
+++ b/src/libs/ifc/exception/vexceptionconversionerror.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vexceptionconversionerror.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,11 +19,10 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
  **  @file   vexceptionconversionerror.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -29,17 +30,17 @@
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -62,7 +63,8 @@
  * @param str string, where happend error
  */
 VExceptionConversionError::VExceptionConversionError(const QString &error, const QString &str)
-    :VException(error), str(str)
+    : VException(error)
+    , str(str)
 {
     Q_ASSERT_X(not str.isEmpty(), Q_FUNC_INFO, "Error converting string is empty");
 }
@@ -72,19 +74,20 @@ VExceptionConversionError::VExceptionConversionError(const QString &error, const
  * @brief VExceptionConversionError copy constructor
  * @param e exception
  */
-VExceptionConversionError::VExceptionConversionError(const VExceptionConversionError &e)
-    :VException(e), str(e.String())
+VExceptionConversionError::VExceptionConversionError(const VExceptionConversionError &error)
+    : VException(error)
+    , str(error.String())
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
-VExceptionConversionError &VExceptionConversionError::operator=(const VExceptionConversionError &e)
+VExceptionConversionError &VExceptionConversionError::operator=(const VExceptionConversionError &error)
 {
-    if ( &e == this )
+    if (&error == this)
     {
         return *this;
     }
-    VException::operator=(e);
-    str = e.String();
+    VException::operator=(error);
+    str = error.String();
     return *this;
 }
 

--- a/src/libs/ifc/exception/vexceptionconversionerror.h
+++ b/src/libs/ifc/exception/vexceptionconversionerror.h
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vexceptionconversionerror.h
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,11 +19,10 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
  **  @file   vexceptionconversionerror.h
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -29,17 +30,17 @@
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -65,8 +66,8 @@ class VExceptionConversionError : public VException
 {
 public:
     VExceptionConversionError(const QString &error, const QString &str);
-    VExceptionConversionError(const VExceptionConversionError &e);
-    VExceptionConversionError &operator=(const VExceptionConversionError &e);
+    VExceptionConversionError(const VExceptionConversionError &error);
+    VExceptionConversionError &operator=(const VExceptionConversionError &error);
     virtual         ~VExceptionConversionError() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
     virtual QString ErrorMessage() const Q_DECL_OVERRIDE;
     QString         String() const;

--- a/src/libs/ifc/exception/vexceptionemptyparameter.cpp
+++ b/src/libs/ifc/exception/vexceptionemptyparameter.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vexceptionemptyparameter.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,11 +19,10 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
  **  @file   vexceptionemptyparameter.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -29,17 +30,17 @@
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -65,7 +66,11 @@
  */
 VExceptionEmptyParameter::VExceptionEmptyParameter(const QString &what, const QString &name,
                                                    const QDomElement &domElement)
-    : VException(what), name(name), tagText(QString()), tagName(QString()), lineNumber(-1)
+    : VException(what)
+    , name(name)
+    , tagText(QString())
+    , tagName(QString())
+    , lineNumber(-1)
 {
     Q_ASSERT_X(not domElement.isNull(), Q_FUNC_INFO, "domElement is null");
     Q_ASSERT_X(not name.isEmpty(), Q_FUNC_INFO, "Parameter name is empty");
@@ -80,22 +85,26 @@ VExceptionEmptyParameter::VExceptionEmptyParameter(const QString &what, const QS
  * @brief VExceptionEmptyParameter copy constructor
  * @param e exception
  */
-VExceptionEmptyParameter::VExceptionEmptyParameter(const VExceptionEmptyParameter &e)
-    :VException(e), name(e.Name()), tagText(e.TagText()), tagName(e.TagName()), lineNumber(e.LineNumber())
+VExceptionEmptyParameter::VExceptionEmptyParameter(const VExceptionEmptyParameter &error)
+    : VException(error)
+    , name(error.Name())
+    , tagText(error.TagText())
+    , tagName(error.TagName())
+    , lineNumber(error.LineNumber())
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
-VExceptionEmptyParameter &VExceptionEmptyParameter::operator=(const VExceptionEmptyParameter &e)
+VExceptionEmptyParameter &VExceptionEmptyParameter::operator=(const VExceptionEmptyParameter &error)
 {
-    if ( &e == this )
+    if (&error == this)
     {
         return *this;
     }
-    VException::operator=(e);
-    name = e.Name();
-    tagText = e.TagText();
-    tagName = e.TagName();
-    lineNumber = e.LineNumber();
+    VException::operator=(error);
+    name = error.Name();
+    tagText = error.TagText();
+    tagName = error.TagName();
+    lineNumber = error.LineNumber();
     return *this;
 }
 

--- a/src/libs/ifc/exception/vexceptionemptyparameter.h
+++ b/src/libs/ifc/exception/vexceptionemptyparameter.h
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vexceptionemptyparameter.h
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vexceptionemptyparameter.h
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -68,8 +68,8 @@ class VExceptionEmptyParameter : public VException
 {
 public:
     VExceptionEmptyParameter(const QString &what, const QString &name, const QDomElement &domElement);
-    VExceptionEmptyParameter(const VExceptionEmptyParameter &e);
-    VExceptionEmptyParameter &operator=(const VExceptionEmptyParameter &e);
+    VExceptionEmptyParameter(const VExceptionEmptyParameter &error);
+    VExceptionEmptyParameter &operator=(const VExceptionEmptyParameter &error);
     virtual         ~VExceptionEmptyParameter() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
     virtual QString ErrorMessage() const Q_DECL_OVERRIDE;
     virtual QString DetailedInformation() const Q_DECL_OVERRIDE;

--- a/src/libs/ifc/exception/vexceptionobjecterror.cpp
+++ b/src/libs/ifc/exception/vexceptionobjecterror.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vexceptionobjecterror.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vexceptionobjecterror.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -63,7 +63,10 @@
  * @param domElement dom element
  */
 VExceptionObjectError::VExceptionObjectError(const QString &what, const QDomElement &domElement)
-    :VException(what), tagText(QString()), tagName(QString()), lineNumber(-1)
+    : VException(what)
+    , tagText(QString())
+    , tagName(QString())
+    , lineNumber(-1)
 {
     Q_ASSERT_X(not domElement.isNull(), Q_FUNC_INFO, "domElement is null");
     QTextStream stream(&tagText);
@@ -77,21 +80,24 @@ VExceptionObjectError::VExceptionObjectError(const QString &what, const QDomElem
  * @brief VExceptionObjectError copy constructor
  * @param e exception
  */
-VExceptionObjectError::VExceptionObjectError(const VExceptionObjectError &e)
-    :VException(e), tagText(e.TagText()), tagName(e.TagName()), lineNumber(e.LineNumber())
+VExceptionObjectError::VExceptionObjectError(const VExceptionObjectError &error)
+    : VException(error)
+    , tagText(error.TagText())
+    , tagName(error.TagName())
+    , lineNumber(error.LineNumber())
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
-VExceptionObjectError &VExceptionObjectError::operator=(const VExceptionObjectError &e)
+VExceptionObjectError &VExceptionObjectError::operator=(const VExceptionObjectError &error)
 {
-    if ( &e == this )
+    if (&error == this)
     {
         return *this;
     }
-    VException::operator=(e);
-    tagText = e.TagText();
-    tagName = e.TagName();
-    lineNumber = e.LineNumber();
+    VException::operator=(error);
+    tagText = error.TagText();
+    tagName = error.TagName();
+    lineNumber = error.LineNumber();
     return *this;
 }
 

--- a/src/libs/ifc/exception/vexceptionobjecterror.h
+++ b/src/libs/ifc/exception/vexceptionobjecterror.h
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vexceptionobjecterror.h
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vexceptionobjecterror.h
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -68,8 +68,8 @@ class VExceptionObjectError : public VException
 {
 public:
     VExceptionObjectError(const QString &what, const QDomElement &domElement);
-    VExceptionObjectError(const VExceptionObjectError &e);
-    VExceptionObjectError &operator=(const VExceptionObjectError &e);
+    VExceptionObjectError(const VExceptionObjectError &error);
+    VExceptionObjectError &operator=(const VExceptionObjectError &error);
     virtual ~VExceptionObjectError() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
     virtual QString ErrorMessage() const Q_DECL_OVERRIDE;
     virtual QString DetailedInformation() const Q_DECL_OVERRIDE;

--- a/src/libs/ifc/exception/vexceptionundo.cpp
+++ b/src/libs/ifc/exception/vexceptionundo.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vexceptionundo.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,28 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
  **  @file   vexceptionundo.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   23 6, 2014
+ **  @date   23 Jun, 2014
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2014 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -55,10 +56,10 @@
 
 //---------------------------------------------------------------------------------------------------------------------
 VExceptionUndo::VExceptionUndo(const QString &what)
-    :VException(what)
+    : VException(what)
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
-VExceptionUndo::VExceptionUndo(const VExceptionUndo &e)
-    :VException(e)
+VExceptionUndo::VExceptionUndo(const VExceptionUndo &error)
+    : VException(error)
 {}

--- a/src/libs/ifc/exception/vexceptionundo.h
+++ b/src/libs/ifc/exception/vexceptionundo.h
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vexceptionundo.h
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vexceptionundo.h
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   23 6, 2014
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2014 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -62,7 +62,7 @@ class VExceptionUndo : public VException
 {
 public:
     explicit VExceptionUndo(const QString &what);
-    VExceptionUndo(const VExceptionUndo &e);
+    VExceptionUndo(const VExceptionUndo &error);
     virtual ~VExceptionUndo() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
 };
 

--- a/src/libs/ifc/exception/vexceptionwrongid.cpp
+++ b/src/libs/ifc/exception/vexceptionwrongid.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vexceptionwrongparameterid.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,11 +19,10 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
  **  @file   vexceptionwrongparameterid.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -29,17 +30,17 @@
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -63,7 +64,10 @@
  * @param domElement som element
  */
 VExceptionWrongId::VExceptionWrongId(const QString &what, const QDomElement &domElement)
-    :VException(what), tagText(QString()), tagName(QString()), lineNumber(-1)
+    : VException(what)
+    , tagText(QString())
+    , tagName(QString())
+    , lineNumber(-1)
 {
     Q_ASSERT_X(not domElement.isNull(), Q_FUNC_INFO, "domElement is null");
     QTextStream stream(&tagText);
@@ -77,21 +81,24 @@ VExceptionWrongId::VExceptionWrongId(const QString &what, const QDomElement &dom
  * @brief VExceptionWrongId copy constructor
  * @param e exception
  */
-VExceptionWrongId::VExceptionWrongId(const VExceptionWrongId &e)
-    :VException(e), tagText(e.TagText()), tagName(e.TagName()), lineNumber(e.LineNumber())
+VExceptionWrongId::VExceptionWrongId(const VExceptionWrongId &error)
+    : VException(error)
+    , tagText(error.TagText())
+    , tagName(error.TagName())
+    , lineNumber(error.LineNumber())
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
-VExceptionWrongId &VExceptionWrongId::operator=(const VExceptionWrongId &e)
+VExceptionWrongId &VExceptionWrongId::operator=(const VExceptionWrongId &error)
 {
-    if ( &e == this )
+    if (&error == this)
     {
         return *this;
     }
-    VException::operator=(e);
-    tagText = e.TagText();
-    tagName = e.TagName();
-    lineNumber = e.LineNumber();
+    VException::operator=(error);
+    tagText = error.TagText();
+    tagName = error.TagName();
+    lineNumber = error.LineNumber();
     return *this;
 }
 

--- a/src/libs/ifc/exception/vexceptionwrongid.h
+++ b/src/libs/ifc/exception/vexceptionwrongid.h
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vexceptionwrongparameterid.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,28 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
- **  @file   vexceptionwrongparameterid.h
+ **  @file   vexceptionwrongparameterid.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -67,15 +68,16 @@ class QDomElement;
 class VExceptionWrongId : public VException
 {
 public:
-    VExceptionWrongId(const QString &what, const QDomElement &domElement);
-    VExceptionWrongId(const VExceptionWrongId &e);
-    VExceptionWrongId &operator=(const VExceptionWrongId &e);
-    virtual ~VExceptionWrongId() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
+                    VExceptionWrongId(const QString &what, const QDomElement &domElement);
+                    VExceptionWrongId(const VExceptionWrongId &error);
+                    VExceptionWrongId &operator=(const VExceptionWrongId &error);
+    virtual        ~VExceptionWrongId() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
     virtual QString ErrorMessage() const Q_DECL_OVERRIDE;
     virtual QString DetailedInformation() const Q_DECL_OVERRIDE;
     QString         TagText() const;
     QString         TagName() const;
     qint32          LineNumber() const;
+    
 protected:
     /** @brief tagText tag text */
     QString         tagText;

--- a/src/libs/ifc/xml/vabstractconverter.cpp
+++ b/src/libs/ifc/xml/vabstractconverter.cpp
@@ -1,10 +1,10 @@
 /***************************************************************************
  **  @file   vabstractconverter.cpp
  **  @author Douglas S Caskey
- **  @date   Dec 27, 2022
+ **  @date  17 Sep, 2023
  **
  **  @copyright
- **  Copyright (C) 2017 - 2022 Seamly, LLC
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
  **  https://github.com/fashionfreedom/seamly2d
  **
  **  @brief
@@ -73,15 +73,15 @@
 
 //---------------------------------------------------------------------------------------------------------------------
 VAbstractConverter::VAbstractConverter(const QString &fileName)
-    : VDomDocument(),
-      m_ver(0x0),
-      m_convertedFileName(fileName),
-      m_tmpFile()
+    : VDomDocument()
+    , m_ver(0x0)
+    , m_convertedFileName(fileName)
+    , m_tmpFile()
 {
     setXMLContent(m_convertedFileName);// Throw an exception on error
     m_ver = GetVersion(GetVersionStr());
 
-    qDebug() << "VAbstractConverter::GetVersion() = " << m_ver;
+    qInfo() << "VAbstractConverter::GetVersion() = " << m_ver;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -92,7 +92,7 @@ QString VAbstractConverter::Convert()
         return m_convertedFileName;
     }
 
-    if (not IsReadOnly())
+    if (!IsReadOnly())
     {
         ReserveFile();
     }
@@ -107,8 +107,8 @@ QString VAbstractConverter::Convert()
         throw VException(errorMsg);
     }
 
-    qDebug() << " m_ver = " << m_ver;
-    qDebug() << " MaxVer = " << MaxVer();
+    qInfo() << " m_ver = " << m_ver;
+    qInfo() << " MaxVer = " << MaxVer();
 
     m_ver < MaxVer() ? ApplyPatches() : DowngradeToCurrentMaxVersion();
 
@@ -143,7 +143,7 @@ QString VAbstractConverter::GetVersionStr() const
         const QDomElement domElement = domNode.toElement();
         if (domElement.isNull() == false)
         {
-            qDebug() << " VAbstractConverter::GetVersionStr()" << domElement.text();
+            qInfo() << " VAbstractConverter::GetVersionStr()" << domElement.text();
             return domElement.text();
         }
     }
@@ -159,21 +159,21 @@ int VAbstractConverter::GetVersion(const QString &version)
 
     bool ok = false;
     const int major = ver.at(0).toInt(&ok);
-    if (not ok)
+    if (!ok)
     {
         return 0x0;
     }
 
     ok = false;
     const int minor = ver.at(1).toInt(&ok);
-    if (not ok)
+    if (!ok)
     {
         return 0x0;
     }
 
     ok = false;
     const int patch = ver.at(2).toInt(&ok);
-    if (not ok)
+    if (!ok)
     {
         return 0x0;
     }
@@ -282,7 +282,7 @@ void VAbstractConverter::ReserveFile() const
         sequencePart = QString("_(%1)").arg(++sequenceNumber);
     } while (QFileInfo(reserveFileName).exists());
 
-    if (not SafeCopy(m_convertedFileName, reserveFileName, error))
+    if (!SafeCopy(m_convertedFileName, reserveFileName, error))
     {
 #ifdef Q_OS_WIN32
         qt_ntfs_permission_lookup++; // turn checking on
@@ -292,7 +292,7 @@ void VAbstractConverter::ReserveFile() const
         qt_ntfs_permission_lookup--; // turn it off again
 #endif /*Q_OS_WIN32*/
 
-        if (not IsReadOnly() && isFileWritable)
+        if (!IsReadOnly() && isFileWritable)
         {
             const QString errorMsg(tr("Error creating a reserv copy: %1.").arg(error));
             throw VException(errorMsg);
@@ -366,7 +366,7 @@ void VAbstractConverter::ValidateInputFile(const QString &currentSchema) const
     {
         schema = XSDSchema(m_ver);
     }
-    catch(const VException &e)
+    catch(const VException &error)
     {
         if (m_ver < MinVer())
         { // Version less than minimally supported version. Can't do anything.
@@ -381,7 +381,7 @@ void VAbstractConverter::ValidateInputFile(const QString &currentSchema) const
             catch(const VException &exp)
             { // Nope, we can't.
                 Q_UNUSED(exp)
-                throw e;
+                throw error;
             }
         }
         else
@@ -402,9 +402,9 @@ void VAbstractConverter::Save()
     {
         TestUniqueId();
     }
-    catch (const VExceptionWrongId &e)
+    catch (const VExceptionWrongId &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         VException ex(tr("Error no unique id."));
         throw ex;
     }
@@ -415,7 +415,7 @@ void VAbstractConverter::Save()
     out.setCodec("UTF-8");
     save(out, indent);
 
-    if (not m_tmpFile.flush())
+    if (!m_tmpFile.flush())
     {
         VException e(m_tmpFile.errorString());
         throw e;

--- a/src/libs/ifc/xml/vabstractpattern.cpp
+++ b/src/libs/ifc/xml/vabstractpattern.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   vabstractpattern.cpp
  **  @author Douglas S Caskey
- **  @date   Mar 1, 2023
+ **  @date   17 Sep, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2023 Seamly, LLC
@@ -240,9 +240,9 @@ void ReadExpressionAttribute(QVector<VFormulaField> &expressions, const QDomElem
     {
         formula.expression = VDomDocument::GetParametrString(element, attribute);
     }
-    catch (VExceptionEmptyParameter &e)
+    catch (VExceptionEmptyParameter &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;
     }
 
@@ -539,18 +539,18 @@ QDomElement VAbstractPattern::getDraftBlockElement(const QString &name)
  */
 bool VAbstractPattern::renameDraftBlock(const QString &oldName, const QString &newName)
 {
-    Q_ASSERT_X(not newName.isEmpty(), Q_FUNC_INFO, "new name draft block is empty");
-    Q_ASSERT_X(not oldName.isEmpty(), Q_FUNC_INFO, "old name draft block is empty");
+    Q_ASSERT_X(!newName.isEmpty(), Q_FUNC_INFO, "new name draft block is empty");
+    Q_ASSERT_X(!oldName.isEmpty(), Q_FUNC_INFO, "old name draft block is empty");
 
     if (draftBlockNameExists(oldName) == false)
     {
-        qDebug()<<"Do not exist draft block with name"<<oldName;
+        qWarning() << "Draft block does not exist with name" << oldName;
         return false;
     }
 
     if (draftBlockNameExists(newName))
     {
-        qDebug()<<"Already exist draft block with name"<<newName;
+        qWarning() << "Draft block already exists with name" << newName;
         return false;
     }
 
@@ -568,7 +568,7 @@ bool VAbstractPattern::renameDraftBlock(const QString &oldName, const QString &n
     }
     else
     {
-        qDebug()<<"Can't find draft block node with name"<<oldName<<Q_FUNC_INFO;
+        qWarning() << "Can't find draft block node with name" << oldName << Q_FUNC_INFO;
         return false;
     }
 }
@@ -893,7 +893,7 @@ void VAbstractPattern::SetMPath(const QString &path)
     }
     else
     {
-        qDebug()<<"Can't save path to measurements"<<Q_FUNC_INFO;
+        qWarning() << "Can't save path to measurements" << Q_FUNC_INFO;
     }
 }
 
@@ -1051,7 +1051,7 @@ void VAbstractPattern::SetGradationHeights(const QMap<GHeights, bool> &options)
     QDomNodeList tags = elementsByTagName(TagGradation);
     if (tags.isEmpty())
     {
-        qDebug()<<"Can't save tag "<<TagGradation<<Q_FUNC_INFO;
+        qWarning() << "Can't save tag " << TagGradation << Q_FUNC_INFO;
         return;
     }
 
@@ -1245,7 +1245,7 @@ void VAbstractPattern::SetGradationSizes(const QMap<GSizes, bool> &options)
     QDomNodeList tags = elementsByTagName(TagGradation);
     if (tags.isEmpty())
     {
-        qDebug()<<"Can't save tag "<<TagGradation<<Q_FUNC_INFO;
+        qWarning() << "Can't save tag " << TagGradation << Q_FUNC_INFO;
         return;
     }
 
@@ -1812,9 +1812,9 @@ QStringList VAbstractPattern::ListIncrements() const
         {
             increments.append(GetParametrString(dom, IncrementName));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
     }
 
@@ -2152,10 +2152,10 @@ QPair<bool, QMap<quint32, quint32> > VAbstractPattern::parseItemElement(const QD
 
         return group;
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
         VExceptionObjectError excep(tr("Error creating or updating group"), domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }
@@ -2722,7 +2722,7 @@ QDomElement VAbstractPattern::addGroupItem(quint32 toolId, quint32 objectId, qui
     }
     else
     {
-        qDebug() << "The group of id " << groupId << " doesn't exist";
+        qWarning() << "The group of id " << groupId << " doesn't exist";
     }
 
     return QDomElement();
@@ -2790,7 +2790,7 @@ QDomElement VAbstractPattern::removeGroupItem(quint32 toolId, quint32 objectId, 
     }
     else
     {
-        qDebug() << "The group of id " << groupId << " doesn't exist";
+        qWarning() << "The group of id " << groupId << " doesn't exist";
     }
 
     return QDomElement();
@@ -2812,7 +2812,7 @@ bool VAbstractPattern::isGroupEmpty(quint32 id)
     }
     else
     {
-        qDebug() << "The group of id " << id << " doesn't exist";
+        qWarning() << "The group of id " << id << " doesn't exist";
         return true;
     }
 }
@@ -2827,7 +2827,7 @@ bool VAbstractPattern::getGroupVisibility(quint32 id)
     }
     else
     {
-        qDebug("Can't get group by id = %u.", id);
+        qWarning("Can't get group by id = %u.", id);
         return true;
     }
 }
@@ -2850,7 +2850,7 @@ void VAbstractPattern::setGroupVisibility(quint32 id, bool visible)
     }
     else
     {
-        qDebug("Can't get group by id = %u.", id);
+        qWarning("Can't get group by id = %u.", id);
     }
 }
 
@@ -2871,7 +2871,7 @@ bool VAbstractPattern::getGroupLock(quint32 id)
     }
     else
     {
-        qDebug("Can't get group by id = %u.", id);
+        qWarning("Can't get group by id = %u.", id);
         return true;
     }
 }

--- a/src/libs/ifc/xml/vdomdocument.cpp
+++ b/src/libs/ifc/xml/vdomdocument.cpp
@@ -1,39 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
-
- ************************************************************************
- **
  **  @file   vdomdocument.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   November 15, 2013
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
  **
  **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -45,9 +19,36 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+ /************************************************************************
+  **
+  **  @file   vtoolline.cpp
+  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
+  **  @date   November 15, 2013
+  **
+  **  @brief
+  **  @copyright
+  **  This source code is part of the Valentina project, a pattern making
+  **  program, whose allow create and modeling patterns of clothing.
+  **  Copyright (C) 2013-2015 Valentina project
+  **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+  **
+  **  Valentina is free software: you can redistribute it and/or modify
+  **  it under the terms of the GNU General Public License as published by
+  **  the Free Software Foundation, either version 3 of the License, or
+  **  (at your option) any later version.
+  **
+  **  Valentina is distributed in the hope that it will be useful,
+  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  **  GNU General Public License for more details.
+  **
+  **  You should have received a copy of the GNU General Public License
+  **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+  **
+  *************************************************************************/
 
 #include "vdomdocument.h"
 
@@ -369,10 +370,10 @@ quint32 VDomDocument::GetParametrUInt(const QDomElement &domElement, const QStri
             throw VExceptionConversionError(QObject::tr("Can't convert toUInt parameter"), name);
         }
     }
-    catch (const VExceptionEmptyParameter &e)
+    catch (const VExceptionEmptyParameter &error)
     {
         VExceptionConversionError excep(QObject::tr("Can't convert toUInt parameter"), name);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 
@@ -411,10 +412,10 @@ bool VDomDocument::getParameterBool(const QDomElement &domElement, const QString
                 throw VExceptionConversionError(message, name);
         }
     }
-    catch (const VExceptionEmptyParameter &e)
+    catch (const VExceptionEmptyParameter &error)
     {
         VExceptionConversionError excep(message, name);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 
@@ -516,10 +517,10 @@ qreal VDomDocument::GetParametrDouble(const QDomElement &domElement, const QStri
             throw VExceptionConversionError(message, name);
         }
     }
-    catch (const VExceptionEmptyParameter &e)
+    catch (const VExceptionEmptyParameter &error)
     {
         VExceptionConversionError excep(message, name);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
     return param;
@@ -546,10 +547,10 @@ quint32 VDomDocument::getParameterId(const QDomElement &domElement)
             throw VExceptionWrongId(message, domElement);
         }
     }
-    catch (const VExceptionConversionError &e)
+    catch (const VExceptionConversionError &error)
     {
         VExceptionWrongId excep(message, domElement);
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
     return id;
@@ -742,7 +743,7 @@ bool VDomDocument::SaveDocument(const QString &fileName, QString &error)
 {
     if (fileName.isEmpty())
     {
-        qDebug()<<"Got empty file name.";
+        qWarning() << "Got empty file name.";
         return false;
     }
     bool success = false;
@@ -805,7 +806,7 @@ bool VDomDocument::setTagText(const QString &tag, const QString &text)
     const QDomNodeList nodeList = this->elementsByTagName(tag);
     if (nodeList.isEmpty())
     {
-        qDebug()<<"Can't save tag "<<tag<<Q_FUNC_INFO;
+        qWarning() << "Can't save tag " << tag << Q_FUNC_INFO;
     }
     else
     {

--- a/src/libs/ifc/xml/vpatternconverter.cpp
+++ b/src/libs/ifc/xml/vpatternconverter.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   vpatternconverter.cpp
  **  @author Douglas S Caskey
- **  @date   Mar 2, 2023
+ **  @date   17 Sep, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2023 Seamly, LLC
@@ -1398,10 +1398,10 @@ QSet<QString> VPatternConverter::FixIncrementsToV0_2_0()
                         const QString base = GetParametrString(domElement, strBase);
                         domElement.setAttribute(strFormula, base);
                     }
-                    catch (VExceptionEmptyParameter &e)
+                    catch (VExceptionEmptyParameter &error)
                     {
                         VException excep("Can't get increment.");
-                        excep.AddMoreInformation(e.ErrorMessage());
+                        excep.AddMoreInformation(error.ErrorMessage());
                         throw excep;
                     }
                     domElement.removeAttribute(strId);
@@ -1434,9 +1434,9 @@ void VPatternConverter::FixPointExpressionsToV0_2_0(const QSet<QString> &names)
             formula = GetParametrString(dom, strLength);
             dom.setAttribute(strLength, FixIncrementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1444,18 +1444,18 @@ void VPatternConverter::FixPointExpressionsToV0_2_0(const QSet<QString> &names)
             formula = GetParametrString(dom, strAngle);
             dom.setAttribute(strAngle, FixIncrementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
         try
         {
             formula = GetParametrString(dom, strC1Radius);
             dom.setAttribute(strC1Radius, FixIncrementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1463,9 +1463,9 @@ void VPatternConverter::FixPointExpressionsToV0_2_0(const QSet<QString> &names)
             formula = GetParametrString(dom, strC2Radius);
             dom.setAttribute(strC2Radius, FixIncrementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1473,9 +1473,9 @@ void VPatternConverter::FixPointExpressionsToV0_2_0(const QSet<QString> &names)
             formula = GetParametrString(dom, strCRadius);
             dom.setAttribute(strCRadius, FixIncrementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
     }
 }
@@ -1498,9 +1498,9 @@ void VPatternConverter::FixArcExpressionsToV0_2_0(const QSet<QString> &names)
             formula = GetParametrString(dom, strAngle1);
             dom.setAttribute(strAngle1, FixIncrementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1508,9 +1508,9 @@ void VPatternConverter::FixArcExpressionsToV0_2_0(const QSet<QString> &names)
             formula = GetParametrString(dom, strAngle2);
             dom.setAttribute(strAngle2, FixIncrementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1518,9 +1518,9 @@ void VPatternConverter::FixArcExpressionsToV0_2_0(const QSet<QString> &names)
             formula = GetParametrString(dom, strRadius);
             dom.setAttribute(strRadius, FixIncrementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1528,9 +1528,9 @@ void VPatternConverter::FixArcExpressionsToV0_2_0(const QSet<QString> &names)
             formula = GetParametrString(dom, strLength);
             dom.setAttribute(strLength, FixIncrementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
     }
 }
@@ -1553,9 +1553,9 @@ void VPatternConverter::FixPathPointExpressionsToV0_2_0(const QSet<QString> &nam
             formula = GetParametrString(dom, strKAsm1);
             dom.setAttribute(strKAsm1, FixIncrementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1563,9 +1563,9 @@ void VPatternConverter::FixPathPointExpressionsToV0_2_0(const QSet<QString> &nam
             formula = GetParametrString(dom, strKAsm2);
             dom.setAttribute(strKAsm2, FixIncrementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1573,9 +1573,9 @@ void VPatternConverter::FixPathPointExpressionsToV0_2_0(const QSet<QString> &nam
             formula = GetParametrString(dom, strAngle);
             dom.setAttribute(strAngle, FixIncrementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
     }
 }
@@ -1598,9 +1598,9 @@ void VPatternConverter::ConvertPointExpressionsToV0_2_0(const QMap<QString, QStr
             formula = GetParametrString(dom, strLength);
             dom.setAttribute(strLength, FixMeasurementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1608,18 +1608,18 @@ void VPatternConverter::ConvertPointExpressionsToV0_2_0(const QMap<QString, QStr
             formula = GetParametrString(dom, strAngle);
             dom.setAttribute(strAngle, FixMeasurementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
         try
         {
             formula = GetParametrString(dom, strC1Radius);
             dom.setAttribute(strC1Radius, FixMeasurementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1627,9 +1627,9 @@ void VPatternConverter::ConvertPointExpressionsToV0_2_0(const QMap<QString, QStr
             formula = GetParametrString(dom, strC2Radius);
             dom.setAttribute(strC2Radius, FixMeasurementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1637,9 +1637,9 @@ void VPatternConverter::ConvertPointExpressionsToV0_2_0(const QMap<QString, QStr
             formula = GetParametrString(dom, strCRadius);
             dom.setAttribute(strCRadius, FixMeasurementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
     }
 }
@@ -1662,9 +1662,9 @@ void VPatternConverter::ConvertArcExpressionsToV0_2_0(const QMap<QString, QStrin
             formula = GetParametrString(dom, strAngle1);
             dom.setAttribute(strAngle1, FixMeasurementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1672,9 +1672,9 @@ void VPatternConverter::ConvertArcExpressionsToV0_2_0(const QMap<QString, QStrin
             formula = GetParametrString(dom, strAngle2);
             dom.setAttribute(strAngle2, FixMeasurementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1682,9 +1682,9 @@ void VPatternConverter::ConvertArcExpressionsToV0_2_0(const QMap<QString, QStrin
             formula = GetParametrString(dom, strRadius);
             dom.setAttribute(strRadius, FixMeasurementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1692,9 +1692,9 @@ void VPatternConverter::ConvertArcExpressionsToV0_2_0(const QMap<QString, QStrin
             formula = GetParametrString(dom, strLength);
             dom.setAttribute(strLength, FixMeasurementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
     }
 }
@@ -1717,9 +1717,9 @@ void VPatternConverter::ConvertPathPointExpressionsToV0_2_0(const QMap<QString, 
             formula = GetParametrString(dom, strKAsm1);
             dom.setAttribute(strKAsm1, FixMeasurementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1727,9 +1727,9 @@ void VPatternConverter::ConvertPathPointExpressionsToV0_2_0(const QMap<QString, 
             formula = GetParametrString(dom, strKAsm2);
             dom.setAttribute(strKAsm2, FixMeasurementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         try
@@ -1737,9 +1737,9 @@ void VPatternConverter::ConvertPathPointExpressionsToV0_2_0(const QMap<QString, 
             formula = GetParametrString(dom, strAngle);
             dom.setAttribute(strAngle, FixMeasurementInFormulaToV0_2_0(formula, names));
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
     }
 }
@@ -1879,10 +1879,10 @@ QString VPatternConverter::MUnitV0_1_4() const
     {
         return GetParametrString(element, strUnit);
     }
-    catch (VExceptionEmptyParameter &e)
+    catch (VExceptionEmptyParameter &error)
     {
         VException excep("Can't get unit.");
-        excep.AddMoreInformation(e.ErrorMessage());
+        excep.AddMoreInformation(error.ErrorMessage());
         throw excep;
     }
 }

--- a/src/libs/qmuparser/qmuparserbase.cpp
+++ b/src/libs/qmuparser/qmuparserbase.cpp
@@ -1,3 +1,26 @@
+/***************************************************************************
+ **  @file   qmuparserbase.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 /***************************************************************************************************
  **
  **  Copyright (C) 2013 Ingo Berg
@@ -53,9 +76,9 @@ bool QmuParserBase::g_DbgDumpStack = false;
  * When defining custom binary operators with #AddOprt(...) make sure not to choose
  * names conflicting with these definitions.
  */
-const QStringList QmuParserBase::c_DefaultOprt = QStringList()<< "<=" << ">=" << "!=" << "==" << "<"  << ">"  << "+"
-                                                              << "-"  << "*"  << "/"  << "^"  << "&&" << "||" << "="
-                                                              << "("  << ")"  << "?"  << ":";
+const QStringList QmuParserBase::c_DefaultOprt = QStringList() << "<=" << ">=" << "!=" << "==" << "<"  << ">"  << "+"
+                                                               << "-"  << "*"  << "/"  << "^"  << "&&" << "||" << "="
+                                                               << "("  << ")"  << "?"  << ":";
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
@@ -707,9 +730,9 @@ const varmap_type& QmuParserBase::GetUsedVar() const
         m_pParseFormula = &QmuParserBase::ParseString;
         m_pTokenReader->IgnoreUndefVar(false);
     }
-    catch (const QmuParserError &e)
+    catch (const QmuParserError &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         // Make sure to stay in string parse mode, dont call ReInit()
         // because it deletes the array with the used variables
         m_pParseFormula = &QmuParserBase::ParseString;
@@ -925,7 +948,7 @@ void QmuParserBase::ApplyBinOprt(QStack<token_type> &a_stOpt, QStack<token_type>
         {
             Error(ecUNEXPECTED_OPERATOR);
         }
-        
+
         token_type valTok1 = a_stVal.pop(),
                    valTok2 = a_stVal.pop(),
                    optTok  = a_stOpt.pop(),
@@ -1817,82 +1840,82 @@ void QmuParserBase::StackDump(const QStack<token_type> &a_stVal, const QStack<to
     QStack<token_type> stOprt(a_stOprt),
                        stVal(a_stVal);
 
-    qDebug() << "\nValue stack:\n";
+    qWarning() << "\nValue stack:\n";
     while ( stVal.empty() == false )
     {
         token_type val = stVal.pop();
         if (val.GetType()==tpSTR)
         {
-            qDebug() << " \"" << val.GetAsString() << "\" ";
+            qWarning() << " \"" << val.GetAsString() << "\" ";
         }
         else
         {
-            qDebug() << " " << val.GetVal() << " ";
+            qWarning() << " " << val.GetVal() << " ";
         }
     }
-    qDebug() << "\nOperator stack:\n";
+    qWarning() << "\nOperator stack:\n";
 
     while ( stOprt.empty() == false )
     {
         const token_type &topToken = stOprt.top();
         if (topToken.GetCode()<=cmASSIGN)
         {
-            qDebug() << "OPRT_INTRNL \"" << QmuParserBase::c_DefaultOprt[topToken.GetCode()] << "\" \n";
+            qWarning() << "OPRT_INTRNL \"" << QmuParserBase::c_DefaultOprt[topToken.GetCode()] << "\" \n";
         }
         else
         {
             switch ( topToken.GetCode())
             {
                 case cmVAR:
-                    qDebug() << "VAR\n";
+                    qWarning() << "VAR\n";
                     break;
                 case cmVAL:
-                    qDebug() << "VAL\n";
+                    qWarning() << "VAL\n";
                     break;
                 case cmFUNC:
-                    qDebug() << "FUNC \"" << topToken.GetAsString() << "\"\n";
+                    qWarning() << "FUNC \"" << topToken.GetAsString() << "\"\n";
                     break;
                 case cmFUNC_BULK:
-                    qDebug() << "FUNC_BULK \"" << topToken.GetAsString() << "\"\n";
+                    qWarning() << "FUNC_BULK \"" << topToken.GetAsString() << "\"\n";
                     break;
                 case cmOPRT_INFIX:
-                    qDebug() << "OPRT_INFIX \"" << topToken.GetAsString() << "\"\n";
+                    qWarning() << "OPRT_INFIX \"" << topToken.GetAsString() << "\"\n";
                     break;
                 case cmOPRT_BIN:
-                    qDebug() << "OPRT_BIN \"" << topToken.GetAsString() << "\"\n";
+                    qWarning() << "OPRT_BIN \"" << topToken.GetAsString() << "\"\n";
                     break;
                 case cmFUNC_STR:
-                    qDebug() << "FUNC_STR\n";
+                    qWarning() << "FUNC_STR\n";
                     break;
                 case cmEND:
-                    qDebug() << "END\n";
+                    qWarning() << "END\n";
                     break;
                 case cmUNKNOWN:
-                    qDebug() << "UNKNOWN\n";
+                    qWarning() << "UNKNOWN\n";
                     break;
                 case cmBO:
-                    qDebug() << "BRACKET \"(\"\n";
+                    qWarning() << "BRACKET \"(\"\n";
                     break;
                 case cmBC:
-                    qDebug() << "BRACKET \")\"\n";
+                    qWarning() << "BRACKET \")\"\n";
                     break;
                 case cmIF:
-                    qDebug() << "IF\n";
+                    qWarning() << "IF\n";
                     break;
                 case cmELSE:
-                    qDebug() << "ELSE\n";
+                    qWarning() << "ELSE\n";
                     break;
                 case cmENDIF:
-                    qDebug() << "ENDIF\n";
+                    qWarning() << "ENDIF\n";
                     break;
                 default:
-                    qDebug() << topToken.GetCode() << " ";
+                    qWarning() << topToken.GetCode() << " ";
                     break;
             }
         }
         stOprt.pop();
     }
-    qDebug() << Qt::dec;
+    qWarning() << Qt::dec;
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/qmuparser/qmuparserbytecode.cpp
+++ b/src/libs/qmuparser/qmuparserbytecode.cpp
@@ -1,3 +1,27 @@
+/***************************************************************************
+ **  @file   qmuparserbytecode.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
 /***************************************************************************************************
  **
  **  Copyright (C) 2013 Ingo Berg
@@ -548,92 +572,92 @@ void QmuParserByteCode::AsciiDump()
 {
     if (m_vRPN.size() == false)
     {
-        qDebug() << "No bytecode available\n";
+        qWarning() << "No bytecode available\n";
         return;
     }
 
-    qDebug() << "Number of RPN tokens:" << m_vRPN.size() << "\n";
+    qInfo() << "Number of RPN tokens:" << m_vRPN.size() << "\n";
     for (int i=0; i<m_vRPN.size() && m_vRPN.at(i).Cmd!=cmEND; ++i)
     {
-        qDebug() << i << " : \t";
+        qInfo() << i << " : \t";
         switch (m_vRPN.at(i).Cmd)
         {
             case cmVAL:
-                qDebug() << "VAL \t" << "[" << m_vRPN.at(i).Val.data2 << "]\n";
+                qInfo() << "VAL \t" << "[" << m_vRPN.at(i).Val.data2 << "]\n";
                 break;
             case cmVAR:
-                qDebug() << "VAR \t" << "[ADDR: 0x" << QString::number(*m_vRPN.at(i).Val.ptr, 'f', 16) << "]\n";
+                qInfo() << "VAR \t" << "[ADDR: 0x" << QString::number(*m_vRPN.at(i).Val.ptr, 'f', 16) << "]\n";
                 break;
             case cmVARPOW2:
-                qDebug() << "VARPOW2 \t" << "[ADDR: 0x" << QString::number(*m_vRPN.at(i).Val.ptr, 'f', 16) << "]\n";
+                qInfo() << "VARPOW2 \t" << "[ADDR: 0x" << QString::number(*m_vRPN.at(i).Val.ptr, 'f', 16) << "]\n";
                 break;
             case cmVARPOW3:
-                qDebug() << "VARPOW3 \t" << "[ADDR: 0x" << QString::number(*m_vRPN.at(i).Val.ptr, 'f', 16) << "]\n";
+                qInfo() << "VARPOW3 \t" << "[ADDR: 0x" << QString::number(*m_vRPN.at(i).Val.ptr, 'f', 16) << "]\n";
                 break;
             case cmVARPOW4:
-                qDebug() << "VARPOW4 \t" << "[ADDR: 0x" << QString::number(*m_vRPN.at(i).Val.ptr, 'f', 16) << "]\n";
+                qInfo() << "VARPOW4 \t" << "[ADDR: 0x" << QString::number(*m_vRPN.at(i).Val.ptr, 'f', 16) << "]\n";
                 break;
             case cmVARMUL:
-                qDebug() << "VARMUL \t" << "[ADDR: 0x" << QString::number(*m_vRPN.at(i).Val.ptr, 'f', 16) << "]" << " * [" //-V807
+                qInfo() << "VARMUL \t" << "[ADDR: 0x" << QString::number(*m_vRPN.at(i).Val.ptr, 'f', 16) << "]" << " * [" //-V807
                          << m_vRPN.at(i).Val.data << "]" << " + [" << m_vRPN.at(i).Val.data2 << "]\n";
                 break;
             case cmFUNC:
-                qDebug() << "CALL\t" << "[ARG:" << m_vRPN.at(i).Fun.argc << "]" << "[ADDR: 0x" << m_vRPN.at(i).Fun.ptr << "]"
+                qInfo() << "CALL\t" << "[ARG:" << m_vRPN.at(i).Fun.argc << "]" << "[ADDR: 0x" << m_vRPN.at(i).Fun.ptr << "]"
                          << "\n";
                 break;
             case cmFUNC_STR:
-                qDebug() << "CALL STRFUNC\t" << "[ARG:" << m_vRPN.at(i).Fun.argc << "]" << "[IDX:" << m_vRPN.at(i).Fun.idx //-V807
+                qInfo() << "CALL STRFUNC\t" << "[ARG:" << m_vRPN.at(i).Fun.argc << "]" << "[IDX:" << m_vRPN.at(i).Fun.idx //-V807
                          << "]" << "[ADDR: 0x" << m_vRPN.at(i).Fun.ptr << "]\n";
                 break;
             case cmLT:
-                qDebug() << "LT\n";
+                qInfo() << "LT\n";
                 break;
             case cmGT:
-                qDebug() << "GT\n";
+                qInfo() << "GT\n";
                 break;
             case cmLE:
-                qDebug() << "LE\n";
+                qInfo() << "LE\n";
                 break;
             case cmGE:
-                qDebug() << "GE\n";
+                qInfo() << "GE\n";
                 break;
             case cmEQ:
-                qDebug() << "EQ\n";
+                qInfo() << "EQ\n";
                 break;
             case cmNEQ:
-                qDebug() << "NEQ\n";
+                qInfo() << "NEQ\n";
                 break;
             case cmADD:
-                qDebug() << "ADD\n";
+                qInfo() << "ADD\n";
                 break;
             case cmLAND:
-                qDebug() << "&&\n";
+                qInfo() << "&&\n";
                 break;
             case cmLOR:
-                qDebug() << "||\n";
+                qInfo() << "||\n";
                 break;
             case cmSUB:
-                qDebug() << "SUB\n";
+                qInfo() << "SUB\n";
                 break;
             case cmMUL:
-                qDebug() << "MUL\n";
+                qInfo() << "MUL\n";
                 break;
             case cmDIV:
-                qDebug() << "DIV\n";
+                qInfo() << "DIV\n";
                 break;
             case cmPOW:
-                qDebug() << "POW\n";
+                qInfo() << "POW\n";
                 break;
             case cmIF:
-                qDebug() << "IF\t" << "[OFFSET:" << m_vRPN.at(i).Oprt.offset << "]\n";
+                qInfo() << "IF\t" << "[OFFSET:" << m_vRPN.at(i).Oprt.offset << "]\n";
                 break;
             case cmELSE:
-                qDebug() << "ELSE\t" << "[OFFSET:" << m_vRPN.at(i).Oprt.offset << "]\n";
+                qInfo() << "ELSE\t" << "[OFFSET:" << m_vRPN.at(i).Oprt.offset << "]\n";
                 break;
             case cmENDIF:
-                qDebug() << "ENDIF\n"; break;
+                qInfo() << "ENDIF\n"; break;
             case cmASSIGN:
-                qDebug() << "ASSIGN\t" << "[ADDR: 0x" << QString::number(*m_vRPN.at(i).Oprt.ptr, 'f', 16) << "]\n";
+                qInfo() << "ASSIGN\t" << "[ADDR: 0x" << QString::number(*m_vRPN.at(i).Oprt.ptr, 'f', 16) << "]\n";
                 break;
             case cmBO:
             case cmBC:
@@ -647,11 +671,11 @@ void QmuParserByteCode::AsciiDump()
             case cmEND:
             case cmUNKNOWN:
             default:
-                qDebug() << "(unknown code: " << m_vRPN.at(i).Cmd << ")\n";
+                qWarning() << "(unknown code: " << m_vRPN.at(i).Cmd << ")\n";
                 break;
         } // switch cmdCode
     } // while bytecode
 
-    qDebug() << "END";
+    qInfo() << "END";
 }
 } // namespace qmu

--- a/src/libs/qmuparser/qmuparsertest.cpp
+++ b/src/libs/qmuparser/qmuparsertest.cpp
@@ -1,3 +1,27 @@
+/***************************************************************************
+ **  @file   qmuparsertest.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
 /***************************************************************************************************
  **
  **  Copyright (C) 2013 Ingo Berg
@@ -54,7 +78,8 @@ int QmuParserTester::c_iCount = 0;
 
 //---------------------------------------------------------------------------------------------------------------------
 QmuParserTester::QmuParserTester(QObject *parent)
-    : QObject(parent), m_vTestFun()
+    : QObject(parent)
+    , m_vTestFun()
 {
     AddTest ( &QmuParserTester::TestNames );
     AddTest ( &QmuParserTester::TestSyntax );
@@ -1127,16 +1152,16 @@ void QmuParserTester::Run()
             iStat += ( this->*m_vTestFun[i] ) ();
         }
     }
-    catch ( QmuParserError &e )
+    catch ( QmuParserError &error)
     {
-        qWarning() << "\n" << e.GetMsg();
-        qWarning() << e.GetToken();
+        qWarning() << "\n" << error.GetMsg();
+        qWarning() << error.GetToken();
         Abort();
         return;
     }
-    catch ( std::exception &e )
+    catch ( std::exception &error)
     {
-        qWarning() << e.what();
+        qWarning() << error.what();
         Abort();
         return;
     }
@@ -1188,16 +1213,16 @@ int QmuParserTester::ThrowTest ( const QString &a_str, int a_iErrc, bool a_bFail
         p.SetExpr ( a_str );
         p.Eval();
     }
-    catch ( const qmu::QmuParserError &e )
+    catch ( const qmu::QmuParserError &error)
     {
         // output the formula in case of an failed test
-        if ( a_bFail == false || ( a_bFail == true && a_iErrc != e.GetCode() ) )
+        if ( a_bFail == false || ( a_bFail == true && a_iErrc != error.GetCode() ) )
         {
-            qWarning() << "\n  " << "Expression: " << a_str << "  Code:" << e.GetCode() << "(" << e.GetMsg() << ")"
+            qWarning() << "\n  " << "Expression: " << a_str << "  Code:" << error.GetCode() << "(" << error.GetMsg() << ")"
                      << "  Expected:" << a_iErrc;
         }
 
-        return ( a_iErrc == e.GetCode() ) ? 0 : 1;
+        return ( a_iErrc == error.GetCode() ) ? 0 : 1;
     }
 
     // if a_bFail==false no exception is expected
@@ -1250,14 +1275,14 @@ int QmuParserTester::EqnTestWithVarChange (const QString &a_str, double a_fRes1,
             throw std::runtime_error ( "incorrect result (second pass)" );
         }
     }
-    catch ( QmuParserError &e )
+    catch ( QmuParserError &error)
     {
-        qWarning() << "\n  fail: " << a_str << " (" << e.GetMsg() << ")";
+        qWarning() << "\n  fail: " << a_str << " (" << error.GetMsg() << ")";
         return 1;
     }
-    catch ( std::exception &e )
+    catch ( std::exception &error)
     {
-        qWarning() << "\n  fail: " << a_str << " (" << e.what() << ")";
+        qWarning() << "\n  fail: " << a_str << " (" << error.what() << ")";
         return 1;  // always return a failure since this exception is not expected
     }
     catch ( ... )
@@ -1395,9 +1420,9 @@ int QmuParserTester::EqnTest ( const QString &a_str, double a_fRes, bool a_fPass
             qreal *v = p2.Eval ( nNum );
             fVal[4] = v[nNum - 1];
         }
-        catch ( std::exception &e )
+        catch ( std::exception &error)
         {
-            qWarning() << "\n  " << e.what() << "\n";
+            qWarning() << "\n  " << error.what() << "\n";
         }
 
         // limited floating point accuracy requires the following test
@@ -1433,7 +1458,7 @@ QT_WARNING_POP
                      << fVal[4] << ").";
         }
     }
-    catch ( QmuParserError &e )
+    catch ( QmuParserError &error)
     {
         if ( a_fPass )
         {
@@ -1445,14 +1470,14 @@ QT_WARNING_POP
             }
             else
             {
-                qWarning() << "\n  fail: " << a_str << " (" << e.GetMsg() << ")";
+                qWarning() << "\n  fail: " << a_str << " (" << error.GetMsg() << ")";
             }
             return 1;
         }
     }
-    catch ( std::exception &e )
+    catch ( std::exception &error)
     {
-        qWarning() << "\n  fail: " << a_str << " (" << e.what() << ")";
+        qWarning() << "\n  fail: " << a_str << " (" << error.what() << ")";
         return 1;  // always return a failure since this exception is not expected
     }
     catch ( ... )
@@ -1504,11 +1529,11 @@ int QmuParserTester::EqnTestBulk(const QString &a_str, double a_fRes[4], bool a_
                        << "," << vResults[1] << "," << vResults[2] << "," << vResults[3] << "}";
         }
     }
-    catch (QmuParserError &e)
+    catch (QmuParserError &error)
     {
         if (a_fPass)
         {
-            qWarning() << "\n  fail: " << e.GetExpr() << " : " << e.GetMsg();
+            qWarning() << "\n  fail: " << error.GetExpr() << " : " << error.GetMsg();
             iRet = 1;
         }
     }

--- a/src/libs/qmuparser/qmuparsertokenreader.cpp
+++ b/src/libs/qmuparser/qmuparsertokenreader.cpp
@@ -1,3 +1,27 @@
+/***************************************************************************
+ **  @file   qmuparsertokenreader.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
 /***************************************************************************************************
  **
  **  Copyright (C) 2013 Ingo Berg
@@ -536,9 +560,9 @@ bool QmuParserTokenReader::IsEOF ( token_type &a_Tok )
             {
                 Error ( ecUNEXPECTED_EOF, m_iPos );
             }
-            catch (qmu::QmuParserError &e)
+            catch (qmu::QmuParserError &error)
             {
-                qDebug() << "  Code:" << e.GetCode() << "(" << e.GetMsg() << ")";
+                qWarning() << "  Code:" << error.GetCode() << "(" << error.GetMsg() << ")";
                 throw;
             }
         }

--- a/src/libs/qmuparser/qmutokenparser.cpp
+++ b/src/libs/qmuparser/qmutokenparser.cpp
@@ -1,3 +1,26 @@
+/***************************************************************************
+ **  @file   qmutokenparser.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 /***************************************************************************************************
  **
  **  Copyright (C) 2015 Roman Telezhynskyi
@@ -100,9 +123,9 @@ bool QmuTokenParser::IsSingle(const QString &formula)
         cal->SetExpr(formula);
         cal->Eval();// We don't need save result, only parse formula
     }
-    catch (const qmu::QmuParserError &e)
+    catch (const qmu::QmuParserError &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return false;// something wrong with formula, say no
     }
 

--- a/src/libs/vdxf/vdxfengine.cpp
+++ b/src/libs/vdxf/vdxfengine.cpp
@@ -105,7 +105,7 @@ bool VDxfEngine::begin(QPaintDevice *pdev)
 
     if (size.isValid() == false)
     {
-        qWarning()<<"VDxfEngine::begin(), size is not valid";
+        qWarning() << "VDxfEngine::begin(), size is not valid";
         return false;
     }
 
@@ -608,7 +608,7 @@ bool VDxfEngine::ExportToAAMA(const QVector<VLayoutPiece> &details)
 {
     if (size.isValid() == false)
     {
-        qWarning()<<"VDxfEngine::begin(), size is not valid";
+        qWarning() << "VDxfEngine::begin(), size is not valid";
         return false;
     }
 

--- a/src/libs/vformat/vmeasurements.cpp
+++ b/src/libs/vformat/vmeasurements.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vmeasurements.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,11 +19,10 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
  **  @file   vmeasurements.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -29,17 +30,17 @@
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -298,9 +299,9 @@ void VMeasurements::ReadMeasurements() const
         {
             description = GetParametrString(dom, AttrDescription);
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         QString fullName;
@@ -308,9 +309,9 @@ void VMeasurements::ReadMeasurements() const
         {
             fullName = GetParametrString(dom, AttrFullName);
         }
-        catch (VExceptionEmptyParameter &e)
+        catch (VExceptionEmptyParameter &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
         }
 
         QSharedPointer<VMeasurement> meash;
@@ -947,9 +948,9 @@ qreal VMeasurements::EvalFormula(VContainer *data, const QString &formula, bool 
             (qIsInf(result) || qIsNaN(result)) ? *ok = false : *ok = true;
             return result;
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             *ok = false;
             return 0;
         }

--- a/src/libs/vgeometry/vabstractcubicbezier.cpp
+++ b/src/libs/vgeometry/vabstractcubicbezier.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vabstractcubicbezier.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vabstractcubicbezier.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   8 3, 2016
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2016 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -571,7 +571,7 @@ qreal VAbstractCubicBezier::LengthT(qreal t) const
 {
     if (t < 0 || t > 1)
     {
-        qDebug()<<"Wrong value t.";
+        qWarning() << "Wrong value t.";
         return 0;
     }
     QLineF seg1_2 ( static_cast<QPointF>(GetP1 ()), GetControlPoint1 () );

--- a/src/libs/vgeometry/vabstractcurve.cpp
+++ b/src/libs/vgeometry/vabstractcurve.cpp
@@ -217,7 +217,7 @@ QPainterPath VAbstractCurve::GetPath() const
     }
     else
     {
-        qDebug()<<"points.count() < 2"<<Q_FUNC_INFO;
+        qDebug() << "points.count() < 2" << Q_FUNC_INFO;
     }
     return path;
 }

--- a/src/libs/vgeometry/vsplinepoint_p.h
+++ b/src/libs/vgeometry/vsplinepoint_p.h
@@ -85,7 +85,7 @@ public:
     {
         if (VFuzzyComparePossibleNulls(angle1, angle2) || not qFuzzyCompare(qAbs(angle1-angle2), 180) )
         {
-            qDebug()<<"Make angle1 and angle2 correct.";
+            qDebug() << "Make angle1 and angle2 correct.";
             this->angle2 = this->angle1 + 180;
         }
     }
@@ -197,7 +197,7 @@ VSplinePointData::VSplinePointData(VPointF pSpline, qreal angle1, const QString 
 {
     if (not VFuzzyComparePossibleNulls(qAbs(angle1-angle2), 180))
     {
-        qDebug()<<"Make angle1 and angle2 correct.";
+        qDebug() << "Make angle1 and angle2 correct.";
 
         QLineF line (0, 0, 100, 0);
 

--- a/src/libs/vlayout/vabstractpiece.cpp
+++ b/src/libs/vlayout/vabstractpiece.cpp
@@ -208,14 +208,14 @@ QVector<QPointF> VAbstractPiece::Equidistant(const QVector<VSAPoint> &points, qr
 {
     if (width < 0)
     {
-        qDebug()<<"Width < 0.";
+        qDebug() << "Width < 0.";
         return QVector<QPointF>();
     }
 
     QVector<VSAPoint> p = CorrectEquidistantPoints(points);
     if ( p.size() < 3 )
     {
-        qDebug()<<"Not enough points for building the equidistant.";
+        qDebug() << "Not enough points for building the equidistant.";
         return QVector<QPointF>();
     }
 
@@ -489,7 +489,7 @@ QVector<QPointF> VAbstractPiece::EkvPoint(const VSAPoint &p1Line1, const VSAPoin
     QVector<QPointF> points;
     if (p2Line1 != p2Line2)
     {
-        qDebug()<<"Last points of two lines must be equal.";
+        qDebug() << "Last points of two lines must be equal.";
         return QVector<QPointF>(); // Wrong edges
     }
 
@@ -626,7 +626,7 @@ QVector<QPointF> VAbstractPiece::AngleByLength(const QPointF &p2, const QPointF 
         QLineF::IntersectType type = QLineF(sp1, sp2).intersects(cutLine, &px);
         if (type == QLineF::NoIntersection)
         {
-            qDebug()<<"Couldn't find intersection with cut line.";
+            qDebug() << "Couldn't find intersection with cut line.";
         }
         points.append(px);
 
@@ -634,7 +634,7 @@ QVector<QPointF> VAbstractPiece::AngleByLength(const QPointF &p2, const QPointF 
         type = QLineF(sp2, sp3).intersects(cutLine, &px);
         if (type == QLineF::NoIntersection)
         {
-            qDebug()<<"Couldn't find intersection with cut line.";
+            qDebug() << "Couldn't find intersection with cut line.";
         }
         points.append(px);
     }

--- a/src/libs/vlayout/vabstractpiece.h
+++ b/src/libs/vlayout/vabstractpiece.h
@@ -272,7 +272,7 @@ QVector<T> VAbstractPiece::CorrectEquidistantPoints(const QVector<T> &points, bo
 {
     if (points.size()<4)//Better don't check if only three points. We can destroy equidistant.
     {
-        qDebug()<<"Only three points.";
+        qDebug() << "Only three points.";
         return points;
     }
 

--- a/src/libs/vlayout/vlayoutpiece.cpp
+++ b/src/libs/vlayout/vlayoutpiece.cpp
@@ -1,10 +1,10 @@
 /***************************************************************************
  **  @file   vlayoutpiece.cpp
  **  @author Douglas S Caskey
- **  @date   Dec 27, 2022
+ **  @date  17 Sep, 2023
  **
  **  @copyright
- **  Copyright (C) 2017 - 2022 Seamly, LLC
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
  **  https://github.com/fashionfreedom/seamly2d
  **
  **  @brief
@@ -119,9 +119,9 @@ bool FindLabelGeometry(const VPatternLabelData &labelData, const VContainer *pat
         Calculator cal1;
         rotationAngle = cal1.EvalFormula(pattern->DataVariables(), labelData.GetRotation());
     }
-    catch(qmu::QmuParserError &e)
+    catch(qmu::QmuParserError &error)
     {
-        Q_UNUSED(e);
+        Q_UNUSED(error);
         return false;
     }
 
@@ -158,9 +158,9 @@ bool FindLabelGeometry(const VPatternLabelData &labelData, const VContainer *pat
         Calculator cal2;
         labelHeight = cal2.EvalFormula(pattern->DataVariables(), labelData.GetLabelHeight());
     }
-    catch(qmu::QmuParserError &e)
+    catch(qmu::QmuParserError &error)
     {
-        Q_UNUSED(e);
+        Q_UNUSED(error);
         return false;
     }
 
@@ -235,9 +235,9 @@ bool FindGrainlineGeometry(const VGrainlineData& data, const VContainer *pattern
         length = cal2.EvalFormula(pattern->DataVariables(), data.GetLength());
         length = ToPixel(length, *pattern->GetPatternUnit());
     }
-    catch(qmu::QmuParserError &e)
+    catch(qmu::QmuParserError &error)
     {
-        Q_UNUSED(e);
+        Q_UNUSED(error);
         return false;
     }
 
@@ -496,7 +496,7 @@ void VLayoutPiece::setSeamAllowancePoints(const QVector<QPointF> &points, bool s
         }
         else if (not IsSeamAllowanceBuiltIn())
         {
-            qWarning()<<"Seam allowance is empty.";
+            qWarning() << "Seam allowance is empty.";
             SetSeamAllowance(false);
         }
     }

--- a/src/libs/vmisc/vabstractapplication.cpp
+++ b/src/libs/vmisc/vabstractapplication.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vabstractapplication.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,11 +19,10 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
  **  @file   vabstractapplication.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -31,7 +32,7 @@
  **  @copyright
  **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Valentina project
+ **  Copyright (C) 2013-2015 Valentina project
  **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
  **  Valentina is free software: you can redistribute it and/or modify
@@ -45,7 +46,7 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+ **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
  **
  *************************************************************************/
 
@@ -268,10 +269,10 @@ void VAbstractApplication::loadTranslations(const QString &locale)
 {
     if (locale.isEmpty())
     {
-        qDebug()<<"Locale is empty.";
+        qInfo() << "Locale is empty.";
         return;
     }
-    qDebug()<<"Checked locale:"<<locale;
+    qInfo() << "Checked locale:" << locale;
 
     ClearTranslation();
 

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vcommonsettings.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vcommonsettings.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   15 7, 2015
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -526,8 +526,8 @@ int VCommonSettings::getAutosaveInterval() const
     int val = value(settingConfigurationAutosaveTime, 1).toInt(&ok);
     if (ok == false)
     {
-        qDebug()<<"Could not convert value"<<value(settingConfigurationAutosaveTime, 1)
-               <<"to int. Return default value for autosave time"<<1<<"minutes.";
+        qWarning() << "Could not convert value"<<value(settingConfigurationAutosaveTime, 1)
+                   << "to int. Return default value for autosave time" << 1 << "minutes.";
         val = 1;
     }
     return val;
@@ -1101,8 +1101,8 @@ int VCommonSettings::GetUndoCount() const
     int val = value(settingPatternUndo, 0).toInt(&ok);
     if (ok == false)
     {
-        qDebug()<<"Could not convert value"<<value(settingPatternUndo, 0)
-               <<"to int. Return default value for undo counts 0 (no limit).";
+        qWarning() << "Could not convert value"<<value(settingPatternUndo, 0)
+                   << "to int. Return default value for undo counts 0 (no limit).";
         val = 0;
     }
     return val;
@@ -1497,9 +1497,8 @@ double VCommonSettings::GetDefaultSeamAllowance()
     double val = value(settingPatternDefaultSeamAllowance, -1).toDouble(&ok);
     if (ok == false)
     {
-        qDebug()<< "Could not convert value"<<value(settingPatternDefaultSeamAllowance, 0)
-                << "to real. Return default value for default seam allowance is "
-                << defaultValue << ".";
+        qWarning() <<  "Could not convert value"<<value(settingPatternDefaultSeamAllowance, 0)
+                   << "to real. Return default value for default seam allowance is " << defaultValue << ".";
         val = defaultValue;
     }
 

--- a/src/libs/vobj/vobjengine.cpp
+++ b/src/libs/vobj/vobjengine.cpp
@@ -151,7 +151,7 @@ bool VObjEngine::begin(QPaintDevice *pdev)
 
     if (size.isValid() == false)
     {
-        qWarning()<<"VObjEngine::begin(), size is not valid";
+        qWarning() << "VObjEngine::begin(), size is not valid";
         return false;
     }
 

--- a/src/libs/vpatterndb/floatItemData/vabstractfloatitemdata.cpp
+++ b/src/libs/vpatterndb/floatItemData/vabstractfloatitemdata.cpp
@@ -106,6 +106,6 @@ bool VAbstractFloatItemData::IsVisible() const
 //---------------------------------------------------------------------------------------------------------------------
 void VAbstractFloatItemData::SetVisible(bool bVisible)
 {
-    qDebug()<<"SetVisible Selected = "<< bVisible;
+    qDebug() << "SetVisible Selected = "<< bVisible;
     d->m_bVisible = bVisible;
 }

--- a/src/libs/vpatterndb/variables/vmeasurement.cpp
+++ b/src/libs/vpatterndb/variables/vmeasurement.cpp
@@ -133,7 +133,7 @@ QStringList VMeasurement::ListHeights(QMap<GHeights, bool> heights, Unit pattern
     QStringList list;
     if (patternUnit == Unit::Inch)
     {
-        qWarning()<<"Multisize table doesn't support inches.";
+        qWarning() << "Multisize table doesn't support inches.";
         return list;
     }
 
@@ -160,7 +160,7 @@ QStringList VMeasurement::ListSizes(QMap<GSizes, bool> sizes, Unit patternUnit)
     QStringList list;
     if (patternUnit == Unit::Inch)
     {
-        qWarning()<<"Multisize table doesn't support inches.";
+        qWarning() << "Multisize table doesn't support inches.";
         return list;
     }
 
@@ -187,7 +187,7 @@ QStringList VMeasurement::WholeListHeights(Unit patternUnit)
     QStringList list;
     if (patternUnit == Unit::Inch)
     {
-        qWarning()<<"Multisize table doesn't support inches.";
+        qWarning() << "Multisize table doesn't support inches.";
         return list;
     }
 
@@ -205,7 +205,7 @@ QStringList VMeasurement::WholeListSizes(Unit patternUnit)
     QStringList list;
     if (patternUnit == Unit::Inch)
     {
-        qWarning()<<"Multisize table doesn't support inches.";
+        qWarning() << "Multisize table doesn't support inches.";
         return list;
     }
 

--- a/src/libs/vpatterndb/vcontainer.cpp
+++ b/src/libs/vpatterndb/vcontainer.cpp
@@ -1,10 +1,10 @@
 /***************************************************************************
  **  @file   vcontainer.cpp
  **  @author Douglas S Caskey
- **  @date   Dec 11, 2022
+ **  @date   17 Sep, 2023
  **
  **  @copyright
- **  Copyright (C) 2017 - 2022 Seamly, LLC
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
  **  https://github.com/fashionfreedom/seamly2d
  **
  **  @brief
@@ -255,7 +255,7 @@ quint32 VContainer::getNextId()
     //But for now better to keep it as it is now.
     if (_id == UINT_MAX)
     {
-        qCritical()<<(tr("Number of free id exhausted."));
+        qCritical() << (tr("Number of free id exhausted."));
     }
     _id++;
     return _id;

--- a/src/libs/vpatterndb/vformula.cpp
+++ b/src/libs/vpatterndb/vformula.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vformula.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,11 +19,10 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
  **  @file   vformula.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -29,17 +30,17 @@
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2014 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -290,16 +291,16 @@ void VFormula::Eval()
                 }
             }
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
             value = tr("Error");
             _error = true;
             dValue = 0;
-            qDebug() << "\nMath parser error:\n"
-                     << "--------------------------------------\n"
-                     << "Message:     " << e.GetMsg()  << "\n"
-                     << "Expression:  " << e.GetExpr() << "\n"
-                     << "--------------------------------------";
+            qWarning() << "\nMath parser error:\n"
+                       << "--------------------------------------\n"
+                       << "Message:     " << error.GetMsg()  << "\n"
+                       << "Expression:  " << error.GetExpr() << "\n"
+                       << "--------------------------------------";
         }
     }
 }

--- a/src/libs/vpatterndb/vpiece.cpp
+++ b/src/libs/vpatterndb/vpiece.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   vpiece.cpp
  **  @author Douglas S Caskey
- **  @date   Jan 3, 2023
+ **  @date   17 Sep, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2023 Seamly, LLC
@@ -263,7 +263,7 @@ QVector<QPointF> VPiece::SeamAllowancePoints(const VContainer *data) const
             }
             break;
             default:
-                qDebug()<<"Get wrong tool type. Ignore."<< static_cast<char>(node.GetTypeTool());
+                qWarning() << "Get wrong tool type. Ignore."<< static_cast<char>(node.GetTypeTool());
                 break;
         }
     }
@@ -1035,7 +1035,7 @@ QVector<QLineF> VPiece::createSeamAllowanceNotch(const QVector<VPieceNode> &path
             // After notch
             QLineF line(notchSAPoint, previousSAPoint);
             line.setAngle(line.angle() - 180.0);
-            line.setLength(40000.0); 
+            line.setLength(40000.0);
 
             QVector<QPointF> intersections = VAbstractCurve::CurveIntersectLine(seamPoints, line);
             intersections.removeOne(notchSAPoint);
@@ -1047,7 +1047,7 @@ QVector<QLineF> VPiece::createSeamAllowanceNotch(const QVector<VPieceNode> &path
                 notches += createNotches(notchData, pathPoints);
             }
         }
-        
+
 
         {
             // Before notch

--- a/src/libs/vpatterndb/vpiecenode.cpp
+++ b/src/libs/vpatterndb/vpiecenode.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vpiecemode.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,28 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
- **  @file
+ **  @file   vpiecemode.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   3 11, 2016
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2016 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -81,9 +82,9 @@ qreal EvalFormula(const VContainer *data, QString formula)
             }
             return result;
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             return -1;
         }
     }

--- a/src/libs/vpatterndb/vpiecepath.cpp
+++ b/src/libs/vpatterndb/vpiecepath.cpp
@@ -1,10 +1,10 @@
 /***************************************************************************
  **  @file   vpiecepath.cpp
  **  @author Douglas S Caskey
- **  @date   Dec 11, 2022
+ **  @date   17 Sep, 2023
  **
  **  @copyright
- **  Copyright (C) 2017 - 2022 Seamly, LLC
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
  **  https://github.com/fashionfreedom/seamly2d
  **
  **  @brief
@@ -148,7 +148,7 @@ int IndexOfNode(const QVector<VPieceNode> &list, quint32 id)
             return i;
         }
     }
-    qDebug()<<"Can't find node.";
+    qDebug() << "Can't find node:" << id;
     return -1;
 }
 }
@@ -316,7 +316,7 @@ QVector<QPointF> VPiecePath::PathPoints(const VContainer *data) const
                 }
                 break;
             default:
-                qDebug() << "Got wrong tool type. Ignore." << static_cast<char>(at(i).GetTypeTool());
+                qWarning() << "Got wrong tool type. Ignore." << static_cast<char>(at(i).GetTypeTool());
                 break;
         }
     }
@@ -379,7 +379,7 @@ QVector<VSAPoint> VPiecePath::SeamAllowancePoints(const VContainer *data, qreal 
                 }
                 break;
             default:
-                qDebug() << "Got wrong tool type. Ignore." << static_cast<char>(node.GetTypeTool());
+                qWarning() << "Got wrong tool type. Ignore." << static_cast<char>(node.GetTypeTool());
                 break;
         }
     }
@@ -521,7 +521,7 @@ void VPiecePath::NodeOnEdge(quint32 index, VPieceNode &p1, VPieceNode &p2) const
     const QVector<VPieceNode> list = ListNodePoint();
     if (index > static_cast<quint32>(list.size()))
     {
-        qDebug()<<"Wrong edge index index ="<<index;
+        qWarning() << "Wrong edge index index =" << index;
         return;
     }
     p1 = list.at(static_cast<int>(index));
@@ -561,7 +561,7 @@ bool VPiecePath::OnEdge(quint32 p1, quint32 p2) const
     const QVector<VPieceNode> list = ListNodePoint();
     if (list.size() < 2)
     {
-        qDebug()<<"Not enough points.";
+        qDebug() << "Not enough points.";
         return false;
     }
     int i = IndexOfNode(list, p1);
@@ -599,13 +599,13 @@ bool VPiecePath::OnEdge(quint32 p1, quint32 p2) const
  * located arcs or splines ignore this.
  * @param p1 id first point.
  * @param p2 id second point.
- * @return edge index or -1 if points don't located on edge
+ * @return edge index or -1 if points are not located on edge
  */
 int VPiecePath::Edge(quint32 p1, quint32 p2) const
 {
     if (OnEdge(p1, p2) == false)
     {
-        qDebug()<<"Points don't on edge.";
+        qDebug() << "Points are not located on edge.";
         return -1;
     }
 
@@ -740,7 +740,7 @@ QPointF VPiecePath::NodePreviousPoint(const VContainer *data, int i) const
             }
                 break;
             default:
-                qDebug() << "Got wrong tool type. Ignore." << static_cast<char>(node.GetTypeTool());
+                qWarning() << "Got wrong tool type. Ignore." << static_cast<char>(node.GetTypeTool());
                 break;
         }
     }
@@ -792,7 +792,7 @@ QPointF VPiecePath::NodeNextPoint(const VContainer *data, int i) const
             }
                 break;
             default:
-                qDebug()<<"Got wrong tool type. Ignore."<< static_cast<char>(node.GetTypeTool());
+                qWarning() << "Got wrong tool type. Ignore." << static_cast<char>(node.GetTypeTool());
                 break;
         }
     }
@@ -810,7 +810,7 @@ int VPiecePath::indexOfNode(const QVector<VPieceNode> &nodes, quint32 id)
             return i;
         }
     }
-    qDebug()<<"Can't find node.";
+    qDebug() << "Can't find node:" << id;
     return -1;
 }
 

--- a/src/libs/vpatterndb/vtranslatevars.cpp
+++ b/src/libs/vpatterndb/vtranslatevars.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtranslatevars.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,11 +19,10 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
  **  @file   vtranslatevars.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -29,17 +30,17 @@
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -70,15 +71,15 @@
 
 //---------------------------------------------------------------------------------------------------------------------
 VTranslateVars::VTranslateVars()
-    :VTranslateMeasurements(),
-      PMSystemNames(QMap<QString, qmu::QmuTranslation>()),
-      PMSystemAuthors(QMap<QString, qmu::QmuTranslation>()),
-      PMSystemBooks(QMap<QString, qmu::QmuTranslation>()),
-      variables(QMap<QString, qmu::QmuTranslation>()),
-      functions(QMap<QString, qmu::QmuTranslation>()),
-      postfixOperators(QMap<QString, qmu::QmuTranslation>()),
-      placeholders(QMap<QString, qmu::QmuTranslation>()),
-      stDescriptions(QMap<QString, qmu::QmuTranslation>())
+    : VTranslateMeasurements()
+    , PMSystemNames(QMap<QString, qmu::QmuTranslation>())
+    , PMSystemAuthors(QMap<QString, qmu::QmuTranslation>())
+    , PMSystemBooks(QMap<QString, qmu::QmuTranslation>())
+    , variables(QMap<QString, qmu::QmuTranslation>())
+    , functions(QMap<QString, qmu::QmuTranslation>())
+    , postfixOperators(QMap<QString, qmu::QmuTranslation>())
+    , placeholders(QMap<QString, qmu::QmuTranslation>())
+    , stDescriptions(QMap<QString, qmu::QmuTranslation>())
 {
     InitPatternMakingSystems();
     InitVariables();
@@ -919,7 +920,7 @@ QString VTranslateVars::FormulaFromUser(const QString &formula, bool osSeparator
             const qreal d = loc.toDouble(nValues.at(i), &ok);
             if (ok == false)
             {
-                qDebug()<<"Can't convert to double token"<<nValues.at(i);
+                qWarning() << "Can't convert to double token"<<nValues.at(i);
                 continue;//Leave with out translation
             }
 
@@ -946,9 +947,9 @@ QString VTranslateVars::TryFormulaFromUser(const QString &formula, bool osSepara
     {
         return qApp->TrVars()->FormulaFromUser(formula, osSeparator);
     }
-    catch (qmu::QmuParserError &e)// In case something bad will happen
+    catch (qmu::QmuParserError &error)// In case something bad will happen
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return formula;
     }
 }
@@ -977,13 +978,13 @@ QString VTranslateVars::FormulaToUser(const QString &formula, bool osSeparator) 
         tokens = cal->GetTokens();// Tokens (variables, measurements)
         numbers = cal->GetNumbers();// All numbers in expression for changing decimal separator
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
-        qDebug() << "\nMath parser error:\n"
-                 << "--------------------------------------\n"
-                 << "Message:     " << e.GetMsg()  << "\n"
-                 << "Expression:  " << e.GetExpr() << "\n"
-                 << "--------------------------------------";
+        qWarning() << "\nMath parser error:\n"
+                   << "--------------------------------------\n"
+                   << "Message:     " << error.GetMsg()  << "\n"
+                   << "Expression:  " << error.GetExpr() << "\n"
+                   << "--------------------------------------";
         return newFormula;
     }
 
@@ -1060,7 +1061,7 @@ QString VTranslateVars::FormulaToUser(const QString &formula, bool osSeparator) 
             const qreal d = loc.toDouble(nValues.at(i), &ok);
             if (ok == false)
             {
-                qDebug()<<"Can't convert to double token"<<nValues.at(i);
+                qWarning() << "Can't convert to double token"<<nValues.at(i);
                 continue;//Leave with out translation
             }
 

--- a/src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp
+++ b/src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   editlabeltemplate_dialog.cpp
  **  @author Douglas S Caskey
- **  @date   Dec 26, 2022
+ **  @date   17 Sep, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2022 Seamly, LLC
@@ -397,10 +397,10 @@ void EditLabelTemplateDialog::ImportTemplate()
         ltemplate.setXMLContent(VLabelTemplateConverter(fileName).Convert());
         SetTemplate(ltemplate.ReadLines());
     }
-    catch (VException &e)
+    catch (VException &error)
     {
-        qCritical("%s\n\n%s\n\n%s", qUtf8Printable(tr("File error.")), qUtf8Printable(e.ErrorMessage()),
-                  qUtf8Printable(e.DetailedInformation()));
+        qCritical("%s\n\n%s\n\n%s", qUtf8Printable(tr("File error.")), qUtf8Printable(error.ErrorMessage()),
+                  qUtf8Printable(error.DetailedInformation()));
     }
 }
 

--- a/src/libs/vtools/dialogs/tools/dialogsplinepath.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogsplinepath.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   dialogsplinepath.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,11 +19,10 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
  **  @file   dialogsplinepath.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -29,17 +30,17 @@
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -410,9 +411,9 @@ void DialogSplinePath::Angle1Changed()
         {
             p.SetAngle1(angle1, qApp->TrVars()->FormulaFromUser(angle1F, qApp->Settings()->GetOsSeparator()));
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             p.SetAngle1(angle1, angle1F);
         }
 
@@ -453,9 +454,9 @@ void DialogSplinePath::Angle2Changed()
         {
             p.SetAngle2(angle2, qApp->TrVars()->FormulaFromUser(angle2F, qApp->Settings()->GetOsSeparator()));
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             p.SetAngle2(angle2, angle2F);
         }
 
@@ -496,9 +497,9 @@ void DialogSplinePath::Length1Changed()
         {
             p.SetLength1(length1, qApp->TrVars()->FormulaFromUser(length1F, qApp->Settings()->GetOsSeparator()));
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             p.SetLength1(length1, length1F);
         }
 
@@ -530,9 +531,9 @@ void DialogSplinePath::Length2Changed()
         {
             p.SetLength2(length2, qApp->TrVars()->FormulaFromUser(length2F, qApp->Settings()->GetOsSeparator()));
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             p.SetLength2(length2, length2F);
         }
 

--- a/src/libs/vtools/dialogs/tools/dialogtool.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogtool.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   dialogtool.cpp
  **  @author Douglas S Caskey
- **  @date   Dec 11, 2022
+ **  @date   17 Sep, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2022 Seamly, LLC
@@ -691,7 +691,7 @@ void DialogTool::newNodeItem(QListWidget *listWidget, const VPieceNode &node, bo
             info = getNodeInfo(node, true);
             break;
         default:
-            qDebug()<<"Got wrong tools. Ignore.";
+            qWarning() << "Got wrong tools. Ignore.";
             return;
     }
 
@@ -863,18 +863,18 @@ qreal DialogTool::Eval(const QString &text, bool &flag, QLabel *label, const QSt
                 }
             }
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
             label->setText(tr("Error") + " (" + postfix + ")");
             flag = false;
             ChangeColor(labelEditFormula, Qt::red);
-            emit ToolTip(tr("Parser error: %1").arg(e.GetMsg()));
-            label->setToolTip(tr("Parser error: %1").arg(e.GetMsg()));
-            qDebug() << "\nMath parser error:\n"
-                     << "--------------------------------------\n"
-                     << "Message:     " << e.GetMsg()  << "\n"
-                     << "Expression:  " << e.GetExpr() << "\n"
-                     << "--------------------------------------";
+            emit ToolTip(tr("Parser error: %1").arg(error.GetMsg()));
+            label->setToolTip(tr("Parser error: %1").arg(error.GetMsg()));
+            qWarning() << "\nMath parser error:\n"
+                       << "--------------------------------------\n"
+                       << "Message:     " << error.GetMsg()  << "\n"
+                       << "Expression:  " << error.GetExpr() << "\n"
+                       << "--------------------------------------";
         }
     }
     CheckState(); // Disable Ok and Apply buttons if something wrong.
@@ -983,7 +983,7 @@ bool DialogTool::SetObject(const quint32 &id, QComboBox *box, const QString &too
     }
     else
     {
-        qWarning()<<"Can't find object by id"<<id;
+        qWarning() << "Can't find object by id"<<id;
     }
     return false;
 }

--- a/src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/insert_nodes_dialog.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   insert_nodes_dialog.cpp
  **  @author Douglas S Caskey
- **  @date   Dec 11, 2022
+ **  @date   17 Sep, 202
  **
  **  @copyright
  **  Copyright (C) 2017 - 2022 Seamly, LLC
@@ -174,7 +174,7 @@ void InsertNodesDialog::SelectedObject(bool selected, quint32 objId, quint32 too
             }
             catch (const VExceptionBadId &)
             {
-                qDebug() << "Cannot find an object with id" << objId;
+                qWarning() << "Cannot find an object with id" << objId;
                 return;
             }
             m_beep->play();
@@ -250,7 +250,7 @@ void InsertNodesDialog::SelectedObject(bool selected, quint32 objId, quint32 too
                     break;
                 case GOType::Unknown:
                 default:
-                    qDebug() << "Ignore unknown object type.";
+                    qWarning() << "Ignore unknown object type.";
                     return;
             }
 

--- a/src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   dialoginternalpath.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   dialoginternalpath.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   22 11, 2016
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2016 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -145,7 +145,7 @@ void DialogInternalPath::ChosenObject(quint32 id, const SceneObject &type)
                 case (SceneObject::Piece):
                 case (SceneObject::Unknown):
                 default:
-                    qDebug() << "Got wrong scene object. Ignore.";
+                    qWarning() << "Got wrong scene object. Ignore.";
                     break;
             }
         }

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   pattern_piece_dialog.cpp
  **  @author Douglas S Caskey
- **  @date   Dec 11, 2022
+ **  @date   17 Sep, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2022 Seamly, LLC
@@ -458,7 +458,7 @@ void PatternPieceDialog::ChosenObject(quint32 id, const SceneObject &type)
                 case (SceneObject::Piece):
                 case (SceneObject::Unknown):
                 default:
-                    qDebug() << "Invalid scene object. Ignore.";
+                    qWarning() << "Invalid scene object. Ignore.";
                     break;
             }
         }
@@ -1412,10 +1412,10 @@ void PatternPieceDialog::pathDialogClosed(int result)
             updateCurrentCustomSARecord();
             updateCurrentInternalPathRecord();
         }
-        catch (const VExceptionBadId &e)
+        catch (const VExceptionBadId &error)
         {
             qCritical("%s\n\n%s\n\n%s", qUtf8Printable(tr("Error. Can't save piece path.")),
-                       qUtf8Printable(e.ErrorMessage()), qUtf8Printable(e.DetailedInformation()));
+                       qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         }
     }
     delete m_dialog;
@@ -1685,12 +1685,12 @@ void PatternPieceDialog::updateGrainlineValues()
                 ChangeColor(labelText, okColor);
             }
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
             formulaValueStr = tr("Error");
             !flagGrainlineAnchor ? ChangeColor(labelText, Qt::red) : ChangeColor(labelText, okColor);
             formulasOK[i] = false;
-            labelValue->setToolTip(tr("Parser error: %1").arg(e.GetMsg()));
+            labelValue->setToolTip(tr("Parser error: %1").arg(error.GetMsg()));
         }
 
         if (formulasOK[i] && formulaValueStr.isEmpty() == false)
@@ -1767,12 +1767,12 @@ void PatternPieceDialog::updatePieceLabelValues()
                 ChangeColor(labelText, okColor);
             }
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
             formulaValueStr = tr("Error");
             !flagPieceLabelAnchor ? ChangeColor(labelText, Qt::red) : ChangeColor(labelText, okColor);
             formulasOK[i] = false;
-            labelValue->setToolTip(tr("Parser error: %1").arg(e.GetMsg()));
+            labelValue->setToolTip(tr("Parser error: %1").arg(error.GetMsg()));
         }
 
         if (formulasOK[i] && formulaValueStr.isEmpty() == false)
@@ -1852,12 +1852,12 @@ void PatternPieceDialog::updatePatternLabelValues()
                 ChangeColor(labelText, okColor);
             }
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
             formulaValueStr = tr("Error");
             !flagPatternLabelAnchor ? ChangeColor(labelText, Qt::red) : ChangeColor(labelText, okColor);
             formulasOK[i] = false;
-            labelValue->setToolTip(tr("Parser error: %1").arg(e.GetMsg()));
+            labelValue->setToolTip(tr("Parser error: %1").arg(error.GetMsg()));
         }
 
         if (formulasOK[i] && formulaValueStr.isEmpty() == false)

--- a/src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp
+++ b/src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolmirrorbyaxis.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
- **  @file
+/************************************************************************
+ **  @file   vtoolmirrorbyaxis.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   16 9, 2016
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2016 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -264,9 +264,9 @@ void VToolMirrorByAxis::showContextMenu(QGraphicsSceneContextMenuEvent *event, q
     {
         ContextMenu<DialogMirrorByAxis>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp
+++ b/src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolmirrorbyline.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
- **  @file
+/************************************************************************
+ **  @file   vtoolmirrorbyline.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   12 9, 2016
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2016 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -268,9 +268,9 @@ void VToolMirrorByLine::showContextMenu(QGraphicsSceneContextMenuEvent *event, q
     {
         ContextMenu<DialogMirrorByLine>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp
+++ b/src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vabstractoperation.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
- **  @file
+/************************************************************************
+ **  @file   vabstractoperation.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   12 9, 2016
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2016 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -48,6 +48,7 @@
  **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
  **
  *************************************************************************/
+
 #include <QtDebug>
 
 #include "vabstractoperation.h"
@@ -537,9 +538,9 @@ void VAbstractOperation::deletePoint()
     {
         deleteTool();
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp
+++ b/src/libs/vtools/tools/drawTools/operation/vtoolmove.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolmove.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
- **  @file
+/************************************************************************
+ **  @file   vtoolmove.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   1 10, 2016
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2016 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -585,9 +585,9 @@ void VToolMove::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 i
     {
         ContextMenu<DialogMove>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp
+++ b/src/libs/vtools/tools/drawTools/operation/vtoolrotation.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolrotation.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolrotation.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   12 4, 2016
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2016 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -406,9 +406,9 @@ void VToolRotation::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint
     {
         ContextMenu<DialogRotation>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vabstractspline.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vabstractspline.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vabstractspline.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   4 3, 2014
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2014 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -284,9 +284,9 @@ void VAbstractSpline::keyReleaseEvent(QKeyEvent *event)
             {
                 deleteTool();
             }
-            catch(const VExceptionToolWasDeleted &e)
+            catch(const VExceptionToolWasDeleted &error)
             {
-                Q_UNUSED(e)
+                Q_UNUSED(error)
                 return;//Leave this method immediately!!!
             }
             break;

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.cpp
@@ -1,40 +1,45 @@
-/******************************************************************************
- *   @file   vtoolarc.cpp
- **  @author Douglas S Caskey
- **  @date   21 Mar, 2023
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Seamly2D project, a pattern making
- **  program to create and model patterns of clothing.
- **  Copyright (C) 2017-2023 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *****************************************************************************/
-
-/************************************************************************
- **
+/***************************************************************************
  **  @file   vtoolarc.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   November 15, 2013
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
  **
  **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
  **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+/************************************************************************
+ **  @file   vtoolarc.cpp
+ **  @author Roman Telezhynskyi <dismine(at)gmail.com>
+ **  @date   November 15, 2013
+ **
+ **  @brief
+ **  @copyright
+ **  This source code is part of the Valentina project, a pattern making
+ **  program, whose allow create and modeling patterns of clothing.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+ **
+ **  Valentina is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -361,9 +366,9 @@ void VToolArc::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id
     {
         ContextMenu<DialogArc>(event);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.cpp
@@ -1,40 +1,45 @@
-/******************************************************************************
- *   @file   vtoolarcwithlength.cpp
- **  @author Douglas S Caskey
- **  @date   21 Mar, 2023
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Seamly2D project, a pattern making
- **  program to create and model patterns of clothing.
- **  Copyright (C) 2017-2023 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *****************************************************************************/
-
-/************************************************************************
- **
+/***************************************************************************
  **  @file   vtoolarcwithlength.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   9 6, 2015
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
  **
  **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
  **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+/************************************************************************
+ **  @file   vtoolarcwithlength.cpp
+ **  @author Roman Telezhynskyi <dismine(at)gmail.com>
+ **  @date   9 6, 2015
+ **
+ **  @brief
+ **  @copyright
+ **  This source code is part of the Valentina project, a pattern making
+ **  program, whose allow create and modeling patterns of clothing.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+ **
+ **  Valentina is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -307,9 +312,9 @@ void VToolArcWithLength::showContextMenu(QGraphicsSceneContextMenuEvent *event, 
     {
         ContextMenu<DialogArcWithLength>(event);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolcubicbezier.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolcubicbezier.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   10 3, 2016
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -222,9 +222,9 @@ void VToolCubicBezier::showContextMenu(QGraphicsSceneContextMenuEvent *event, qu
     {
         ContextMenu<DialogCubicBezier>(event);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezierpath.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezierpath.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolcubicbezierpath.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolcubicbezierpath.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   18 3, 2016
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -207,9 +207,9 @@ void VToolCubicBezierPath::showContextMenu(QGraphicsSceneContextMenuEvent *event
     {
         ContextMenu<DialogCubicBezierPath>(event);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
  *   @file   vtoolellipticalarc.cpp
  **  @author Douglas S Caskey
- **  @date   21 Mar, 2023
+ **  @date   17 Sep, 2023
  **
  **  @brief
  **  @copyright
@@ -409,9 +409,9 @@ void VToolEllipticalArc::showContextMenu(QGraphicsSceneContextMenuEvent *event, 
     {
         ContextMenu<DialogEllipticalArc>(event);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolspline.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolspline.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -326,9 +326,9 @@ void VToolSpline::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32
     {
         ContextMenu<DialogSpline>(event);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolsplinepath.cpp
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolsplinepath.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolsplinepath.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolsplinepath.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -403,9 +403,9 @@ void VToolSplinePath::showContextMenu(QGraphicsSceneContextMenuEvent *event, qui
     {
         ContextMenu<DialogSplinePath>(event);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtooldoublepoint.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtooldoublepoint.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   20 6, 2015
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -360,9 +360,9 @@ void VToolDoublePoint::keyReleaseEvent(QKeyEvent *event)
             {
                 deleteTool();
             }
-            catch(const VExceptionToolWasDeleted &e)
+            catch(const VExceptionToolWasDeleted &error)
             {
-                Q_UNUSED(e)
+                Q_UNUSED(error)
                 return;//Leave this method immediately!!!
             }
             break;

--- a/src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooltruedarts.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooltruedarts.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtooltruedarts.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtooltruedarts.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   23 6, 2015
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -374,9 +374,9 @@ void VToolTrueDarts::showContextMenu(QGraphicsSceneContextMenuEvent *event, quin
     {
         ContextMenu<DialogTrueDarts>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.cpp
@@ -1,25 +1,45 @@
-/**************************************************************************
- **
+/***************************************************************************
  **  @file   intersect_circles_tool.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+/************************************************************************
+ **  @file   vtoolpointofintersectioncircles.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   29 5, 2015
  **
- **  @author Douglas S. Caskey
- **  @date   7.16.2022
- **
+ **  @brief
  **  @copyright
- **  Copyright (C) 2013-2022 Seamly2D project.
- **  This source code is part of the Seamly2D project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Valentina is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published
- **  by the Free Software Foundation, either version 3 of the License,
- **  or (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -354,9 +374,9 @@ void IntersectCirclesTool::showContextMenu(QGraphicsSceneContextMenuEvent *event
     {
         ContextMenu<IntersectCirclesDialog>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.cpp
@@ -1,25 +1,45 @@
-/**************************************************************************
- **
+/***************************************************************************
  **  @file   intersect_circletangent_tool.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+/************************************************************************
+ **  @file   vtoolpointfromcircleandtangent.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   3 6, 2015
  **
- **  @author Douglas S. Caskey
- **  @date   7.16.2022
- **
+ **  @brief
  **  @copyright
- **  Copyright (C) 2013-2022 Seamly2D project.
- **  This source code is part of the Seamly2D project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Valentina is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published
- **  by the Free Software Foundation, either version 3 of the License,
- **  or (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -317,9 +337,9 @@ void IntersectCircleTangentTool::showContextMenu(QGraphicsSceneContextMenuEvent 
     {
         ContextMenu<IntersectCircleTangentDialog>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/point_intersectxy_tool.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/point_intersectxy_tool.cpp
@@ -1,25 +1,45 @@
-/**************************************************************************
- **
+/***************************************************************************
  **  @file   point_intersectxy_tool.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   November 15, 2013
- **
  **  @author Douglas S Caskey
- **  @date   7.21.2022
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
  **
  **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2022 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
  **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+/************************************************************************
+ **  @file   VToolPointOfIntersection.cpp
+ **  @author Roman Telezhynskyi <dismine(at)gmail.com>
+ **  @date   November 15, 2013
+ **
+ **  @brief
+ **  @copyright
+ **  This source code is part of the Valentina project, a pattern making
+ **  program, whose allow create and modeling patterns of clothing.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+ **
+ **  Valentina is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -234,9 +254,9 @@ void PointIntersectXYTool::showContextMenu(QGraphicsSceneContextMenuEvent *event
     {
         ContextMenu<PointIntersectXYDialog>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolcutarc.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolcutarc.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   7 1, 2014
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2014 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -223,9 +223,9 @@ void VToolCutArc::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32
     {
         ContextMenu<DialogCutArc>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolcutspline.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolcutspline.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   15 12, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -223,9 +223,9 @@ void VToolCutSpline::showContextMenu(QGraphicsSceneContextMenuEvent *event, quin
     {
         ContextMenu<DialogCutSpline>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolcutsplinepath.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolcutsplinepath.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   15 12, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -173,7 +173,7 @@ VToolCutSplinePath* VToolCutSplinePath::Create(const quint32 _id, const QString 
     quint32 id = _id;
     VSplinePath *splPath1 = nullptr;
     VSplinePath *splPath2 = nullptr;
-    
+
     VPointF *p = VToolCutSplinePath::CutSplinePath(qApp->toPixel(result), splPath, pointName, &splPath1, &splPath2);
     p->setShowPointName(showPointName);
 
@@ -310,9 +310,9 @@ void VToolCutSplinePath::showContextMenu(QGraphicsSceneContextMenuEvent *event, 
     {
         ContextMenu<DialogCutSplinePath>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolalongline.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolalongline.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -116,9 +116,9 @@ void VToolAlongLine::showContextMenu(QGraphicsSceneContextMenuEvent *event, quin
     {
         ContextMenu<DialogAlongLine>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolbisector.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolbisector.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolbisector.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolbisector.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -287,9 +287,9 @@ void VToolBisector::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint
     {
         ContextMenu<DialogBisector>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolcurveintersectaxis.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolcurveintersectaxis.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   21 10, 2014
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2014 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -329,9 +329,9 @@ void VToolCurveIntersectAxis::showContextMenu(QGraphicsSceneContextMenuEvent *ev
     {
         ContextMenu<DialogCurveIntersectAxis>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolendline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolendline.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolendline.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolendline.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -234,9 +234,9 @@ void VToolEndLine::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint3
     {
         ContextMenu<DialogEndLine>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolheight.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolheight.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -261,9 +261,9 @@ void VToolHeight::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32
     {
         ContextMenu<DialogHeight>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoollineintersectaxis.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoollineintersectaxis.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   19 10, 2014
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2014 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -322,9 +322,9 @@ void VToolLineIntersectAxis::showContextMenu(QGraphicsSceneContextMenuEvent *eve
     {
         ContextMenu<DialogLineIntersectAxis>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolnormal.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolnormal.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolnormal.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolnormal.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -264,9 +264,9 @@ void VToolNormal::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32
     {
         ContextMenu<DialogNormal>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolshoulderpoint.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolshoulderpoint.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -303,9 +303,9 @@ void VToolShoulderPoint::showContextMenu(QGraphicsSceneContextMenuEvent *event, 
     {
         ContextMenu<DialogShoulderPoint>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.cpp
@@ -1,10 +1,10 @@
 /***************************************************************************
- **  @file   vtoolsinglepoint.cpp
+ **  @file   vtoolbasepoint.cpp
  **  @author Douglas S Caskey
- **  @date   Dec 27, 2022
+ **  @date   17 Sep, 2023
  **
  **  @copyright
- **  Copyright (C) 2017 - 2022 Seamly, LLC
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
  **  https://github.com/fashionfreedom/seamly2d
  **
  **  @brief
@@ -23,8 +23,7 @@
  **************************************************************************/
 
 /************************************************************************
- **
- **  @file   vtoolsinglepoint.cpp
+ **  @file   vtoolbasepoint.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
@@ -32,7 +31,7 @@
  **  @copyright
  **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Valentina project
+ **  Copyright (C) 2013 Valentina project
  **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
  **  Valentina is free software: you can redistribute it and/or modify
@@ -46,7 +45,7 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+ **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
  **
  *************************************************************************/
 
@@ -433,10 +432,10 @@ void VToolBasePoint::showContextMenu(QGraphicsSceneContextMenuEvent *event, quin
             ContextMenu<DialogSinglePoint>(event, id, RemoveOption::Disable);
         }
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
         qCDebug(vTool, "Tool was deleted. Leave method immediately.");
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
     qCDebug(vTool, "Context menu was closed. Tool was not deleted.");

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoollineintersect.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoollineintersect.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -265,9 +265,9 @@ void VToolLineIntersect::showContextMenu(QGraphicsSceneContextMenuEvent *event, 
     {
         ContextMenu<DialogLineIntersect>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
 *   @file   vtoolpointfromarcandtangent.cpp
 **  @author Douglas S Caskey
-**  @date   30 Apr, 2023
+**  @date   17 Sep, 2023
 **
 **  @brief
 **  @copyright
@@ -33,17 +33,17 @@
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -363,9 +363,9 @@ void VToolPointFromArcAndTangent::showContextMenu(QGraphicsSceneContextMenuEvent
     {
         ContextMenu<DialogPointFromArcAndTangent>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolpointofcontact.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolpointofcontact.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -176,7 +176,7 @@ QPointF VToolPointOfContact::FindPoint(const qreal &radius, const QPointF &cente
             }
         }
         default:
-            qDebug() << "Unxpected value" << res;
+            qWarning() << "Unxpected value" << res;
             break;
     }
     return QPointF();
@@ -310,9 +310,9 @@ void VToolPointOfContact::showContextMenu(QGraphicsSceneContextMenuEvent *event,
     {
         ContextMenu<DialogPointOfContact>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.cpp
@@ -1,7 +1,7 @@
 /******************************************************************************
 *   @file   vtoolpointofintersectionarcs.cpp
 **  @author Douglas S Caskey
-**  @date   30 Apr, 2023
+**  @date   17 Sep, 2023
 **
 **  @brief
 **  @copyright
@@ -33,17 +33,17 @@
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -357,9 +357,9 @@ void VToolPointOfIntersectionArcs::showContextMenu(QGraphicsSceneContextMenuEven
     {
         ContextMenu<DialogPointOfIntersectionArcs>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolpointofintersectioncurves.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolpointofintersectioncurves.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   22 1, 2016
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2016 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -419,9 +419,9 @@ void VToolPointOfIntersectionCurves::showContextMenu(QGraphicsSceneContextMenuEv
     {
         ContextMenu<DialogPointOfIntersectionCurves>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolsinglepoint.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolsinglepoint.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtoolsinglepoint.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtoolsinglepoint.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -335,9 +335,9 @@ void VToolSinglePoint::keyReleaseEvent(QKeyEvent *event)
             {
                 deleteTool();
             }
-            catch(const VExceptionToolWasDeleted &e)
+            catch(const VExceptionToolWasDeleted &error)
             {
-                Q_UNUSED(e)
+                Q_UNUSED(error)
                 return;//Leave this method immediately!!!
             }
             break;

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtooltriangle.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtooltriangle.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vtooltriangle.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vtooltriangle.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -315,9 +315,9 @@ void VToolTriangle::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint
     {
         ContextMenu<DialogTriangle>(event, id);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/toolpoint/vabstractpoint.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/vabstractpoint.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vabstractpoint.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,11 +19,10 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
+/************************************************************************
  **
  **  @file   vabstractpoint.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -29,17 +30,17 @@
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2015 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -87,9 +88,9 @@ void VAbstractPoint::deletePoint()
     {
         deleteTool();
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }

--- a/src/libs/vtools/tools/drawTools/vdrawtool.cpp
+++ b/src/libs/vtools/tools/drawTools/vdrawtool.cpp
@@ -1,19 +1,13 @@
-/**************************************************************************
- **
+/***************************************************************************
  **  @file   vdrawtool.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   November 15, 2013
- **
  **  @author Douglas S Caskey
- **  @date   7.23.2022
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
  **
  **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2022 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -25,10 +19,36 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+/************************************************************************
+ **  @file   vdrawtool.cpp
+ **  @author Roman Telezhynskyi <dismine(at)gmail.com>
+ **  @date   November 15, 2013
+ **
+ **  @brief
+ **  @copyright
+ **  This source code is part of the Valentina project, a pattern making
+ **  program, whose allow create and modeling patterns of clothing.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+ **
+ **  Valentina is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Valentina is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
  **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
  **
  *************************************************************************/
-
+ 
 #include "vdrawtool.h"
 
 #include "../vabstracttool.h"
@@ -122,7 +142,7 @@ void VDrawTool::SaveDialogChange()
     }
     else
     {
-        qCDebug(vTool, "Can't find tool with id = %u", m_id);
+        qCWarning(vTool, "Can't find tool with id = %u", m_id);
     }
 }
 
@@ -155,7 +175,7 @@ void VDrawTool::SaveOption(QSharedPointer<VGObject> &obj)
     }
     else
     {
-        qCDebug(vTool, "Can't find tool with id = %u", m_id);
+        qCWarning(vTool, "Can't find tool with id = %u", m_id);
     }
 }
 
@@ -196,7 +216,7 @@ void VDrawTool::ReadAttributes()
     }
     else
     {
-        qCDebug(vTool, "Can't find tool with id = %u", m_id);
+        qCWarning(vTool, "Can't find tool with id = %u", m_id);
     }
 }
 

--- a/src/libs/vtools/tools/drawTools/vdrawtool.h
+++ b/src/libs/vtools/tools/drawTools/vdrawtool.h
@@ -1,19 +1,13 @@
-/**************************************************************************
- **
+/***************************************************************************
  **  @file   vdrawtool.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   November 15, 2013
- **
  **  @author Douglas S Caskey
- **  @date   7.23.2022
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
  **
  **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2022 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -25,9 +19,36 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+/************************************************************************
+ **  @file   vdrawtool.h
+ **  @author Roman Telezhynskyi <dismine(at)gmail.com>
+ **  @date   November 15, 2013
+ **
+ **  @brief
+ **  @copyright
+ **  This source code is part of the Valentina project, a pattern making
+ **  program, whose allow create and modeling patterns of clothing.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+ **
+ **  Valentina is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Valentina is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
  **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
  **
  *************************************************************************/
+
 #ifndef VDRAWTOOL_H
 #define VDRAWTOOL_H
 
@@ -142,7 +163,7 @@ private:
 template <typename Dialog>
 /**
  * @brief ContextMenu show context menu for tool.
- * @param itemId id of point. 
+ * @param itemId id of point.
  * @param event context menu event.
  * @param showRemove true - tool enable option delete.
  * @param ref true - do not ignore referens value.
@@ -164,9 +185,9 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
         {
             itemType = data.GetGObject(itemId)->getType();
         }
-        catch (const VExceptionBadId &e)
+        catch (const VExceptionBadId &error)
         { // Possible case. Parent was deleted, but the node object is still here.
-            qWarning() << qUtf8Printable(e.ErrorMessage());
+            qWarning() << qUtf8Printable(error.ErrorMessage());
         }
     }
 
@@ -350,11 +371,11 @@ QString VDrawTool::ObjectName(quint32 id) const
     {
         return data.GeometricObject<T>(id)->name();
     }
-    catch (const VExceptionBadId &e)
+    catch (const VExceptionBadId &error)
     {
-        qCDebug(vTool, "Error! Couldn't get object name by id = %s. %s %s", qUtf8Printable(QString().setNum(id)),
-                qUtf8Printable(e.ErrorMessage()),
-                qUtf8Printable(e.DetailedInformation()));
+        qCWarning(vTool, "Error! Couldn't get object name by id = %s. %s %s", qUtf8Printable(QString().setNum(id)),
+                qUtf8Printable(error.ErrorMessage()),
+                qUtf8Printable(error.DetailedInformation()));
         return QString("");// Return empty string for property browser
     }
 }

--- a/src/libs/vtools/tools/drawTools/vtoolline.cpp
+++ b/src/libs/vtools/tools/drawTools/vtoolline.cpp
@@ -1,20 +1,26 @@
 /******************************************************************************
  *   @file   vtoolline.cpp
  **  @author Douglas S Caskey
- **  @date   21 Mar, 2023
+ **  @date   17 Sep, 2023
+ **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
  **
  **  @brief
- **  @copyright
- **  This source code is part of the Seamly2D project, a pattern making
- **  program to create and model patterns of clothing.
- **  Copyright (C) 2017-2023 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
  **  Seamly2D is free software: you can redistribute it and/or modify
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
  **
- *****************************************************************************/
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
 /************************************************************************
  **
@@ -24,17 +30,17 @@
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -295,9 +301,9 @@ void VToolLine::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 i
     {
         ContextMenu<DialogLine>(event);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return;//Leave this method immediately!!!
     }
 }
@@ -394,9 +400,9 @@ void VToolLine::keyReleaseEvent(QKeyEvent *event)
             {
                 deleteTool();
             }
-            catch(const VExceptionToolWasDeleted &e)
+            catch(const VExceptionToolWasDeleted &error)
             {
-                Q_UNUSED(e)
+                Q_UNUSED(error)
                 return;//Leave this method immediately!!!
             }
             break;

--- a/src/libs/vtools/tools/nodeDetails/anchorpoint_tool.cpp
+++ b/src/libs/vtools/tools/nodeDetails/anchorpoint_tool.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   anchorpoint_tool.cpp
  **  @author Douglas S Caskey
- **  @date   Jan 3, 2023
+ **  @date   17 Sep, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2023 Seamly, LLC
@@ -87,9 +87,9 @@ AnchorPointTool *AnchorPointTool::Create(quint32 _id, quint32 pointId, quint32 p
         {
             point = data->GeometricObject<VPointF>(pointId);
         }
-        catch (const VExceptionBadId &e)
+        catch (const VExceptionBadId &error)
         { // Possible case. Parent was deleted, but the node object is still here.
-            Q_UNUSED(e)
+            Q_UNUSED(error)
             data->UpdateId(id);
             return nullptr;// Just ignore
         }

--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   pattern_piece_tool.cpp
  **  @author Douglas S Caskey
- **  @date   Dec 27, 2022
+ **  @date   17 Sep, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2022 Seamly, LLC
@@ -193,9 +193,9 @@ void PatternPieceTool::Remove(bool ask)
     {
         deleteTool(ask);
     }
-    catch(const VExceptionToolWasDeleted &e)
+    catch(const VExceptionToolWasDeleted &error)
     {
-        Q_UNUSED(e);
+        Q_UNUSED(error);
         return;//Leave this method immediately!!!
     }
 }
@@ -687,7 +687,7 @@ void PatternPieceTool::UpdateGrainline()
     const VPiece piece = VAbstractTool::data.GetPiece(m_id);
     const VGrainlineData &data = piece.GetGrainlineGeometry();
 
-    qDebug()<<"Update Grainline IsVisible() = "<< data.IsVisible();
+    qDebug() << "Update Grainline IsVisible() = " << data.IsVisible();
 
     if (data.IsVisible() & qApp->Settings()->showGrainlines())
     {
@@ -1212,7 +1212,7 @@ void PatternPieceTool::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 
     QAction *showGrainline = menu.addAction(QIcon("://icon/32x32/grainline.png"), tr("Show Grainline") + "\tG");
     showGrainline->setCheckable(true);
-    qDebug()<<"Grainline IsVisible() = "<< piece.GetGrainlineGeometry().IsVisible();
+    qDebug() << "Grainline IsVisible() = " << piece.GetGrainlineGeometry().IsVisible();
     showGrainline->setChecked(piece.GetGrainlineGeometry().IsVisible());
 
     QAction *showPatternLabel = menu.addAction(QIcon("://icon/32x32/pattern_label.png"), tr("Show Pattern Label") + "\t[");
@@ -1289,9 +1289,9 @@ void PatternPieceTool::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
         {
             deleteTool();
         }
-        catch(const VExceptionToolWasDeleted &e)
+        catch(const VExceptionToolWasDeleted &error)
         {
-            Q_UNUSED(e);
+            Q_UNUSED(error);
             return;//Leave this method immediately!!!
         }
         return; //Leave this method immediately after call!!!
@@ -1311,9 +1311,9 @@ void PatternPieceTool::keyReleaseEvent(QKeyEvent *event)
                 {
                     deleteTool();
                 }
-                catch(const VExceptionToolWasDeleted &e)
+                catch(const VExceptionToolWasDeleted &error)
                 {
-                    Q_UNUSED(e);
+                    Q_UNUSED(error);
                     return;//Leave this method immediately!!!
                 }
             }
@@ -1594,9 +1594,9 @@ VPieceItem::MoveTypes PatternPieceTool::FindLabelGeometry(const VPatternLabelDat
         Calculator cal1;
         rotationAngle = cal1.EvalFormula(VAbstractTool::data.DataVariables(), labelData.GetRotation());
     }
-    catch(qmu::QmuParserError &e)
+    catch(qmu::QmuParserError &error)
     {
-        Q_UNUSED(e);
+        Q_UNUSED(error);
         return VPieceItem::Error;
     }
 
@@ -1647,9 +1647,9 @@ VPieceItem::MoveTypes PatternPieceTool::FindLabelGeometry(const VPatternLabelDat
             restrictions &= ~ VPieceItem::IsResizable;
         }
     }
-    catch(qmu::QmuParserError &e)
+    catch(qmu::QmuParserError &error)
     {
-        Q_UNUSED(e);
+        Q_UNUSED(error);
         return VPieceItem::Error;
     }
 
@@ -1733,9 +1733,9 @@ VPieceItem::MoveTypes PatternPieceTool::FindGrainlineGeometry(const VGrainlineDa
         Calculator cal2;
         length = cal2.EvalFormula(VAbstractTool::data.DataVariables(), data.GetLength());
     }
-    catch(qmu::QmuParserError &e)
+    catch(qmu::QmuParserError &error)
     {
-        Q_UNUSED(e);
+        Q_UNUSED(error);
         return VPieceItem::Error;
     }
 
@@ -1810,7 +1810,7 @@ void PatternPieceTool::initializeNode(const VPieceNode &node, VMainGraphicsScene
             doc->IncrementReferens(data->GetGObject(node.GetId())->getIdTool());
             break;
         default:
-            qDebug()<<"Get wrong tool type. Ignore.";
+            qDebug() << "Get wrong tool type. Ignore.";
             break;
     }
 }

--- a/src/libs/vtools/tools/union_tool.cpp
+++ b/src/libs/vtools/tools/union_tool.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   union_tool.cpp
  **  @author Douglas S Caskey
- **  @date   Dec 27, 2022
+ **  @date   17 Sep, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2022 Seamly, LLC
@@ -32,7 +32,7 @@
  **  @copyright
  **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Valentina project
+ **  Copyright (C) 2013-2013 Valentina project
  **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
  **  Valentina is free software: you can redistribute it and/or modify
@@ -654,7 +654,7 @@ void AddNodeToNewPath(const UnionToolInitData &initData, VPiecePath &newPath, VP
             id = AddNodeSplinePath(node, initData, idTool, children, blockName, dx, dy, pRotate, angle);
             break;
         default:
-            qDebug()<<"May be wrong tool type!!! Ignoring."<<Q_FUNC_INFO;
+            qWarning() << "May be wrong tool type!!! Ignoring." << Q_FUNC_INFO;
             break;
     }
 
@@ -1004,7 +1004,7 @@ void UpdatePathNode(VContainer *data, const VPieceNode &node, QVector<quint32> &
             UpdateNodeSplinePath(data, node, children, dx, dy, pRotate, angle);
             break;
         default:
-            qDebug()<<"May be wrong tool type!!! Ignoring."<<Q_FUNC_INFO;
+            qWarning() << "May be wrong tool type!!! Ignoring." << Q_FUNC_INFO;
             break;
     }
 }

--- a/src/libs/vtools/tools/vabstracttool.cpp
+++ b/src/libs/vtools/tools/vabstracttool.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
+ **  @file   vabstracttool.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   vabstracttool.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   November 15, 2013
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -190,17 +190,17 @@ qreal VAbstractTool::CheckFormula(const quint32 &toolId, QString &formula, VCont
 
         if (qIsInf(result) || qIsNaN(result))
         {
-            qDebug() << "Invalid the formula value";
+            qWarning() << "Invalid the formula value";
             return 0;
         }
     }
-    catch (qmu::QmuParserError &e)
+    catch (qmu::QmuParserError &error)
     {
-        qDebug() << "\nMath parser error:\n"
-                 << "--------------------------------------\n"
-                 << "Message:     " << e.GetMsg()  << "\n"
-                 << "Expression:  " << e.GetExpr() << "\n"
-                 << "--------------------------------------";
+        qWarning() << "\nMath parser error:\n"
+                   << "--------------------------------------\n"
+                   << "Message:     " << error.GetMsg()  << "\n"
+                   << "Expression:  " << error.GetExpr() << "\n"
+                   << "--------------------------------------";
 
         if (qApp->IsAppInGUIMode())
         {
@@ -226,7 +226,7 @@ qreal VAbstractTool::CheckFormula(const quint32 &toolId, QString &formula, VCont
 
                             if (qIsInf(result) || qIsNaN(result))
                             {
-                                qDebug() << "Invalid the formula value";
+                                qWarning() << "Invalid the formula value";
                                 return 0;
                             }
 
@@ -288,7 +288,7 @@ void VAbstractTool::deleteTool(bool ask)
     }
     else
     {
-        qCDebug(vTool, "Can't delete, tool has children.");
+        qCWarning(vTool, "Can't delete, tool has children.");
     }
 }
 
@@ -462,7 +462,7 @@ QPixmap VAbstractTool::createColorIcon(const int w, const int h, const QString &
 
     const QRect rectangle = QRect(1, 1, w-2, h-2);
 
-    qDebug()<<"createColorIcon - color = "<< color;
+    qDebug() << "createColorIcon - color = " << color;
 
     if (color == "No Group")
     {
@@ -670,7 +670,7 @@ QDomElement VAbstractTool::AddSANode(VAbstractPattern *doc, const QString &tagNa
             doc->SetAttribute(nod, AttrType, VAbstractPattern::NodeSplinePath);
             break;
         default:
-            qDebug()<<"May be wrong tool type!!! Ignoring."<<Q_FUNC_INFO;
+            qWarning() << "May be wrong tool type!!! Ignoring."<<Q_FUNC_INFO;
             break;
     }
 
@@ -772,7 +772,7 @@ quint32 VAbstractTool::PrepareNode(const VPieceNode &node, VMainGraphicsScene *s
             VNodeSplinePath::Create(doc, data, id, node.GetId(), Document::FullParse, Source::FromGui);
             break;
         default:
-            qDebug()<<"May be wrong tool type!!! Ignoring."<<Q_FUNC_INFO;
+            qWarning() << "May be wrong tool type!!! Ignoring."<<Q_FUNC_INFO;
             break;
     }
     return id;

--- a/src/libs/vtools/undocommands/savepieceoptions.cpp
+++ b/src/libs/vtools/undocommands/savepieceoptions.cpp
@@ -1,7 +1,7 @@
 /***************************************************************************
  **  @file   savepieceoptions.cpp
  **  @author Douglas S Caskey
- **  @date   Dec 11, 2022
+ **  @date   17 Sep, 2023
  **
  **  @copyright
  **  Copyright (C) 2017 - 2022 Seamly, LLC
@@ -109,7 +109,7 @@ void SavePieceOptions::undo()
     }
     else
     {
-        qCDebug(vUndo, "Can't find piece with id = %u.", nodeId);
+        qCWarning(vUndo, "Can't find piece with id = %u.", nodeId);
         return;
     }
 }
@@ -141,7 +141,7 @@ void SavePieceOptions::redo()
     }
     else
     {
-        qCDebug(vUndo, "Can't find piece with id = %u.", nodeId);
+        qCWarning(vUndo, "Can't find piece with id = %u.", nodeId);
         return;
     }
 }

--- a/src/libs/vtools/undocommands/savepiecepathoptions.cpp
+++ b/src/libs/vtools/undocommands/savepiecepathoptions.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   savepiecepathoptions.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
- **  @file
+/************************************************************************
+ **  @file   savepiecepathoptions.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   26 11, 2016
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2016 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -95,7 +95,7 @@ void SavePiecePathOptions::undo()
     }
     else
     {
-        qCDebug(vUndo, "Can't find path with id = %u.", nodeId);
+        qCWarning(vUndo, "Can't find path with id = %u.", nodeId);
         return;
     }
 }
@@ -119,7 +119,7 @@ void SavePiecePathOptions::redo()
     }
     else
     {
-        qCDebug(vUndo, "Can't find path with id = %u.", nodeId);
+        qCWarning(vUndo, "Can't find path with id = %u.", nodeId);
         return;
     }
 }

--- a/src/libs/vtools/undocommands/savetooloptions.cpp
+++ b/src/libs/vtools/undocommands/savetooloptions.cpp
@@ -1,11 +1,13 @@
 /***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
+ **  @file   savetooloptions.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
  **  Seamly2D is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
@@ -17,29 +19,27 @@
  **  GNU General Public License for more details.
  **
  **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
 
- ************************************************************************
- **
+/************************************************************************
  **  @file   savetooloptions.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   11 6, 2014
  **
  **  @brief
  **  @copyright
- **  This source code is part of the Valentine project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Copyright (C) 2013-2014 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
+ **  Valentina is free software: you can redistribute it and/or modify
  **  it under the terms of the GNU General Public License as published by
  **  the Free Software Foundation, either version 3 of the License, or
  **  (at your option) any later version.
  **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -85,7 +85,7 @@ void SaveToolOptions::undo()
     }
     else
     {
-        qCDebug(vUndo, "Can't find tool with id = %u.", nodeId);
+        qCWarning(vUndo, "Can't find tool with id = %u.", nodeId);
         return;
     }
 }
@@ -104,7 +104,7 @@ void SaveToolOptions::redo()
     }
     else
     {
-        qCDebug(vUndo, "Can't find tool with id = %u.", nodeId);
+        qCWarning(vUndo, "Can't find tool with id = %u.", nodeId);
         return;
     }
 }

--- a/src/libs/vtools/visualization/visualization.cpp
+++ b/src/libs/vtools/visualization/visualization.cpp
@@ -1,26 +1,45 @@
-/**************************************************************************
+/***************************************************************************
+ **  @file   visualization.cpp
+ **  @author Douglas S Caskey
+ **  @date   17 Sep, 2023
  **
+ **  @copyright
+ **  Copyright (C) 2017 - 2023 Seamly, LLC
+ **  https://github.com/fashionfreedom/seamly2d
+ **
+ **  @brief
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+ **************************************************************************/
+
+/************************************************************************
  **  @file   visualization.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
  **  @date   15 8, 2014
  **
- **  @author Douglas S Caskey
- **  @date   7.23.2022
- **
  **  @brief
  **  @copyright
- **  Copyright (C) 2013-2022 Seamly2D project.
- **  This source code is part of the Seamly2D project, a pattern making
+ **  This source code is part of the Valentina project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
+ **  Copyright (C) 2014 Valentina project
+ **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **  Valentina is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
  **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published
- **  by the Free Software Foundation, either version 3 of the License,
- **  or (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
+ **  Valentina is distributed in the hope that it will be useful,
  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  **  GNU General Public License for more details.
@@ -186,14 +205,14 @@ qreal Visualization::FindVal(const QString &expression,
                 val = 0;
             }
         }
-        catch (qmu::QmuParserError &e)
+        catch (qmu::QmuParserError &error)
         {
             val = 0;
-            qDebug() << "\nMath parser error:\n"
-                     << "--------------------------------------\n"
-                     << "Message:     " << e.GetMsg()  << "\n"
-                     << "Expression:  " << e.GetExpr() << "\n"
-                     << "--------------------------------------";
+            qWarning() << "\nMath parser error:\n"
+                       << "--------------------------------------\n"
+                       << "Message:     " << error.GetMsg()  << "\n"
+                       << "Expression:  " << error.GetExpr() << "\n"
+                       << "--------------------------------------";
         }
     }
     return val;

--- a/src/libs/vwidgets/export_format_combobox.cpp
+++ b/src/libs/vwidgets/export_format_combobox.cpp
@@ -1,7 +1,7 @@
  /******************************************************************************
   *   @file   export_format_combobox.cpp
   **  @author DS Caskey
-  **  @date   Mar 15, 2022
+  **  @date   @date   17 Sep, 2023
   **
   **  @brief
   **  @copyright
@@ -192,7 +192,7 @@ bool ExportFormatCombobox::testPdf()
     }
     else
     {
-        qDebug()<<PDFTOPS<<"error"<<proc.error()<<proc.errorString();
+        qWarning() << PDFTOPS << "error" << proc.error() << proc.errorString();
     }
     return res;
 }

--- a/src/test/Seamly2DTest/tst_qmutokenparser.cpp
+++ b/src/test/Seamly2DTest/tst_qmutokenparser.cpp
@@ -168,9 +168,9 @@ bool TST_QmuTokenParser::IsSingleFromUser(const QString &formula)
         tokens = cal->GetTokens();// Tokens (variables, measurements)
         numbers = cal->GetNumbers();// All numbers in expression
     }
-    catch (const qmu::QmuParserError &e)
+    catch (const qmu::QmuParserError &error)
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         return false;// something wrong with formula, say no
     }
 

--- a/src/test/Seamly2DTest/tst_vlayoutdetail.cpp
+++ b/src/test/Seamly2DTest/tst_vlayoutdetail.cpp
@@ -63,13 +63,13 @@ TST_VLayoutDetail::TST_VLayoutDetail(QObject *parent)
 //---------------------------------------------------------------------------------------------------------------------
 void TST_VLayoutDetail::RemoveDublicates() const
 {
-    qDebug()<<"Case 1.";
+    qDebug() << "Case 1.";
     Case1();
 
-    qDebug()<<"Case 2.";
+    qDebug() << "Case 2.";
     Case2();
 
-    qDebug()<<"Case 3.";
+    qDebug() << "Case 3.";
     Case3();
 }
 

--- a/src/test/Seamly2DTest/tst_vmeasurements.cpp
+++ b/src/test/Seamly2DTest/tst_vmeasurements.cpp
@@ -106,9 +106,9 @@ void TST_VMeasurements::CreateEmptyMultisizeFile()
     {
         VDomDocument::ValidateXML(VVSTConverter::CurrentSchema, fileName);
     }
-    catch (VException &e)
+    catch (VException &error)
     {
-        QFAIL(e.ErrorMessage().toUtf8().constData());
+        QFAIL(error.ErrorMessage().toUtf8().constData());
     }
 }
 
@@ -146,9 +146,9 @@ void TST_VMeasurements::CreateEmptyIndividualFile()
     {
         VDomDocument::ValidateXML(VVITConverter::CurrentSchema, fileName);
     }
-    catch (VException &e)
+    catch (VException &error)
     {
-        QFAIL(e.ErrorMessage().toUtf8().constData());
+        QFAIL(error.ErrorMessage().toUtf8().constData());
     }
 }
 
@@ -201,9 +201,9 @@ void TST_VMeasurements::ValidPMCodesMultisizeFile()
         {
             VDomDocument::ValidateXML(VVSTConverter::CurrentSchema, fileName);
         }
-        catch (VException &e)
+        catch (VException &error)
         {
-            const QString message = QString("Error: %1 for code=%2").arg(e.ErrorMessage()).arg(listSystems.at(i));
+            const QString message = QString("Error: %1 for code=%2").arg(error.ErrorMessage()).arg(listSystems.at(i));
             QFAIL(qUtf8Printable(message));
         }
     }
@@ -252,9 +252,9 @@ void TST_VMeasurements::ValidPMCodesIndividualFile()
         {
             VDomDocument::ValidateXML(VVITConverter::CurrentSchema, fileName);
         }
-        catch (VException &e)
+        catch (VException &error)
         {
-            const QString message = QString("Error: %1 for code=%2").arg(e.ErrorMessage()).arg(listSystems.at(i));
+            const QString message = QString("Error: %1 for code=%2").arg(error.ErrorMessage()).arg(listSystems.at(i));
             QFAIL(qUtf8Printable(message));
         }
     }

--- a/src/test/Seamly2DTest/tst_vtranslatevars.cpp
+++ b/src/test/Seamly2DTest/tst_vtranslatevars.cpp
@@ -100,9 +100,9 @@ void TST_VTranslateVars::TestFormulaFromUser()
     {
         result = m_trMs->FormulaFromUser(input, true);
     }
-    catch (qmu::QmuParserError &e)// In case something bad will happen
+    catch (qmu::QmuParserError &error)// In case something bad will happen
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         result = input;
     }
 
@@ -139,9 +139,9 @@ void TST_VTranslateVars::TestFormulaToUser()
     {
         result = m_trMs->FormulaToUser(input, true);
     }
-    catch (qmu::QmuParserError &e)// In case something bad will happen
+    catch (qmu::QmuParserError &error)// In case something bad will happen
     {
-        Q_UNUSED(e)
+        Q_UNUSED(error)
         result = input;
     }
 


### PR DESCRIPTION
This fixes the excessive file logging in release mode.

- Adds a CONFIG define  to only output qDebug() or qCDebug() messages in debug mode. 
- Replaces some qDebug()  messages with  qInfo() or qWarning() messages in order to control which messages we want to output to the log file, while allowing all messages to output in debug mode. 
- Refactors some  symbols named "e" with "event" or "error".
- Updates the Copyright notices in affected files.

Fixes issue #1024 