### PR TITLE
fix: revert qCWarning() to qCDebug()

### DIFF
--- a/src/app/seamlyme/mapplication.cpp
+++ b/src/app/seamlyme/mapplication.cpp
@@ -647,7 +647,7 @@ void MApplication::ParseCommandLine(const SocketConnection &connection, const QS
             return;
         }
 
-        qCWarning(mApp, "Can't establish connection to the server '%s'", qUtf8Printable(serverName));
+        qCDebug(mApp, "Can't establish connection to the server '%s'", qUtf8Printable(serverName));
 
         localServer = new QLocalServer(this);
         connect(localServer, &QLocalServer::newConnection, this, &MApplication::NewLocalSocketConnection);


### PR DESCRIPTION
This reverts inadvertant qCWarning() to a qCDebug(). 

Fixes issue #1034 