### PR TITLE
bug: fix and widen tool dialogs

### DIFF
--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
@@ -81,39 +81,39 @@
       <attribute name="title">
        <string>Appearance</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_7">
+      <layout class="QVBoxLayout" name="verticalLayout_11">
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <item>
-          <widget class="QGroupBox" name="toolbarsGroupBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>9</pointsize>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="title">
-            <string>Toolbars</string>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_10">
+        <widget class="QGroupBox" name="toolbarsGroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>9</pointsize>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="title">
+          <string>Toolbars</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_7">
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
             <item>
              <widget class="QCheckBox" name="toolBarStyle_CheckBox">
               <property name="sizePolicy">
@@ -265,88 +265,91 @@
              </widget>
             </item>
            </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="outputGroupBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>9</pointsize>
-             <bold>true</bold>
-            </font>
-           </property>
-           <property name="title">
-            <string>Graphical output</string>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_11">
-            <item>
-             <widget class="QCheckBox" name="graphicsOutput_CheckBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Use anti-aliasing</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <spacer name="verticalSpacer">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="outputGroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>9</pointsize>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="title">
+          <string>Graphical output</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_10">
+          <item>
+           <widget class="QCheckBox" name="graphicsOutput_CheckBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Use anti-aliasing</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>129</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>

--- a/src/libs/vtools/dialogs/tools/dialogalongline.ui
+++ b/src/libs/vtools/dialogs/tools/dialogalongline.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>450</height>
    </rect>
   </property>
@@ -54,7 +54,7 @@
          <widget class="QLabel" name="labelEditNamePoint">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -104,7 +104,7 @@
          <widget class="QLabel" name="labelFirstPoint">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -151,7 +151,7 @@
          <widget class="QLabel" name="labelSecondPoint">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -229,7 +229,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -325,7 +325,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -459,7 +459,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -521,7 +521,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -577,7 +577,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogarc.ui
+++ b/src/libs/vtools/dialogs/tools/dialogarc.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>526</height>
    </rect>
   </property>
@@ -59,7 +59,7 @@
          <widget class="QLabel" name="name_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -103,7 +103,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -181,7 +181,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -271,7 +271,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -378,7 +378,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -468,7 +468,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -575,7 +575,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -665,7 +665,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -797,7 +797,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -859,7 +859,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -915,7 +915,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogarcwithlength.ui
+++ b/src/libs/vtools/dialogs/tools/dialogarcwithlength.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>524</height>
    </rect>
   </property>
@@ -51,7 +51,7 @@
          <widget class="QLabel" name="name_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -95,7 +95,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -170,7 +170,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -260,7 +260,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -367,7 +367,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -457,7 +457,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -565,7 +565,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -655,7 +655,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -786,7 +786,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -848,7 +848,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -904,7 +904,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogbisector.ui
+++ b/src/libs/vtools/dialogs/tools/dialogbisector.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>450</height>
    </rect>
   </property>
@@ -63,7 +63,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -119,7 +119,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -169,7 +169,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -219,7 +219,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -300,7 +300,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -393,7 +393,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -524,7 +524,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -586,7 +586,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -642,7 +642,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.ui
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>380</height>
    </rect>
   </property>
@@ -51,7 +51,7 @@
          <widget class="QLabel" name="labelName">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -98,7 +98,7 @@
          <widget class="QLabel" name="labelFirstPoint">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -142,7 +142,7 @@
          <widget class="QLabel" name="labelSecondPoint">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -186,7 +186,7 @@
          <widget class="QLabel" name="labelThirdPoint">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -230,7 +230,7 @@
          <widget class="QLabel" name="labelForthPoint">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -314,7 +314,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -376,7 +376,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -432,7 +432,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezierpath.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>450</height>
    </rect>
   </property>
@@ -51,7 +51,7 @@
          <widget class="QLabel" name="name_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -92,7 +92,7 @@
          <widget class="QLabel" name="point_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -136,7 +136,7 @@
          <widget class="QLabel" name="path_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -205,7 +205,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -267,7 +267,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -323,7 +323,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui
+++ b/src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>450</height>
    </rect>
   </property>
@@ -57,7 +57,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -110,7 +110,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -160,7 +160,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -241,7 +241,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -331,7 +331,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -466,7 +466,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -528,7 +528,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -584,7 +584,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogcutarc.ui
+++ b/src/libs/vtools/dialogs/tools/dialogcutarc.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>338</height>
    </rect>
   </property>
@@ -57,7 +57,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -107,7 +107,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -176,7 +176,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -269,7 +269,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogcutspline.ui
+++ b/src/libs/vtools/dialogs/tools/dialogcutspline.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>265</height>
    </rect>
   </property>
@@ -57,7 +57,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -107,7 +107,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -182,7 +182,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -275,7 +275,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui
+++ b/src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>270</height>
    </rect>
   </property>
@@ -57,7 +57,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -107,7 +107,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -176,7 +176,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -269,7 +269,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogellipticalarc.ui
+++ b/src/libs/vtools/dialogs/tools/dialogellipticalarc.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>547</width>
+    <width>625</width>
     <height>500</height>
    </rect>
   </property>
@@ -61,7 +61,7 @@
              <widget class="QLabel" name="name_Label">
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -105,7 +105,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -193,7 +193,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -255,7 +255,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -311,7 +311,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -394,7 +394,7 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>90</width>
+              <width>100</width>
               <height>0</height>
              </size>
             </property>
@@ -478,7 +478,7 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
+              <width>10</width>
               <height>20</height>
              </size>
             </property>
@@ -585,7 +585,7 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>90</width>
+              <width>100</width>
               <height>0</height>
              </size>
             </property>
@@ -669,7 +669,7 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
+              <width>10</width>
               <height>20</height>
              </size>
             </property>
@@ -776,7 +776,7 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>90</width>
+              <width>100</width>
               <height>0</height>
              </size>
             </property>
@@ -860,7 +860,7 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
+              <width>10</width>
               <height>20</height>
              </size>
             </property>
@@ -967,7 +967,7 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>90</width>
+              <width>100</width>
               <height>0</height>
              </size>
             </property>
@@ -1051,7 +1051,7 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
+              <width>10</width>
               <height>20</height>
              </size>
             </property>
@@ -1158,7 +1158,7 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>90</width>
+              <width>100</width>
               <height>0</height>
              </size>
             </property>
@@ -1242,7 +1242,7 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
+              <width>10</width>
               <height>20</height>
              </size>
             </property>

--- a/src/libs/vtools/dialogs/tools/dialogendline.ui
+++ b/src/libs/vtools/dialogs/tools/dialogendline.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>457</height>
    </rect>
   </property>
@@ -66,7 +66,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -116,7 +116,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -191,7 +191,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -249,14 +249,14 @@
         <item>
          <widget class="QLabel" name="labelResultCalculation">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>85</width>
+            <width>80</width>
             <height>0</height>
            </size>
           </property>
@@ -284,7 +284,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -400,7 +400,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -458,14 +458,14 @@
         <item>
          <widget class="QLabel" name="labelResultCalculationAngle">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>85</width>
+            <width>80</width>
             <height>0</height>
            </size>
           </property>
@@ -631,7 +631,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -693,7 +693,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -749,7 +749,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogheight.ui
+++ b/src/libs/vtools/dialogs/tools/dialogheight.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>400</height>
    </rect>
   </property>
@@ -54,7 +54,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -104,7 +104,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -148,7 +148,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -192,7 +192,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -264,7 +264,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -326,7 +326,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -382,7 +382,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogline.ui
+++ b/src/libs/vtools/dialogs/tools/dialogline.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>350</height>
    </rect>
   </property>
@@ -57,7 +57,7 @@
          <widget class="QLabel" name="name_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -98,7 +98,7 @@
          <widget class="QLabel" name="labelFirstPoint">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -142,7 +142,7 @@
          <widget class="QLabel" name="labelSecondPoint">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -226,7 +226,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -288,7 +288,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -344,7 +344,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialoglineintersect.ui
+++ b/src/libs/vtools/dialogs/tools/dialoglineintersect.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>387</height>
    </rect>
   </property>
@@ -63,7 +63,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>95</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -144,7 +144,7 @@
              </property>
              <property name="minimumSize">
               <size>
-               <width>90</width>
+               <width>100</width>
                <height>0</height>
               </size>
              </property>
@@ -188,7 +188,7 @@
             <widget class="QLabel" name="labelP2Line1">
              <property name="minimumSize">
               <size>
-               <width>90</width>
+               <width>100</width>
                <height>0</height>
               </size>
              </property>
@@ -266,7 +266,7 @@
              </property>
              <property name="minimumSize">
               <size>
-               <width>90</width>
+               <width>100</width>
                <height>0</height>
               </size>
              </property>
@@ -310,7 +310,7 @@
             <widget class="QLabel" name="labelP2Line2">
              <property name="minimumSize">
               <size>
-               <width>90</width>
+               <width>100</width>
                <height>0</height>
               </size>
              </property>

--- a/src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui
+++ b/src/libs/vtools/dialogs/tools/dialoglineintersectaxis.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>467</height>
    </rect>
   </property>
@@ -57,7 +57,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -113,7 +113,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -166,7 +166,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -219,7 +219,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -297,7 +297,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -338,6 +338,12 @@
             </disabled>
            </palette>
           </property>
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+            <bold>false</bold>
+           </font>
+          </property>
           <property name="text">
            <string>Angle:</string>
           </property>
@@ -375,7 +381,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -501,7 +507,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -563,7 +569,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -619,7 +625,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui
+++ b/src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>260</width>
+    <width>350</width>
     <height>190</height>
    </rect>
   </property>
@@ -53,7 +53,7 @@
          <widget class="QLabel" name="originPoint_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -91,7 +91,7 @@
          <widget class="QLabel" name="suffix_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -129,7 +129,7 @@
          <widget class="QLabel" name="axisType_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui
+++ b/src/libs/vtools/dialogs/tools/dialogmirrorbyline.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>190</height>
    </rect>
   </property>
@@ -66,7 +66,7 @@
          <widget class="QLabel" name="firstLinePoint_Label">
           <property name="minimumSize">
            <size>
-            <width>80</width>
+            <width>120</width>
             <height>0</height>
            </size>
           </property>
@@ -110,7 +110,7 @@
          <widget class="QLabel" name="secondLinePoint_Label">
           <property name="minimumSize">
            <size>
-            <width>80</width>
+            <width>120</width>
             <height>0</height>
            </size>
           </property>
@@ -154,7 +154,7 @@
          <widget class="QLabel" name="suffix_Label">
           <property name="minimumSize">
            <size>
-            <width>80</width>
+            <width>120</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogmove.ui
+++ b/src/libs/vtools/dialogs/tools/dialogmove.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>551</height>
    </rect>
   </property>
@@ -69,7 +69,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -119,7 +119,7 @@
          <widget class="QLabel" name="rotationPoint_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -200,7 +200,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -290,7 +290,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -369,7 +369,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -459,7 +459,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -537,7 +537,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -627,7 +627,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialognormal.ui
+++ b/src/libs/vtools/dialogs/tools/dialognormal.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>275</width>
+    <width>350</width>
     <height>450</height>
    </rect>
   </property>
@@ -74,7 +74,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -130,7 +130,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -180,7 +180,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -255,7 +255,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -345,7 +345,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -452,7 +452,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -557,7 +557,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -613,7 +613,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -675,7 +675,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui
+++ b/src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>198</height>
    </rect>
   </property>
@@ -54,7 +54,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -110,7 +110,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -160,7 +160,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -204,7 +204,7 @@
          <widget class="QLabel" name="label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogpointofcontact.ui
+++ b/src/libs/vtools/dialogs/tools/dialogpointofcontact.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>462</height>
    </rect>
   </property>
@@ -63,7 +63,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -119,7 +119,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -175,7 +175,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -231,7 +231,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -318,7 +318,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -408,7 +408,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui
+++ b/src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>250</height>
    </rect>
   </property>
@@ -60,7 +60,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -110,7 +110,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -160,7 +160,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -204,7 +204,7 @@
          <widget class="QLabel" name="label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui
+++ b/src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>250</height>
    </rect>
   </property>
@@ -63,7 +63,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>22</height>
            </size>
           </property>
@@ -119,7 +119,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>22</height>
            </size>
           </property>
@@ -172,7 +172,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>22</height>
            </size>
           </property>
@@ -222,7 +222,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>22</height>
            </size>
           </property>
@@ -272,7 +272,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>22</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogrotation.ui
+++ b/src/libs/vtools/dialogs/tools/dialogrotation.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>290</height>
    </rect>
   </property>
@@ -60,7 +60,7 @@
          <widget class="QLabel" name="originPoint_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -104,7 +104,7 @@
          <widget class="QLabel" name="suffix_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -185,7 +185,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -281,7 +281,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui
+++ b/src/libs/vtools/dialogs/tools/dialogshoulderpoint.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>447</height>
    </rect>
   </property>
@@ -63,7 +63,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -113,7 +113,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -163,7 +163,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -213,7 +213,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -288,7 +288,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -378,7 +378,7 @@
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>40</width>
+            <width>10</width>
             <height>20</height>
            </size>
           </property>
@@ -509,7 +509,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -571,7 +571,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -627,7 +627,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogsinglepoint.ui
+++ b/src/libs/vtools/dialogs/tools/dialogsinglepoint.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>239</height>
    </rect>
   </property>
@@ -69,7 +69,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -153,7 +153,7 @@
          <widget class="QLabel" name="labelXCor">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -197,7 +197,7 @@
          <widget class="QLabel" name="labelYCor">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogspline.ui
+++ b/src/libs/vtools/dialogs/tools/dialogspline.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>540</width>
+    <width>625</width>
     <height>460</height>
    </rect>
   </property>
@@ -67,7 +67,7 @@
              <widget class="QLabel" name="labelName">
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -108,7 +108,7 @@
              <widget class="QLabel" name="labelFirstPoint">
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -152,7 +152,7 @@
              <widget class="QLabel" name="labelSecondPoint">
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -243,7 +243,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -305,7 +305,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -361,7 +361,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -450,7 +450,7 @@
                </property>
                <property name="minimumSize">
                 <size>
-                 <width>90</width>
+                 <width>100</width>
                  <height>0</height>
                 </size>
                </property>
@@ -540,7 +540,7 @@
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
-                 <width>40</width>
+                 <width>10</width>
                  <height>20</height>
                 </size>
                </property>
@@ -647,7 +647,7 @@
                </property>
                <property name="minimumSize">
                 <size>
-                 <width>90</width>
+                 <width>100</width>
                  <height>0</height>
                 </size>
                </property>
@@ -737,7 +737,7 @@
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
-                 <width>40</width>
+                 <width>10</width>
                  <height>20</height>
                 </size>
                </property>
@@ -859,7 +859,7 @@
                </property>
                <property name="minimumSize">
                 <size>
-                 <width>90</width>
+                 <width>100</width>
                  <height>0</height>
                 </size>
                </property>
@@ -949,7 +949,7 @@
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
-                 <width>40</width>
+                 <width>10</width>
                  <height>20</height>
                 </size>
                </property>
@@ -1056,7 +1056,7 @@
                </property>
                <property name="minimumSize">
                 <size>
-                 <width>90</width>
+                 <width>100</width>
                  <height>0</height>
                 </size>
                </property>
@@ -1146,7 +1146,7 @@
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
-                 <width>40</width>
+                 <width>10</width>
                  <height>20</height>
                 </size>
                </property>

--- a/src/libs/vtools/dialogs/tools/dialogsplinepath.ui
+++ b/src/libs/vtools/dialogs/tools/dialogsplinepath.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>540</width>
+    <width>625</width>
     <height>470</height>
    </rect>
   </property>
@@ -451,7 +451,7 @@
                  </property>
                  <property name="minimumSize">
                   <size>
-                   <width>90</width>
+                   <width>100</width>
                    <height>0</height>
                   </size>
                  </property>
@@ -541,7 +541,7 @@
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
-                   <width>40</width>
+                   <width>10</width>
                    <height>20</height>
                   </size>
                  </property>
@@ -648,7 +648,7 @@
                  </property>
                  <property name="minimumSize">
                   <size>
-                   <width>90</width>
+                   <width>100</width>
                    <height>0</height>
                   </size>
                  </property>
@@ -738,7 +738,7 @@
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
-                   <width>40</width>
+                   <width>10</width>
                    <height>20</height>
                   </size>
                  </property>
@@ -864,7 +864,7 @@
                  </property>
                  <property name="minimumSize">
                   <size>
-                   <width>90</width>
+                   <width>100</width>
                    <height>0</height>
                   </size>
                  </property>
@@ -954,7 +954,7 @@
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
-                   <width>40</width>
+                   <width>10</width>
                    <height>20</height>
                   </size>
                  </property>
@@ -1061,7 +1061,7 @@
                  </property>
                  <property name="minimumSize">
                   <size>
-                   <width>90</width>
+                   <width>100</width>
                    <height>0</height>
                   </size>
                  </property>
@@ -1151,7 +1151,7 @@
                  </property>
                  <property name="sizeHint" stdset="0">
                   <size>
-                   <width>40</width>
+                   <width>10</width>
                    <height>20</height>
                   </size>
                  </property>

--- a/src/libs/vtools/dialogs/tools/dialogtriangle.ui
+++ b/src/libs/vtools/dialogs/tools/dialogtriangle.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>258</height>
    </rect>
   </property>
@@ -65,7 +65,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -109,7 +109,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -147,7 +147,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -185,7 +185,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -223,7 +223,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/dialogtruedarts.ui
+++ b/src/libs/vtools/dialogs/tools/dialogtruedarts.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
-    <height>270</height>
+    <width>350</width>
+    <height>282</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -63,7 +63,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>110</width>
             <height>0</height>
            </size>
           </property>
@@ -107,7 +107,7 @@
          <widget class="QLabel" name="labelSecondNewDartPoint">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>110</width>
             <height>0</height>
            </size>
           </property>
@@ -157,7 +157,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>110</width>
             <height>0</height>
            </size>
           </property>
@@ -207,7 +207,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>110</width>
             <height>0</height>
            </size>
           </property>
@@ -257,7 +257,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>110</width>
             <height>0</height>
            </size>
           </property>
@@ -301,7 +301,7 @@
          <widget class="QLabel" name="labelSecondDartPoint">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>110</width>
             <height>0</height>
            </size>
           </property>
@@ -351,7 +351,7 @@
          <widget class="QLabel" name="labelThirdDartPoint">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>110</width>
             <height>0</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/editgroup_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/editgroup_dialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>260</width>
+    <width>350</width>
     <height>201</height>
    </rect>
   </property>
@@ -24,7 +24,7 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>348</width>
+    <width>16777215</width>
     <height>16777215</height>
    </size>
   </property>
@@ -35,11 +35,11 @@
    <iconset resource="../../../vmisc/share/resources/icon.qrc">
     <normaloff>:/icon/64x64/icon64x64.png</normaloff>:/icon/64x64/icon64x64.png</iconset>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -52,8 +52,8 @@
      </property>
      <property name="maximumSize">
       <size>
-       <width>240</width>
-       <height>120</height>
+       <width>16777215</width>
+       <height>16777215</height>
       </size>
      </property>
      <property name="title">
@@ -62,7 +62,7 @@
      <property name="checkable">
       <bool>false</bool>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
+     <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <layout class="QFormLayout" name="formLayout">
         <property name="labelAlignment">
@@ -72,7 +72,7 @@
          <widget class="QLabel" name="groupName_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -87,7 +87,7 @@
         <item row="0" column="1">
          <widget class="QLineEdit" name="groupName_LineEdit">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -100,8 +100,8 @@
           </property>
           <property name="maximumSize">
            <size>
-            <width>150</width>
-            <height>20</height>
+            <width>16777215</width>
+            <height>16777215</height>
            </size>
           </property>
           <property name="toolTip">
@@ -116,7 +116,7 @@
          <widget class="QLabel" name="groupColor_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -131,7 +131,7 @@
         <item row="1" column="1">
          <widget class="ColorComboBox" name="groupColor_ComboBox">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -144,7 +144,7 @@
           </property>
           <property name="maximumSize">
            <size>
-            <width>150</width>
+            <width>16777215</width>
             <height>16777215</height>
            </size>
           </property>
@@ -160,7 +160,7 @@
          <widget class="QLabel" name="groupLineWeight_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -175,7 +175,7 @@
         <item row="2" column="1">
          <widget class="LineWeightComboBox" name="groupLineWeight_ComboBox">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -188,7 +188,7 @@
           </property>
           <property name="maximumSize">
            <size>
-            <width>150</width>
+            <width>16777215</width>
             <height>16777215</height>
            </size>
           </property>
@@ -204,7 +204,7 @@
          <widget class="QLabel" name="groupLineType_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -219,7 +219,7 @@
         <item row="3" column="1">
          <widget class="LineTypeComboBox" name="groupLineType_ComboBox">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -232,7 +232,7 @@
           </property>
           <property name="maximumSize">
            <size>
-            <width>150</width>
+            <width>16777215</width>
             <height>16777215</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/insert_nodes_dialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>260</width>
+    <width>350</width>
     <height>340</height>
    </rect>
   </property>
@@ -51,7 +51,7 @@
          <widget class="QLabel" name="piece_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>20</height>
            </size>
           </property>
@@ -95,7 +95,7 @@
          <widget class="QLabel" name="nodes_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>0</height>
            </size>
           </property>
@@ -145,7 +145,7 @@
          <widget class="QLabel" name="status_Label">
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>20</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/intersect_circles_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
-    <height>500</height>
+    <width>350</width>
+    <height>510</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -65,7 +65,7 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>90</width>
+              <width>100</width>
               <height>0</height>
              </size>
             </property>
@@ -115,7 +115,7 @@
            <widget class="QLabel" name="label">
             <property name="minimumSize">
              <size>
-              <width>90</width>
+              <width>100</width>
               <height>0</height>
              </size>
             </property>
@@ -205,7 +205,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -259,7 +259,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -349,7 +349,7 @@
               </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>40</width>
+                <width>10</width>
                 <height>20</height>
                </size>
               </property>
@@ -503,7 +503,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -557,7 +557,7 @@
               </property>
               <property name="minimumSize">
                <size>
-                <width>90</width>
+                <width>100</width>
                 <height>0</height>
                </size>
               </property>
@@ -647,7 +647,7 @@
               </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>40</width>
+                <width>10</width>
                 <height>20</height>
                </size>
               </property>

--- a/src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>400</height>
    </rect>
   </property>
@@ -68,7 +68,7 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>90</width>
+              <width>100</width>
               <height>0</height>
              </size>
             </property>
@@ -124,7 +124,7 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>90</width>
+              <width>100</width>
               <height>0</height>
              </size>
             </property>
@@ -202,7 +202,7 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>90</width>
+              <width>100</width>
               <height>0</height>
              </size>
             </property>
@@ -252,7 +252,7 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>90</width>
+              <width>100</width>
               <height>0</height>
              </size>
             </property>
@@ -306,7 +306,7 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>90</width>
+              <width>100</width>
               <height>0</height>
              </size>
             </property>
@@ -396,7 +396,7 @@
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>40</width>
+              <width>10</width>
               <height>20</height>
              </size>
             </property>

--- a/src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/point_intersectxy_dialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>270</width>
+    <width>350</width>
     <height>310</height>
    </rect>
   </property>
@@ -68,7 +68,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>22</height>
            </size>
           </property>
@@ -130,7 +130,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>22</height>
            </size>
           </property>
@@ -186,7 +186,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>22</height>
            </size>
           </property>
@@ -270,7 +270,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>22</height>
            </size>
           </property>
@@ -332,7 +332,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>22</height>
            </size>
           </property>
@@ -388,7 +388,7 @@
           </property>
           <property name="minimumSize">
            <size>
-            <width>90</width>
+            <width>100</width>
             <height>22</height>
            </size>
           </property>

--- a/src/libs/vtools/dialogs/tools/union_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/union_dialog.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
+    <width>350</width>
     <height>96</height>
    </rect>
   </property>


### PR DESCRIPTION
- This fixes the layout for the Show Toolbars groupbox in the Seamly2d Application Preferences from over lapping the checkbox text. Apparently the MacOS build wants the Show Toolbars content in a vertical layout as well where it seems  the Windows build could care less. 

![image](https://github.com/FashionFreedom/Seamly2D/assets/31944718/b80c05db-76b4-4d17-9cdd-02dd5d1dc39e)

- Windens the width of the tool dialogs to 350 px and the Labels to 100 px to allow more display space for translated text. 

![image](https://github.com/FashionFreedom/Seamly2D/assets/31944718/3908a83f-d8a9-45df-9113-384aea26dda3)


Closes issue #1073 