### PR TITLE
ci: pin to macos-13 as macos-latest is too new for Qt5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
 
   macos:
     name: 'macOS: Build'
-    runs-on: macos-latest
+    runs-on: macos-13
     needs: version
     env:
       VERSION_NUMBER: ${{ needs.version.outputs.version_number }}


### PR DESCRIPTION
The macos-latest runners will transition to macos-14 over the next 12 weeks, but that no longer contains XCode 14.2 that we need to build against Qt5. Thus Pin to macos-13, that has Xcode 14.2. See https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/ and https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md