### PR TITLE
bug: fix file path prefs

### DIFF
--- a/src/app/seamly2d/core/vapplication.cpp
+++ b/src/app/seamly2d/core/vapplication.cpp
@@ -604,12 +604,12 @@ void VApplication::InitOptions()
 
     OpenSettings();
     VSettings *settings = Seamly2DSettings();
-    QDir().mkpath(settings->GetDefPathLayout());
-    QDir().mkpath(settings->GetDefPathPattern());
+    QDir().mkpath(settings->getDefaultLayoutPath());
+    QDir().mkpath(settings->getDefaultPatternPath());
     QDir().mkpath(settings->getDefaultIndividualSizePath());
     QDir().mkpath(settings->getDefaultMultisizePath());
     QDir().mkpath(settings->getDefaultTemplatePath());
-    QDir().mkpath(settings->GetDefPathLabelTemplate());
+    QDir().mkpath(settings->getDefaultLabelTemplatePath());
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui
@@ -18,8 +18,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>487</width>
-    <height>572</height>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -32,21 +32,21 @@
    <item>
     <widget class="QTabWidget" name="company_Tab">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="minimumSize">
       <size>
-       <width>465</width>
-       <height>550</height>
+       <width>0</width>
+       <height>0</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>465</width>
-       <height>550</height>
+       <width>16777215</width>
+       <height>16777215</height>
       </size>
      </property>
      <property name="font">
@@ -70,6 +70,12 @@
       <layout class="QVBoxLayout" name="verticalLayout_14">
        <item>
         <widget class="QGroupBox" name="groupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="font">
           <font>
            <bold>true</bold>
@@ -1158,6 +1164,12 @@
       <layout class="QVBoxLayout" name="verticalLayout_10">
        <item>
         <widget class="QGroupBox" name="language_GroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="minimumSize">
           <size>
            <width>0</width>

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -24,8 +24,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>485</width>
-    <height>570</height>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="font">
@@ -56,8 +56,8 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>465</width>
-       <height>550</height>
+       <width>16777215</width>
+       <height>16777215</height>
       </size>
      </property>
      <property name="font">
@@ -137,6 +137,12 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupBox_2">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
@@ -351,6 +357,12 @@
       <layout class="QVBoxLayout" name="verticalLayout_19">
        <item>
         <widget class="QGroupBox" name="labelFont_GroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="minimumSize">
           <size>
            <width>420</width>
@@ -616,6 +628,12 @@
        </item>
        <item>
         <widget class="QGroupBox" name="pointNameFont_GroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="minimumSize">
           <size>
            <width>420</width>
@@ -879,6 +897,12 @@
        </item>
        <item>
         <widget class="QGroupBox" name="pointNameFont_GroupBox_2">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="minimumSize">
           <size>
            <width>420</width>
@@ -1176,7 +1200,7 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>420</width>
+           <width>16777215</width>
            <height>16777215</height>
           </size>
          </property>
@@ -1329,7 +1353,7 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>420</width>
+           <width>16777215</width>
            <height>16777215</height>
           </size>
          </property>
@@ -1482,7 +1506,7 @@
          </property>
          <property name="maximumSize">
           <size>
-           <width>420</width>
+           <width>16777215</width>
            <height>16777215</height>
           </size>
          </property>

--- a/src/app/seamly2d/dialogs/configpages/preferencespathpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencespathpage.ui
@@ -18,8 +18,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>485</width>
-    <height>570</height>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp
@@ -263,7 +263,7 @@ void PreferencesPatternPage::setDefaultTemplate()
 
     QString filter(tr("Label template") + QLatin1String("(*.xml)"));
     const QString fileName = QFileDialog::getOpenFileName(this, tr("Import template"),
-                                                          settings->GetPathLabelTemplate(), filter, nullptr,
+                                                          settings->getLabelTemplatePath(), filter, nullptr,
                                                           QFileDialog::DontUseNativeDialog);
 
 

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -24,8 +24,8 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>600</width>
-    <height>570</height>
+    <width>16777215</width>
+    <height>16777215</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -57,8 +57,8 @@
    </property>
    <property name="maximumSize">
     <size>
-     <width>465</width>
-     <height>555</height>
+     <width>16777215</width>
+     <height>16777215</height>
     </size>
    </property>
    <property name="font">
@@ -73,6 +73,12 @@
     <number>0</number>
    </property>
    <widget class="QWidget" name="tab_4">
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
     <attribute name="title">
      <string>Pattern Piece</string>
     </attribute>
@@ -93,7 +99,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>420</width>
+         <width>16777215</width>
          <height>16777215</height>
         </size>
        </property>
@@ -193,6 +199,12 @@
     </layout>
    </widget>
    <widget class="QWidget" name="tab_5">
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
     <attribute name="title">
      <string>Notches</string>
     </attribute>
@@ -213,7 +225,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>420</width>
+         <width>16777215</width>
          <height>16777215</height>
         </size>
        </property>
@@ -618,6 +630,12 @@
     </layout>
    </widget>
    <widget class="QWidget" name="tab_10">
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
     <attribute name="title">
      <string>Grainlines</string>
     </attribute>
@@ -644,7 +662,7 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>420</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -928,6 +946,12 @@
     </widget>
    </widget>
    <widget class="QWidget" name="tab_6">
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
     <attribute name="title">
      <string>Paths</string>
     </attribute>
@@ -954,7 +978,7 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>420</width>
+       <width>16777215</width>
        <height>16777215</height>
       </size>
      </property>
@@ -1963,6 +1987,12 @@
     </widget>
    </widget>
    <widget class="QWidget" name="tab_7">
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
     <attribute name="title">
      <string>Labels</string>
     </attribute>
@@ -1983,7 +2013,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>420</width>
+         <width>16777215</width>
          <height>16777215</height>
         </size>
        </property>
@@ -2301,7 +2331,7 @@
        </property>
        <property name="maximumSize">
         <size>
-         <width>420</width>
+         <width>16777215</width>
          <height>16777215</height>
         </size>
        </property>

--- a/src/app/seamly2d/dialogs/dialogpreferences.ui
+++ b/src/app/seamly2d/dialogs/dialogpreferences.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>640</width>
+    <width>750</width>
     <height>620</height>
    </rect>
   </property>
@@ -24,7 +24,7 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>640</width>
+    <width>800</width>
     <height>620</height>
    </size>
   </property>

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -3798,7 +3798,7 @@ bool MainWindow::SaveAs()
     bool usedNotExistedDir = false;
     if (filePath.isEmpty())
     {
-        dir = qApp->Seamly2DSettings()->GetPathPattern();
+        dir = qApp->Seamly2DSettings()->getPatternPath();
         fileName = tr("pattern");
     }
     else

--- a/src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp
+++ b/src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.cpp
@@ -164,17 +164,22 @@ void SeamlyMePreferencesPathPage::editPath()
         usedNotExistedDir = directory.mkpath(".");
     }
 
-    const QString dir = QFileDialog::getExistingDirectory(this, tr("Open Directory"), path,
-                                                          QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+    QString filename = fileDialog(this, tr("Open Directory"), path, QString(""), nullptr,
+                                                              QFileDialog::ShowDirsOnly |
+                                                              QFileDialog::DontResolveSymlinks |
+                                                              QFileDialog::DontUseNativeDialog,
+                                                              QFileDialog::Directory, QFileDialog::AcceptOpen);
+
+    const QString dir = QFileInfo(filename).filePath();
+
+    if (usedNotExistedDir)
+    {
+        QDir directory(path);
+        directory.rmpath(".");
+    }
+
     if (dir.isEmpty())
     {
-        if (usedNotExistedDir)
-        {
-            QDir directory(path);
-            directory.rmpath(".");
-        }
-
-        defaultPath();
         return;
     }
 

--- a/src/app/seamlyme/mapplication.cpp
+++ b/src/app/seamlyme/mapplication.cpp
@@ -403,7 +403,7 @@ void MApplication::InitOptions()
     QDir().mkpath(settings->getDefaultTemplatePath());
     QDir().mkpath(settings->getDefaultIndividualSizePath());
     QDir().mkpath(settings->getDefaultMultisizePath());
-    QDir().mkpath(settings->GetDefPathLabelTemplate());
+    QDir().mkpath(settings->getDefaultLabelTemplatePath());
 
     qCInfo(mApp, "Version: %s", qUtf8Printable(APP_VERSION_STR));
     qCInfo(mApp, "Build revision: %s", BUILD_REVISION);

--- a/src/libs/vmisc/def.cpp
+++ b/src/libs/vmisc/def.cpp
@@ -445,12 +445,12 @@ QString AbsoluteMPath(const QString &patternPath, const QString &relativeMPath)
 }
 
 QString fileDialog(QWidget *parent, const QString &title,  const QString &dir, const QString &filter,
-                   QString *selectedFilter, QFileDialog::Option option, QFileDialog::FileMode mode,
+                   QString *selectedFilter, QFileDialog::Options options, QFileDialog::FileMode mode,
                    QFileDialog::AcceptMode accept)
 {
     QFileDialog dialog(parent, title, dir, filter);
     dialog.setWindowFlags(dialog.windowFlags() & ~Qt::WindowContextHelpButtonHint);
-    dialog.setOption(option);
+    dialog.setOptions(options);
     dialog.setFileMode(mode);
     dialog.setAcceptMode(accept);
     dialog.setSupportedSchemes(QStringList(QStringLiteral("file")));

--- a/src/libs/vmisc/def.h
+++ b/src/libs/vmisc/def.h
@@ -493,7 +493,7 @@ Q_REQUIRED_RESULT QString strippedName(const QString &fullFileName);
 Q_REQUIRED_RESULT QString RelativeMPath(const QString &patternPath, const QString &absoluteMPath);
 Q_REQUIRED_RESULT QString AbsoluteMPath(const QString &patternPath, const QString &relativeMPath);
 Q_REQUIRED_RESULT QString fileDialog(QWidget *parent, const QString &title,  const QString &dir,
-                                     const QString &filter, QString *selectedFilter, QFileDialog::Option option,
+                                     const QString &filter, QString *selectedFilter, QFileDialog::Options options,
                                      QFileDialog::FileMode mode,  QFileDialog::AcceptMode accept);
 
 Q_REQUIRED_RESULT QSharedPointer<QPrinter> PreparePrinter(const QPrinterInfo &info,

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -489,15 +489,15 @@ void VCommonSettings::setBodyScansPath(const QString &value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QString VCommonSettings::GetDefPathLabelTemplate()
+QString VCommonSettings::getDefaultLabelTemplatePath()
 {
     return QDir::homePath() + QLatin1String("/seamly2d/") + tr("label templates");
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QString VCommonSettings::GetPathLabelTemplate() const
+QString VCommonSettings::getLabelTemplatePath() const
 {
-    return value(settingPathsLabelTemplate, GetDefPathLabelTemplate()).toString();
+    return value(settingPathsLabelTemplate, getDefaultLabelTemplatePath()).toString();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -509,7 +509,7 @@ void VCommonSettings::SetPathLabelTemplate(const QString &text)
 //---------------------------------------------------------------------------------------------------------------------
 QString VCommonSettings::getDefaultPatternTemplate() const
 {
-    return value(settingDefaultPatternTemplate, GetPathLabelTemplate() + "default_pattern_label.xml").toString();
+    return value(settingDefaultPatternTemplate, getLabelTemplatePath() + "default_pattern_label.xml").toString();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -521,7 +521,7 @@ void VCommonSettings::setDefaultPatternTemplate(const QString &text)
 //---------------------------------------------------------------------------------------------------------------------
 QString VCommonSettings::getDefaultPieceTemplate() const
 {
-    return value(settingDefaultPieceTemplate, GetPathLabelTemplate() + "default_piece_label.xml").toString();
+    return value(settingDefaultPieceTemplate, getLabelTemplatePath() + "default_piece_label.xml").toString();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vmisc/vcommonsettings.h
+++ b/src/libs/vmisc/vcommonsettings.h
@@ -97,8 +97,8 @@ public:
     QString              getTemplatePath() const;
     void                 setTemplatePath(const QString &value);
 
-    static QString       GetDefPathLabelTemplate();
-    QString              GetPathLabelTemplate() const;
+    static QString       getDefaultLabelTemplatePath();
+    QString              getLabelTemplatePath() const;
     void                 SetPathLabelTemplate(const QString &value);
 
     QString              getDefaultPatternTemplate() const;

--- a/src/libs/vmisc/vsettings.cpp
+++ b/src/libs/vmisc/vsettings.cpp
@@ -131,16 +131,16 @@ void VSettings::SetLabelLanguage(const QString &value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QString VSettings::GetDefPathPattern()
+QString VSettings::getDefaultPatternPath()
 {
     return QDir::homePath() + QLatin1String("/seamly2d/") + tr("patterns");
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QString VSettings::GetPathPattern() const
+QString VSettings::getPatternPath() const
 {
     QSettings settings(this->format(), this->scope(), this->organizationName(), this->applicationName());
-    return settings.value(settingPathsPattern, GetDefPathPattern()).toString();
+    return settings.value(settingPathsPattern, getDefaultPatternPath()).toString();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -152,7 +152,7 @@ void VSettings::SetPathPattern(const QString &value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QString VSettings::GetDefPathLayout()
+QString VSettings::getDefaultLayoutPath()
 {
     return QDir::homePath() + QLatin1String("/seamly2d/") + tr("layouts");
 }
@@ -161,7 +161,7 @@ QString VSettings::GetDefPathLayout()
 QString VSettings::getLayoutPath() const
 {
     QSettings settings(this->format(), this->scope(), this->organizationName(), this->applicationName());
-    return settings.value(settingPathsLayout, GetDefPathLayout()).toString();
+    return settings.value(settingPathsLayout, getDefaultLayoutPath()).toString();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vmisc/vsettings.h
+++ b/src/libs/vmisc/vsettings.h
@@ -75,11 +75,11 @@ public:
     QString  GetLabelLanguage() const;
     void     SetLabelLanguage(const QString &value);
 
-    static QString GetDefPathPattern();
-    QString GetPathPattern() const;
+    static QString getDefaultPatternPath();
+    QString getPatternPath() const;
     void SetPathPattern(const QString &value);
 
-    static QString GetDefPathLayout();
+    static QString getDefaultLayoutPath();
     QString getLayoutPath() const;
     void SetPathLayout(const QString &value);
 

--- a/src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp
+++ b/src/libs/vtools/dialogs/support/editlabeltemplate_dialog.cpp
@@ -313,7 +313,7 @@ void EditLabelTemplateDialog::NewTemplate()
 void EditLabelTemplateDialog::ExportTemplate()
 {
     QString filters(tr("Label template") + QLatin1String("(*.xml)"));
-    QString dir = qApp->Settings()->GetPathLabelTemplate();
+    QString dir = qApp->Settings()->getLabelTemplatePath();
 
     bool usedNotExistedDir = false;
     QDir directory(dir);
@@ -384,7 +384,7 @@ void EditLabelTemplateDialog::ImportTemplate()
 
     QString filter(tr("Label template") + QLatin1String("(*.xml)"));
     const QString fileName = QFileDialog::getOpenFileName(this, tr("Import template"),
-                                                          qApp->Settings()->GetPathLabelTemplate(), filter, nullptr,
+                                                          qApp->Settings()->getLabelTemplatePath(), filter, nullptr,
                                                           QFileDialog::DontUseNativeDialog);
     if (fileName.isEmpty())
     {


### PR DESCRIPTION
This fixes the File path preferences.

* Fixes the display and saving of the file path preferences in Seamly2D.
* Changes the file dialog in the edit SeamlyME file paths to not use the native dialog.
* Refactors some more class method names to use camelCase. 

Fixes issues #1054

