### PR TITLE
fix: default piece label template

### DIFF
--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -3071,7 +3071,7 @@ void PatternPieceDialog::initializeLabelsTab()
     if (m_pieceLabelLines.isEmpty())
     {
         VLabelTemplate labelTemplate;
-        QString filename = qApp->Settings()->getDefaultPatternTemplate();
+        QString filename = qApp->Settings()->getDefaultPieceTemplate();
         if (QFileInfo(filename).exists())
         {
             labelTemplate.setXMLContent(VLabelTemplateConverter(filename).Convert());


### PR DESCRIPTION
This fixes issue #1087 

A simple change in method name fixes the issue by retrieving the default piece label template instead of the default pattern label template.

![image](https://github.com/FashionFreedom/Seamly2D/assets/31944718/abe28841-2950-45f9-8426-a56583add1c4)

closes issue #1087