### PR TITLE
fix: switch formula length and angle order in property editor for interactive curve

### DIFF
--- a/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
+++ b/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
@@ -2781,11 +2781,6 @@ void VToolOptionsPropertyBrowser::showOptionsToolSpline(QGraphicsItem *item)
     addObjectProperty(tool, spl.GetP4().name(), tr("Second point:"), AttrSecondPoint, GOType::Point);
 
     addPropertyLabel(tr("Geometry"), AttrName);
-    VFormula angle1(spl.GetStartAngleFormula(), tool->getData());
-    angle1.setCheckZero(false);
-    angle1.setToolId(tool->getId());
-    angle1.setPostfix(degreeSymbol);
-    addPropertyFormula(tr("C1: angle:"), angle1, AttrAngle1);
 
     VFormula length1(spl.GetC1LengthFormula(), tool->getData());
     length1.setCheckZero(false);
@@ -2793,17 +2788,23 @@ void VToolOptionsPropertyBrowser::showOptionsToolSpline(QGraphicsItem *item)
     length1.setPostfix(UnitsToStr(qApp->patternUnit()));
     addPropertyFormula(tr("C1: length:"), length1, AttrLength1);
 
-    VFormula angle2(spl.GetEndAngleFormula(), tool->getData());
-    angle2.setCheckZero(false);
-    angle2.setToolId(tool->getId());
-    angle2.setPostfix(degreeSymbol);
-    addPropertyFormula(tr("C2: angle:"), angle2, AttrAngle2);
+    VFormula angle1(spl.GetStartAngleFormula(), tool->getData());
+    angle1.setCheckZero(false);
+    angle1.setToolId(tool->getId());
+    angle1.setPostfix(degreeSymbol);
+    addPropertyFormula(tr("C1: angle:"), angle1, AttrAngle1);
 
     VFormula length2(spl.GetC2LengthFormula(), tool->getData());
     length2.setCheckZero(false);
     length2.setToolId(tool->getId());
     length2.setPostfix(UnitsToStr(qApp->patternUnit()));
     addPropertyFormula(tr("C2: length:"), length2, AttrLength2);
+
+    VFormula angle2(spl.GetEndAngleFormula(), tool->getData());
+    angle2.setCheckZero(false);
+    angle2.setToolId(tool->getId());
+    angle2.setPostfix(degreeSymbol);
+    addPropertyFormula(tr("C2: angle:"), angle2, AttrAngle2);
 
     addPropertyLabel(tr("Attributes"), AttrName);
     addPropertyLineColor(tool, tr("Color:"), AttrColor);


### PR DESCRIPTION
This switches the order of the length and angle  formula fields for the Curve - Interactive tool in the Property Editor so it matches the order in the dialog. 

![image](https://github.com/FashionFreedom/Seamly2D/assets/31944718/a4d2f704-df8f-4329-9011-4af7db45ae68)

![image](https://github.com/FashionFreedom/Seamly2D/assets/31944718/da966d02-728a-4708-92e8-1f4ff8851be2)

Fixes issue #1105 
