### PR TITLE
fix: revert logging warnings

### DIFF
--- a/src/app/seamly2d/dialogs/dialoghistory.cpp
+++ b/src/app/seamly2d/dialogs/dialoghistory.cpp
@@ -253,7 +253,7 @@ QString DialogHistory::Record(const VToolRecord &tool)
     const QDomElement domElem = doc->elementById(tool.getId());
     if (domElem.isElement() == false)
     {
-        qWarning() << "Can't find element by id" << Q_FUNC_INFO;
+        qDebug() << "Can't find element by id" << Q_FUNC_INFO;
         return QString();
     }
     try
@@ -465,7 +465,7 @@ QString DialogHistory::Record(const VToolRecord &tool)
         qWarning() << error.ErrorMessage() << Q_FUNC_INFO;
         return QString();
     }
-    qWarning() << "Can't create history record for the tool.";
+    qDebug() << "Can't create history record for the tool.";
     return QString();
 }
 

--- a/src/app/seamly2d/dialogs/groups_widget.cpp
+++ b/src/app/seamly2d/dialogs/groups_widget.cpp
@@ -763,7 +763,7 @@ void GroupsWidget::addGroupItem(const quint32 &toolId, const quint32 &objId, con
     const QDomElement domElement = m_doc->elementById(toolId);
     if (domElement.isElement() == false)
     {
-        qWarning() << "Can't find element by id" << Q_FUNC_INFO;
+        qDebug() << "Can't find element by id" << Q_FUNC_INFO;
         return;
     }
         try
@@ -1047,7 +1047,7 @@ void GroupsWidget::addGroupItem(const quint32 &toolId, const quint32 &objId, con
             itemData.append(objId);
             itemData.append(toolId);
 
-            qWarning() << error.ErrorMessage() << Q_FUNC_INFO;
+            qDebug() << error.ErrorMessage() << Q_FUNC_INFO;
             QListWidgetItem *item = new QListWidgetItem(objName);
             item->setIcon(QIcon(":/icons/win.icon.theme/16x16/status/dialog-warning.png"));
             item->setData(Qt::UserRole,  QVariant::fromValue(itemData));
@@ -1096,9 +1096,8 @@ QString GroupsWidget::getObjName(quint32 toolId)
     }
     catch (const VExceptionBadId &error)
     {
-        qWarning(WidgetGroups, "Error! Couldn't get object name by id = %s. %s %s", qUtf8Printable(QString().setNum(toolId)),
-            qUtf8Printable(error.ErrorMessage()),
-            qUtf8Printable(error.DetailedInformation()));
+        qCDebug(WidgetGroups, "Error! Couldn't get object name by id = %s. %s %s", qUtf8Printable(QString().setNum(toolId)),
+                qUtf8Printable(error.ErrorMessage()), qUtf8Printable(error.DetailedInformation()));
         return QString("Unknown Object");// Return Unknown string
     }
 }

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -7199,8 +7199,8 @@ bool MainWindow::IgnoreLocking(int error, const QString &path)
 
     if (answer == QMessageBox::Abort)
     {
-        qCWarning(vMainWindow, "Failed to lock %s", qUtf8Printable(path));
-        qCWarning(vMainWindow, "Error type: %d", error);
+        qCDebug(vMainWindow, "Failed to lock %s", qUtf8Printable(path));
+        qCDebug(vMainWindow, "Error type: %d", error);
         Clear();
         if (!VApplication::IsGUIMode())
         {

--- a/src/app/seamly2d/mainwindowsnogui.cpp
+++ b/src/app/seamly2d/mainwindowsnogui.cpp
@@ -93,7 +93,7 @@ bool CreateLayoutPath(const QString &path)
     bool usedNotExistedDir = true;
     QDir dir(path);
     dir.setPath(path);
-    if (not dir.exists(path))
+    if (!dir.exists(path))
     {
         usedNotExistedDir = dir.mkpath(".");
     }
@@ -308,7 +308,7 @@ void MainWindowsNoGUI::ExportFlatLayout(const ExportLayoutDialog &dialog, const 
 {
     const QString path = dialog.path();
     bool usedNotExistedDir = CreateLayoutPath(path);
-    if (not usedNotExistedDir)
+    if (!usedNotExistedDir)
     {
         qCritical() << tr("Can't create a path");
         return;
@@ -399,7 +399,7 @@ void MainWindowsNoGUI::ExportApparelLayout(const ExportLayoutDialog &dialog, con
 {
     const QString path = dialog.path();
     bool usedNotExistedDir = CreateLayoutPath(path);
-    if (not usedNotExistedDir)
+    if (!usedNotExistedDir)
     {
         qCritical() << tr("Can't create a path");
         return;
@@ -533,7 +533,7 @@ void MainWindowsNoGUI::PrintPages(QPrinter *printer)
     const double scale = qMin(xscale, yscale);
 
     QPainter painter;
-    if (not painter.begin(printer))
+    if (!painter.begin(printer))
     { // failed to open file
         qWarning("failed to open file, is it writable?");
         return;
@@ -598,7 +598,7 @@ void MainWindowsNoGUI::PrintPages(QPrinter *printer)
 
     const int numPages = lastPage - firstPage + 1;
     int copyCount = 1;
-    if (not printer->supportsMultipleCopies())
+    if (!printer->supportsMultipleCopies())
     {
         copyCount = printer->copyCount();
     }
@@ -609,9 +609,9 @@ void MainWindowsNoGUI::PrintPages(QPrinter *printer)
         {
             if (i != 0 || j != 0)
             {
-                if (not printer->newPage())
+                if (!printer->newPage())
                 {
-                    qWarning("failed in flushing page to disk, disk full?");
+                    qWarning("Failed in flushing page to disk, disk may be full.");
                     return;
                 }
             }
@@ -678,7 +678,7 @@ void MainWindowsNoGUI::PrintPages(QPrinter *printer)
 //---------------------------------------------------------------------------------------------------------------------
 void MainWindowsNoGUI::PrintPreviewOrigin()
 {
-    if (not isPagesUniform())
+    if (!isPagesUniform())
     {
         qCritical() << tr("For previewing multipage document all sheet should have the same size.");
         return;
@@ -698,7 +698,7 @@ void MainWindowsNoGUI::PrintPreviewTiled()
 //---------------------------------------------------------------------------------------------------------------------
 void MainWindowsNoGUI::PrintOrigin()
 {
-    if (not isPagesUniform())
+    if (!isPagesUniform())
     {
         qCritical() << tr("For printing multipages document all sheet should have the same size.");
         return;
@@ -774,7 +774,7 @@ void MainWindowsNoGUI::refreshSeamAllowances()
 QVector<VLayoutPiece> MainWindowsNoGUI::preparePiecesForLayout(const QHash<quint32, VPiece> &pieces)
 {
     QVector<VLayoutPiece> pieceList;
-    if (not pieces.isEmpty())
+    if (!pieces.isEmpty())
     {
         QHash<quint32, VPiece>::const_iterator i = pieces.constBegin();
         while (i != pieces.constEnd())
@@ -807,7 +807,7 @@ QIcon MainWindowsNoGUI::ScenePreview(int i) const
         // Create the image with the exact size of the shrunk scene
         image = QImage(QSize(static_cast<qint32>(r.width()), static_cast<qint32>(r.height())), QImage::Format_RGB32);
 
-        if (not image.isNull())
+        if (!image.isNull())
         {
             image.fill(Qt::white);
             QPainter painter(&image);
@@ -1064,7 +1064,7 @@ void MainWindowsNoGUI::PdfTiledFile(const QString &name)
     SetPrinterSettings(&printer, PrintType::PrintPDF);
 
     // Call IsPagesFit after setting a printer settings and check if pages is not bigger than printer's paper size
-    if (not isTiled && not IsPagesFit(printer.pageLayout().fullRectPixels(printer.resolution()).size()))
+    if (!isTiled && not IsPagesFit(printer.pageLayout().fullRectPixels(printer.resolution()).size()))
     {
         qWarning() << tr("Pages will be cropped because they do not fit printer paper size.");
     }
@@ -1368,7 +1368,7 @@ void MainWindowsNoGUI::SetPrinterSettings(QPrinter *printer, const PrintType &pr
     printer->setCreator(QGuiApplication::applicationDisplayName()+" "+QCoreApplication::applicationVersion());
     printer->setPageOrientation(QPageLayout::Orientation::Portrait);
 
-    if (not isTiled)
+    if (!isTiled)
     {
         QSizeF size = QSizeF(FromPixel(paperSize.width(), Unit::Mm), FromPixel(paperSize.height(), Unit::Mm));
         if (isAutoCrop || isUnitePages)
@@ -1411,7 +1411,7 @@ void MainWindowsNoGUI::SetPrinterSettings(QPrinter *printer, const PrintType &pr
 
     qreal left, top, right, bottom;
 
-    if (not isTiled)
+    if (!isTiled)
     {
         QMarginsF pageMargin = QMarginsF(UnitConvertor(margins, Unit::Px, Unit::Mm));
         left = pageMargin.left();
@@ -1442,7 +1442,7 @@ void MainWindowsNoGUI::SetPrinterSettings(QPrinter *printer, const PrintType &pr
     }
 
     const bool success = printer->setPageMargins(QMarginsF(left, top, right, bottom), QPageLayout::Millimeter);
-    if (not success)
+    if (!success)
     {
         qWarning() << tr("Cannot set printer margins");
     }
@@ -1504,7 +1504,7 @@ bool MainWindowsNoGUI::IsLayoutGrayscale() const
             // Restore
             RestorePaper(i);
 
-            if (not image.isGrayscale())
+            if (!image.isGrayscale())
             {
                 return false;
             }

--- a/src/libs/fervor/fvupdater.cpp
+++ b/src/libs/fervor/fvupdater.cpp
@@ -289,7 +289,7 @@ void FvUpdater::fileDownloadFinished(QFile *downloadedFile, QString name) {
 		QProcess proc;
 		auto	 res = proc.startDetached(QDir::toNativeSeparators(fileInfo.absoluteFilePath()), QStringList());
 		auto	 err = proc.error();
-		qWarning() << res << " " << err;
+		qDebug() << res << " " << err;
 #else
 
 		QDesktopServices::openUrl(QUrl::fromLocalFile(fileInfo.absoluteFilePath()));

--- a/src/libs/ifc/xml/vabstractpattern.cpp
+++ b/src/libs/ifc/xml/vabstractpattern.cpp
@@ -544,13 +544,13 @@ bool VAbstractPattern::renameDraftBlock(const QString &oldName, const QString &n
 
     if (draftBlockNameExists(oldName) == false)
     {
-        qWarning() << "Draft block does not exist with name" << oldName;
+        qDebug() << "Draft block does not exist with name" << oldName;
         return false;
     }
 
     if (draftBlockNameExists(newName))
     {
-        qWarning() << "Draft block already exists with name" << newName;
+        qDebug() << "Draft block already exists with name" << newName;
         return false;
     }
 
@@ -568,7 +568,7 @@ bool VAbstractPattern::renameDraftBlock(const QString &oldName, const QString &n
     }
     else
     {
-        qWarning() << "Can't find draft block node with name" << oldName << Q_FUNC_INFO;
+        qDebug() << "Can't find draft block node with name" << oldName << Q_FUNC_INFO;
         return false;
     }
 }


### PR DESCRIPTION
This reverts some of the warning() logging messages back to debug() messages so that a warning dialog does not pop up. In these cases it's perfectly acceptable to only report the debug() messages while running in debug mode. 

Fixes issue #1028 