### PR TITLE
Fix: notch geometry max spinbox values

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -19,7 +19,7 @@
         <translation>Nelze otevřít váš výchozí prohlížeč</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Sestaveno %3 v %2 {1 ?}</translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5929,12 +5929,12 @@ Do you want to download it?</source>
         <translation type="unfinished">Název:</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Šířka:</translation>
     </message>
@@ -10055,7 +10055,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10134,7 +10134,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
@@ -10448,12 +10448,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10556,7 +10556,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10779,7 +10784,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11427,7 +11432,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12452,7 +12457,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12527,7 +12532,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14479,7 +14484,7 @@ When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17256,13 +17261,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17270,7 +17275,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17279,14 +17284,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17295,46 +17300,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation>Středový bod:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17344,7 +17349,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17355,14 +17360,14 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17395,24 +17400,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17477,7 +17482,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17488,27 +17493,27 @@ load in SeamlyME as usual.
         <translation type="unfinished">Název:</translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17539,7 +17544,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17549,7 +17554,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17560,12 +17565,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17590,7 +17595,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17613,7 +17618,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17628,7 +17633,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Souřadnice</translation>
     </message>
@@ -17652,7 +17657,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17661,7 +17666,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17671,7 +17676,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17682,7 +17687,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17692,7 +17697,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17703,7 +17708,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17859,7 +17864,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17909,9 +17914,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17919,8 +17924,8 @@ load in SeamlyME as usual.
         <translation type="unfinished">Oblouk_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17938,7 +17943,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Čára_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation>Středový bod</translation>
     </message>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -19,7 +19,7 @@
         <translation>Standardbrowser kann nicht geöffnet werden</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation>Von links nach rechts</translation>
     </message>
@@ -34,7 +34,7 @@
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Erstellt am %1 um %2</translation>
@@ -3075,7 +3075,7 @@ p, li { white-space: pre-wrap; }
         <translation>Kein Bild</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Bild löschen</translation>
     </message>
@@ -5216,7 +5216,14 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>FvUpdater</name>
     <message>
-        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+351"/>
+        <location filename="../../src/libs/fervor/fvupdater.cpp" line="+230"/>
+        <source>Unable to get exclusive access to file 
+%1
+Possibly the file is already being downloaded.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+121"/>
         <source>Feed download failed: %1.</source>
         <translation>Feed download ist fehlgeschlagen: %1.</translation>
     </message>
@@ -5237,14 +5244,7 @@ p, li { white-space: pre-wrap; }
         <translation>Dateidownload ist fehlgeschlagen: %1.</translation>
     </message>
     <message>
-        <location line="-45"/>
-        <source>Unable to get exclusive access to file
-%1
-Possibly the file is already being downloaded.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+50"/>
+        <location line="+5"/>
         <source>Download has started, the installer will open once it&apos;s finished downloading</source>
         <translation>Download hat begonnen, der Installer öffnet sich, sobald der Download abgeschlossen ist</translation>
     </message>
@@ -5932,12 +5932,12 @@ for writing</source>
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation>Bild sperren:</translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation>Geometrie</translation>
     </message>
@@ -5964,13 +5964,13 @@ for writing</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation>Y Position:</translation>
     </message>
@@ -5985,7 +5985,7 @@ for writing</source>
         <translation>Aspekt sperren:</translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation>Breite:</translation>
     </message>
@@ -6495,7 +6495,7 @@ Das Programm wird WIE ES IST, OHNE GEWÄHRLEISTUNG JEGLICHER ART, EINSCHLIESSLIC
     </message>
     <message>
         <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
-        <source>Margins go beyond printing.
+        <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
@@ -10074,7 +10074,7 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation>Schnittteil</translation>
     </message>
@@ -10153,7 +10153,7 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation>Keine</translation>
@@ -10467,12 +10467,12 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation>Pfeile</translation>
     </message>
@@ -10575,7 +10575,12 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <translation> Breite:</translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation>Markierungslänge auf Standard zurücksetzen.</translation>
     </message>
@@ -10798,7 +10803,7 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <translation>Nur hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation>Markierung auf der Schnittlinie anzeigen.</translation>
     </message>
@@ -11446,7 +11451,7 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <translation>Standard Maßeinheit:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation>Die Standardmaßeinheit wurde geändert und wird als Standard für die nächsten von Dir erstellten Schnittmuster benutzt.</translation>
     </message>
@@ -12472,7 +12477,7 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <translation>Etikettendaten (Datum/Zeit Format</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation>Schlitz</translation>
     </message>
@@ -12547,7 +12552,7 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <translation>Schnittteil Etikett:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation>Etikett Vorlagen</translation>
     </message>
@@ -13231,13 +13236,19 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     </message>
     <message>
         <location line="+22"/>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+74"/>
+        <source>When checked the Welcome window will not be displayed. 
+You can change this setting in the SeamlyMe preferences.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-47"/>
         <source>GUI language:</source>
         <translation>Sprache der Benutzeroberfläche:</translation>
     </message>
@@ -13247,13 +13258,7 @@ When unchecked the period is used.</source>
         <translation>Legt die für SeamlyMe verwendete Sprache fest.</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <source>When checked the Welcome window will not be displayed.
-You can change this setting in the SeamlyMe preferences.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
+        <location line="+29"/>
         <source>Do not show again</source>
         <translation>Nicht mehr anzeigen</translation>
     </message>
@@ -13308,25 +13313,18 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Dezimaltrennzeichen:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
-When unchecked the period is used.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+27"/>
-        <source>GUI language:</source>
-        <translation>Sprache der Benutzeroberfläche:</translation>
-    </message>
-    <message>
-        <location line="+190"/>
-        <source>When checked the Welcome window will not be displayed.
+        <location line="+239"/>
+        <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="-190"/>
+        <source>GUI language:</source>
+        <translation>Sprache der Benutzeroberfläche:</translation>
+    </message>
+    <message>
+        <location line="+194"/>
         <source>Do not show again</source>
         <translation>Nicht mehr anzeigen</translation>
     </message>
@@ -13363,7 +13361,14 @@ You can change this setting in the Seamly2D preferences.</source>
         <translation>Bitte wählen Sie Ihre bevorzugten Einheiten, das Dezimaltrennzeichen, die Sprache und den Auswahlton. (Sie können diese Angaben später ändern.)</translation>
     </message>
     <message>
-        <location line="+159"/>
+        <location line="+91"/>
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
+When unchecked the period is used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+68"/>
         <source>Sound:</source>
         <translation>Ton:</translation>
     </message>
@@ -14499,7 +14504,7 @@ You can change this setting in the Seamly2D preferences.</source>
         <translation>&lt;Tabellenstil=Schriftgröße:11pt; Schriftstärke:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Firma:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = rights&gt;&lt;b&gt;Kunde:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Schnittmuster Bezeichnung:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Schnittmuster Nummer  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Version:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Einheiten:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Maße:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Beschreibung: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Anmerkungen:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Image:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/Tabelle &gt;</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation>Info Dateien</translation>
     </message>
@@ -17284,13 +17289,13 @@ wie gewohnt in SeamlyME laden können.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation>Länge:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17298,7 +17303,7 @@ wie gewohnt in SeamlyME laden können.
         <translation>Winkel:</translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17307,14 +17312,14 @@ wie gewohnt in SeamlyME laden können.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation>Erster Punkt:</translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17323,46 +17328,46 @@ wie gewohnt in SeamlyME laden können.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation>Zweiter Punkt:</translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation>Mittelpunkt:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation>Erster Winkel:</translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Zweiter Winkel:</translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17372,7 +17377,7 @@ wie gewohnt in SeamlyME laden können.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17383,14 +17388,14 @@ wie gewohnt in SeamlyME laden können.
         <translation>Farbe:</translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation>Dritter Punkt:</translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation>Bezeichnung des Punktes 1:</translation>
     </message>
@@ -17423,24 +17428,24 @@ wie gewohnt in SeamlyME laden können.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation>Kurve:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation>Erster Punkt der Linie:</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation>Zweiter Punkt der Linie:</translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation>Mittelpunkt des Bogens:</translation>
     </message>
@@ -17505,7 +17510,7 @@ wie gewohnt in SeamlyME laden können.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17516,27 +17521,27 @@ wie gewohnt in SeamlyME laden können.
         <translation>Bezeichnung:</translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation>C1 Winkel:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation>C1: Länge:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation>C2: Winkel:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation>C2: Länge:</translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17567,7 +17572,7 @@ wie gewohnt in SeamlyME laden können.
         <translation>Vierter Punkt:</translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17577,7 +17582,7 @@ wie gewohnt in SeamlyME laden können.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17588,12 +17593,12 @@ wie gewohnt in SeamlyME laden können.
         <translation>Linientyp:</translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation>Punkt - schneidet XY</translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation>Drehung</translation>
     </message>
@@ -17618,7 +17623,7 @@ wie gewohnt in SeamlyME laden können.
         <translation>Spiegeln an einer Achse</translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17641,7 +17646,7 @@ wie gewohnt in SeamlyME laden können.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17656,7 +17661,7 @@ wie gewohnt in SeamlyME laden können.
         <translation>Auswahl</translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation>Koordinaten</translation>
     </message>
@@ -17680,7 +17685,7 @@ wie gewohnt in SeamlyME laden können.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17689,7 +17694,7 @@ wie gewohnt in SeamlyME laden können.
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17699,7 +17704,7 @@ wie gewohnt in SeamlyME laden können.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17710,7 +17715,7 @@ wie gewohnt in SeamlyME laden können.
         <translation>Eigenschaften</translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17720,7 +17725,7 @@ wie gewohnt in SeamlyME laden können.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17731,7 +17736,7 @@ wie gewohnt in SeamlyME laden können.
         <translation>Linienstärke:</translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation>Punkt - auf Linie</translation>
     </message>
@@ -17887,7 +17892,7 @@ wie gewohnt in SeamlyME laden können.
         <translation>Kurve - interaktiv</translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation>Kurve - fixiert</translation>
     </message>
@@ -17937,9 +17942,9 @@ wie gewohnt in SeamlyME laden können.
         <translation>Bogen - elliptisch</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17947,8 +17952,8 @@ wie gewohnt in SeamlyME laden können.
         <translation>Bogen_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17966,7 +17971,7 @@ wie gewohnt in SeamlyME laden können.
         <translation>Linie_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation>Mittelpunkt</translation>
     </message>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -19,7 +19,7 @@
         <translation>Δεν είναι δυνατό το άνοιγμα του προεπιλεγμένου περιηγητή</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished"></translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation>Χωρίς εικόνα</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Διαγραφή εικόνας</translation>
     </message>
@@ -5929,12 +5929,12 @@ Do you want to download it?</source>
         <translation type="unfinished">Όνομα:</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Φάρδος:</translation>
     </message>
@@ -10055,7 +10055,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10134,7 +10134,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished">Κανένα</translation>
@@ -10448,12 +10448,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Μήκος:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10556,7 +10556,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10779,7 +10784,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished">Μόνο πίσω</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11427,7 +11432,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished">Προεπιλεγμένη μονάδα:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished">Οι προεπιλεγμένες μονάδες έχουν ενημερωθεί και θα χρησιμοποιηθούν ως προεπιλογή για το επόμενο πατρόν που θα δημιουργήσετε.</translation>
     </message>
@@ -12452,7 +12457,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12527,7 +12532,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14479,7 +14484,7 @@ When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17255,13 +17260,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">Μήκος:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17269,7 +17274,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Γωνία:</translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17278,14 +17283,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished">Πρώτο σημείο:</translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17294,46 +17299,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished">Δεύτερο σημείο:</translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">Κεντρικό σημείο:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Ακτίνα:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation>Πρώτη γωνία:</translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Δεύτερη γωνία:</translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17343,7 +17348,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17354,14 +17359,14 @@ load in SeamlyME as usual.
         <translation type="unfinished">Χρώμα:</translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished">Τρίτο σημείο:</translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17394,24 +17399,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished">Καμπύλη:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished">Πρώτο σημείο γραμμής:</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished">Δεύτερο σημείο γραμμής:</translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished">Κέντρο του κύκλου:</translation>
     </message>
@@ -17476,7 +17481,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17487,27 +17492,27 @@ load in SeamlyME as usual.
         <translation>Όνομα:</translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17543,7 +17548,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Τέταρτο σημείο:</translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17553,7 +17558,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17564,12 +17569,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Περιστροφή</translation>
     </message>
@@ -17594,7 +17599,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17617,7 +17622,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17632,7 +17637,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Συντεταγμένες</translation>
     </message>
@@ -17656,7 +17661,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17665,7 +17670,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17675,7 +17680,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17686,7 +17691,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17696,7 +17701,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17707,7 +17712,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17863,7 +17868,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17908,9 +17913,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17918,8 +17923,8 @@ load in SeamlyME as usual.
         <translation type="unfinished">Τόξο_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17937,7 +17942,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Γραμμή_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation type="unfinished">Κεντρικό σημείο</translation>
     </message>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -19,7 +19,7 @@
         <translation>Cannot open your default browser</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished">Automatic</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Built on %1 at %2</translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation>No image</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Delete image</translation>
     </message>
@@ -5929,12 +5929,12 @@ Do you want to download it?</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">px</translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
@@ -10058,7 +10058,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10137,7 +10137,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
@@ -10451,12 +10451,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10559,7 +10559,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10782,7 +10787,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished">Just rear</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11430,7 +11435,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Default unit:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation>The Default unit has been updated and will be used as the default for the next pattern you create.</translation>
     </message>
@@ -12455,7 +12460,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12530,7 +12535,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14482,7 +14487,7 @@ When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17260,13 +17265,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17274,7 +17279,7 @@ load in SeamlyME as usual.
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17283,14 +17288,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17299,46 +17304,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation>Center point:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation>First angle:</translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Second angle:</translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17348,7 +17353,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17359,14 +17364,14 @@ load in SeamlyME as usual.
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation>Third point:</translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation>Point 1 label:</translation>
     </message>
@@ -17399,24 +17404,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation>Curve:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation>First line point:</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation>Second line point:</translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation>Center of arc:</translation>
     </message>
@@ -17481,7 +17486,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17492,27 +17497,27 @@ load in SeamlyME as usual.
         <translation>Name:</translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation>C1: angle:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation>C1: length:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation>C2: angle:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation>C2: length:</translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17548,7 +17553,7 @@ load in SeamlyME as usual.
         <translation>Fourth point:</translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17558,7 +17563,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17569,12 +17574,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
@@ -17599,7 +17604,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17622,7 +17627,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17637,7 +17642,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordinates</translation>
     </message>
@@ -17661,7 +17666,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17670,7 +17675,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17680,7 +17685,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17691,7 +17696,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17701,7 +17706,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17712,7 +17717,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17868,7 +17873,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17913,9 +17918,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17923,8 +17928,8 @@ load in SeamlyME as usual.
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17942,7 +17947,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Line_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -19,7 +19,7 @@
         <translation type="unfinished">Cannot open your default browser</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished">Automatic</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Built on %1 at %2</translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5929,12 +5929,12 @@ Do you want to download it?</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
@@ -10058,7 +10058,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10137,7 +10137,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
@@ -10451,12 +10451,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10559,7 +10559,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10782,7 +10787,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished">Just rear</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11430,7 +11435,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12455,7 +12460,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12530,7 +12535,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14482,7 +14487,7 @@ When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17260,13 +17265,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17274,7 +17279,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17283,14 +17288,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17299,46 +17304,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">Center point:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17348,7 +17353,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17359,14 +17364,14 @@ load in SeamlyME as usual.
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17399,24 +17404,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished">First line point:</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished">Second line point:</translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17481,7 +17486,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17492,27 +17497,27 @@ load in SeamlyME as usual.
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17548,7 +17553,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17558,7 +17563,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17569,12 +17574,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
@@ -17599,7 +17604,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17622,7 +17627,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17637,7 +17642,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordinates</translation>
     </message>
@@ -17661,7 +17666,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17670,7 +17675,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17680,7 +17685,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17691,7 +17696,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17701,7 +17706,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17712,7 +17717,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17868,7 +17873,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17913,9 +17918,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17923,8 +17928,8 @@ load in SeamlyME as usual.
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17942,7 +17947,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Line_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -19,7 +19,7 @@
         <translation>Cannot open your default browser</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished">Automatic</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Built on %1 at %2</translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation>No image</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Delete image</translation>
     </message>
@@ -5929,12 +5929,12 @@ Do you want to download it?</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">px</translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
@@ -10058,7 +10058,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10137,7 +10137,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
@@ -10451,12 +10451,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10559,7 +10559,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10782,7 +10787,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished">Just rear</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11430,7 +11435,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Default unit:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation>The Default unit has been updated and will be used as the default for the next pattern you create.</translation>
     </message>
@@ -12455,7 +12460,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12530,7 +12535,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14482,7 +14487,7 @@ When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17260,13 +17265,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation>Length:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17274,7 +17279,7 @@ load in SeamlyME as usual.
         <translation>Angle:</translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17283,14 +17288,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation>First point:</translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17299,46 +17304,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation>Second point:</translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation>Center point:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation>Radius:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation>First angle:</translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Second angle:</translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17348,7 +17353,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17359,14 +17364,14 @@ load in SeamlyME as usual.
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation>Third point:</translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation>Point 1 label:</translation>
     </message>
@@ -17399,24 +17404,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation>Curve:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation>First line point:</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation>Second line point:</translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation>Center of arc:</translation>
     </message>
@@ -17481,7 +17486,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17492,27 +17497,27 @@ load in SeamlyME as usual.
         <translation>Name:</translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation>C1: angle:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation>C1: length:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation>C2: angle:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation>C2: length:</translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17548,7 +17553,7 @@ load in SeamlyME as usual.
         <translation>Fourth point:</translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17558,7 +17563,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17569,12 +17574,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
@@ -17599,7 +17604,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17622,7 +17627,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17637,7 +17642,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordinates</translation>
     </message>
@@ -17661,7 +17666,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17670,7 +17675,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17680,7 +17685,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17691,7 +17696,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17701,7 +17706,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17712,7 +17717,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17868,7 +17873,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17913,9 +17918,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17923,8 +17928,8 @@ load in SeamlyME as usual.
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17942,7 +17947,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Line_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -19,7 +19,7 @@
         <translation type="unfinished">Cannot open your default browser</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished">Automatic</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Built on %1 at %2</translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5929,12 +5929,12 @@ Do you want to download it?</source>
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Width:</translation>
     </message>
@@ -10058,7 +10058,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10137,7 +10137,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished">None</translation>
@@ -10451,12 +10451,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10559,7 +10559,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10782,7 +10787,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished">Just rear</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11430,7 +11435,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12455,7 +12460,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12530,7 +12535,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14482,7 +14487,7 @@ When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17260,13 +17265,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">Length:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17274,7 +17279,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17283,14 +17288,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished">First point:</translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17299,46 +17304,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished">Second point:</translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">Center point:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17348,7 +17353,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17359,14 +17364,14 @@ load in SeamlyME as usual.
         <translation type="unfinished">Color:</translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17399,24 +17404,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished">First line point:</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished">Second line point:</translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17481,7 +17486,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17492,27 +17497,27 @@ load in SeamlyME as usual.
         <translation type="unfinished">Name:</translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17548,7 +17553,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17558,7 +17563,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17569,12 +17574,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
@@ -17599,7 +17604,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17622,7 +17627,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17637,7 +17642,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordinates</translation>
     </message>
@@ -17661,7 +17666,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17670,7 +17675,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17680,7 +17685,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17691,7 +17696,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17701,7 +17706,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17712,7 +17717,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17868,7 +17873,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17913,9 +17918,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17923,8 +17928,8 @@ load in SeamlyME as usual.
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17942,7 +17947,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Line_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation type="unfinished">Center point</translation>
     </message>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -19,7 +19,7 @@
         <translation>No se puede abrir su navegador por defecto</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation>De izquierda a derecha</translation>
     </message>
@@ -34,7 +34,7 @@
         <translation>Automático</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Construido el %1 a la %2</translation>
@@ -3111,7 +3111,7 @@ p, li { white-space: pre-wrap; }
         <translation>Sin imagen</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Borrar imagen</translation>
     </message>
@@ -5281,7 +5281,7 @@ para la escritura</translation>
     </message>
     <message>
         <location line="-5"/>
-        <source>Unable to get exclusive access to file
+        <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
@@ -5973,12 +5973,12 @@ Do you want to download it?</source>
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation>Imagen de bloqueo:</translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation>Geometría</translation>
     </message>
@@ -6005,13 +6005,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation>px</translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation>Y Posición:</translation>
     </message>
@@ -6026,7 +6026,7 @@ Do you want to download it?</source>
         <translation>Aspecto de la cerradura:</translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation>Anchura:</translation>
     </message>
@@ -6536,7 +6536,7 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
     </message>
     <message>
         <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
-        <source>Margins go beyond printing.
+        <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
@@ -10131,7 +10131,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation>Pieza de Patrón</translation>
     </message>
@@ -10210,7 +10210,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation>Ninguno</translation>
@@ -10524,12 +10524,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation>Flechas</translation>
     </message>
@@ -10632,7 +10632,12 @@ Press enter to temporarily add it to the list.</source>
         <translation> Ancho:</translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation>Restablecer la longitud del piquete a su valor predeterminado.</translation>
     </message>
@@ -10855,7 +10860,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Justo detrás</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation>Mostrar el piquete en la línea de corte.</translation>
     </message>
@@ -11503,7 +11508,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Unidad por defecto:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation>La unidad predeterminada se ha actualizado y se utilizará para el próximo patrón que cree.</translation>
     </message>
@@ -12529,7 +12534,7 @@ actualización:</translation>
         <translation>Datos de etiqueta (formato de fecha/hora)</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation>Abertura</translation>
     </message>
@@ -12604,7 +12609,7 @@ actualización:</translation>
         <translation>Etiqueta de pieza:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation>Plantilla de etiqueta</translation>
     </message>
@@ -13289,13 +13294,19 @@ actualización:</translation>
     </message>
     <message>
         <location line="+22"/>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+74"/>
+        <source>When checked the Welcome window will not be displayed. 
+You can change this setting in the SeamlyMe preferences.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-47"/>
         <source>GUI language:</source>
         <translation>GUI Idioma:</translation>
     </message>
@@ -13305,13 +13316,7 @@ When unchecked the period is used.</source>
         <translation>Establece el idioma utilizado para SeamlyMe.</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <source>When checked the Welcome window will not be displayed.
-You can change this setting in the SeamlyMe preferences.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+4"/>
+        <location line="+29"/>
         <source>Do not show again</source>
         <translation>No volver a mostrar</translation>
     </message>
@@ -13366,25 +13371,18 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Separador decimal:</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
-When unchecked the period is used.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+27"/>
-        <source>GUI language:</source>
-        <translation>GUI Idioma:</translation>
-    </message>
-    <message>
-        <location line="+190"/>
-        <source>When checked the Welcome window will not be displayed.
+        <location line="+239"/>
+        <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+4"/>
+        <location line="-190"/>
+        <source>GUI language:</source>
+        <translation>GUI Idioma:</translation>
+    </message>
+    <message>
+        <location line="+194"/>
         <source>Do not show again</source>
         <translation>No volver a mostrar</translation>
     </message>
@@ -13421,7 +13419,14 @@ You can change this setting in the Seamly2D preferences.</source>
         <translation>Elija las unidades, el separador decimal, el idioma y el sonido de selección que prefiera. (Puede cambiarlos más adelante.)</translation>
     </message>
     <message>
-        <location line="+159"/>
+        <location line="+91"/>
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
+When unchecked the period is used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+68"/>
         <source>Sound:</source>
         <translation>Sonido:</translation>
     </message>
@@ -14557,7 +14562,7 @@ You can change this setting in the Seamly2D preferences.</source>
         <translation>&lt;estilo de tabla=tamaño de fuente:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Empresa: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt; b&gt;Cliente: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Nombre del patrón:&lt;/b&gt;&lt;/td&gt;&lt;td&gt; %3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;N.º de patrón: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Versión: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Unidades: &lt;/b&gt;&lt;/td&gt; &lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Medidas:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt; tr&gt;&lt;td align = right&gt;&lt;b&gt;Descripción: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Notas: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Imagen: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10 &lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation>Archivos de información</translation>
     </message>
@@ -17342,13 +17347,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation>Longitud:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17356,7 +17361,7 @@ load in SeamlyME as usual.
         <translation>Ángulo:</translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17365,14 +17370,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation>Primer punto:</translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17381,46 +17386,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation>Segundo punto:</translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation>Punto central:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation>Radio:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation>Primer ángulo:</translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Segundo ángulo:</translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17430,7 +17435,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17441,14 +17446,14 @@ load in SeamlyME as usual.
         <translation>Color:</translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation>Tercer punto:</translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation>Etiqueta del punto 1:</translation>
     </message>
@@ -17481,24 +17486,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation>Curva:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation>Primer punto de línea:</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation>Segundo punto de línea:</translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation>Centro del arco:</translation>
     </message>
@@ -17563,7 +17568,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17574,27 +17579,27 @@ load in SeamlyME as usual.
         <translation>Nombre:</translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation>C1: ángulo:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation>C1: longitud:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation>C2: ángulo:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation>C2: longitud:</translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17630,7 +17635,7 @@ load in SeamlyME as usual.
         <translation>Cuarto punto:</translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17640,7 +17645,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17651,12 +17656,12 @@ load in SeamlyME as usual.
         <translation>Tipo de línea:</translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation>Punto - Intersección XY</translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation>Rotación</translation>
     </message>
@@ -17681,7 +17686,7 @@ load in SeamlyME as usual.
         <translation>Reflejar por Eje</translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17704,7 +17709,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17719,7 +17724,7 @@ load in SeamlyME as usual.
         <translation>Selección</translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation>Coordenadas</translation>
     </message>
@@ -17743,7 +17748,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17752,7 +17757,7 @@ load in SeamlyME as usual.
         <translation>Geometría</translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17762,7 +17767,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17773,7 +17778,7 @@ load in SeamlyME as usual.
         <translation>Propiedades</translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17783,7 +17788,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17794,7 +17799,7 @@ load in SeamlyME as usual.
         <translation>Grosor de línea:</translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation>Punto - En Línea</translation>
     </message>
@@ -17950,7 +17955,7 @@ load in SeamlyME as usual.
         <translation>Curva - Interactiva</translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation>Curva - Fija</translation>
     </message>
@@ -17995,9 +18000,9 @@ load in SeamlyME as usual.
         <translation>Arco - Elíptico</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -18005,8 +18010,8 @@ load in SeamlyME as usual.
         <translation>Arco_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -18024,7 +18029,7 @@ load in SeamlyME as usual.
         <translation>Línea_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation>Punto central</translation>
     </message>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -19,7 +19,7 @@
         <translation>Oletus selaimen aukaiseminen epäonnistui</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Käännetty %3 klo %2 {1 ?}</translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5929,12 +5929,12 @@ Do you want to download it?</source>
         <translation type="unfinished">Nmi:</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">pikseliä</translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Leveys:</translation>
     </message>
@@ -10055,7 +10055,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10134,7 +10134,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
@@ -10448,12 +10448,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10556,7 +10556,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10779,7 +10784,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11427,7 +11432,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12452,7 +12457,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12527,7 +12532,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14479,7 +14484,7 @@ When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17256,13 +17261,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17270,7 +17275,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17279,14 +17284,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17295,46 +17300,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">Keskipiste:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17344,7 +17349,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17355,14 +17360,14 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17395,24 +17400,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17477,7 +17482,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17488,27 +17493,27 @@ load in SeamlyME as usual.
         <translation type="unfinished">Nmi:</translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17539,7 +17544,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17549,7 +17554,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17560,12 +17565,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17590,7 +17595,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17613,7 +17618,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17628,7 +17633,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Koordinaatit</translation>
     </message>
@@ -17652,7 +17657,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17661,7 +17666,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17671,7 +17676,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17682,7 +17687,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17692,7 +17697,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17703,7 +17708,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17859,7 +17864,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17909,9 +17914,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17919,8 +17924,8 @@ load in SeamlyME as usual.
         <translation type="unfinished">Kaari_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17938,7 +17943,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Viiva_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation>Keskipiste</translation>
     </message>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -19,7 +19,7 @@
         <translation>Impossible d&apos;ouvrir votre navigateur par défaut</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Compilé le %1 à %2</translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation>Image absente</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Effacer image</translation>
     </message>
@@ -5237,7 +5237,14 @@ for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+40"/>
+        <location line="-5"/>
+        <source>Unable to get exclusive access to file 
+%1
+Possibly the file is already being downloaded.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+45"/>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5255,13 +5262,6 @@ for writing</source>
         <location line="+3"/>
         <source>A new release %1 is available.
 Do you want to download it?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-141"/>
-        <source>Unable to get exclusive access to file
-%1
-Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5929,12 +5929,12 @@ Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Possibly the file is already being downloaded.</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">px</translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Possibly the file is already being downloaded.</source>
         <translation>Aspect de la serrure:</translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Largeur :</translation>
     </message>
@@ -6481,7 +6481,14 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Surface décroissante</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+732"/>
+        <location filename="../../src/app/seamly2d/dialogs/layoutsettings_dialog.cpp" line="+615"/>
+        <source>Margins go beyond printing. 
+
+Apply settings anyway?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+117"/>
         <location line="+16"/>
         <source>Centimeters</source>
         <translation>Centimètres</translation>
@@ -6639,13 +6646,6 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <location line="+18"/>
         <source>Millimeters</source>
         <translation type="unfinished">Millimètres</translation>
-    </message>
-    <message>
-        <location line="-134"/>
-        <source>Margins go beyond printing.
-
-Apply settings anyway?</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10058,7 +10058,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10137,7 +10137,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
@@ -10451,12 +10451,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Longueur:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10559,7 +10559,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10782,7 +10787,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished">Juste l&apos;arrière</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11430,7 +11435,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished">Unité par défaut:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished">L&apos;unité par Défaut a été mise à jour et sera utilisée par défaut pour le prochain patron créé.</translation>
     </message>
@@ -12455,7 +12460,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12530,7 +12535,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13214,15 +13219,19 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
-        <translation>Sélectionne le séparateur décimal à utiliser.
-Si la case est cochée, le séparateur de la locale de l&apos;utilisateur est utilisé.
-Si la case n&apos;est pas cochée, c&apos;est le point qui est utilisé.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+27"/>
+        <location line="+74"/>
+        <source>When checked the Welcome window will not be displayed. 
+You can change this setting in the SeamlyMe preferences.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="-47"/>
         <source>GUI language:</source>
         <translation>Langue de l&apos;interface:</translation>
     </message>
@@ -13232,14 +13241,7 @@ Si la case n&apos;est pas cochée, c&apos;est le point qui est utilisé.</transl
         <translation>Définit la langue utilisée pour SeamlyMe.</translation>
     </message>
     <message>
-        <location line="+25"/>
-        <source>When checked the Welcome window will not be displayed.
-You can change this setting in the SeamlyMe preferences.</source>
-        <translation>Si cette option est cochée, la fenêtre de bienvenue ne sera pas affichée.
-Vous pouvez modifier ce paramètre dans les préférences de SeamlyMe.</translation>
-    </message>
-    <message>
-        <location line="+4"/>
+        <location line="+29"/>
         <source>Do not show again</source>
         <translation>Ne plus montrer</translation>
     </message>
@@ -13294,21 +13296,18 @@ Vous pouvez modifier ce paramètre dans les préférences de SeamlyMe.</translat
         <translation>Séparateur décimal :</translation>
     </message>
     <message>
-        <location line="+22"/>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
-When unchecked the period is used.</source>
-        <translation>Sélectionne le séparateur décimal à utiliser.
-Si la case est cochée, le séparateur de la locale de l&apos;utilisateur est utilisé.
-Si la case n&apos;est pas cochée, c&apos;est le point qui est utilisé.</translation>
-    </message>
-    <message>
-        <location line="+27"/>
+        <location line="+49"/>
         <source>GUI language:</source>
         <translation>Langue de l&apos;interface:</translation>
     </message>
     <message>
-        <location line="+194"/>
+        <location line="+190"/>
+        <source>When checked the Welcome window will not be displayed. 
+You can change this setting in the Seamly2D preferences.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+4"/>
         <source>Do not show again</source>
         <translation>Ne plus montrer</translation>
     </message>
@@ -13340,19 +13339,19 @@ Si la case n&apos;est pas cochée, c&apos;est le point qui est utilisé.</transl
         <translation>Définit la langue utilisée pour Seamly2D.</translation>
     </message>
     <message>
-        <location line="+168"/>
-        <source>When checked the Welcome window will not be displayed.
-You can change this setting in the Seamly2D preferences.</source>
-        <translation>Si cette option est cochée, la fenêtre de bienvenue ne sera pas affichée.
-Vous pouvez modifier ce paramètre dans les préférences de Seamly2D.</translation>
-    </message>
-    <message>
-        <location line="-308"/>
+        <location line="-140"/>
         <source>Please choose your preferred units, decimal separator, language, and selection sound. (You can change these later.)</source>
         <translation>Veuillez choisir les unités, le séparateur décimal, la langue et le son de sélection que vous préférez. (Vous pourrez les modifier ultérieurement.)</translation>
     </message>
     <message>
-        <location line="+159"/>
+        <location line="+91"/>
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
+When unchecked the period is used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+68"/>
         <source>Sound:</source>
         <translation>Le son:</translation>
     </message>
@@ -14488,7 +14487,7 @@ Vous pouvez modifier ce paramètre dans les préférences de Seamly2D.</translat
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17265,13 +17264,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">Longueur:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17279,7 +17278,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Angle:</translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17288,14 +17287,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17304,46 +17303,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Rayon:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17353,7 +17352,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17364,14 +17363,14 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17404,24 +17403,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished">Courbe:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished">Point de la première ligne:</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished">Centre de l&apos;arc:</translation>
     </message>
@@ -17486,7 +17485,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17497,27 +17496,27 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17553,7 +17552,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Quatrième point:</translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17563,7 +17562,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17574,12 +17573,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotation</translation>
     </message>
@@ -17604,7 +17603,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17627,7 +17626,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17642,7 +17641,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordonnées</translation>
     </message>
@@ -17666,7 +17665,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17675,7 +17674,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17685,7 +17684,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17696,7 +17695,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17706,7 +17705,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17717,7 +17716,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17873,7 +17872,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17918,9 +17917,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17928,8 +17927,8 @@ load in SeamlyME as usual.
         <translation type="unfinished">Arc_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17947,7 +17946,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Ligne_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation>Point central</translation>
     </message>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -19,7 +19,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished"></translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5929,12 +5929,12 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10054,7 +10054,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10133,7 +10133,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
@@ -10447,12 +10447,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10555,7 +10555,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10778,7 +10783,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11426,7 +11431,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12451,7 +12456,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12526,7 +12531,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14478,7 +14483,7 @@ When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17253,13 +17258,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17267,7 +17272,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17276,14 +17281,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17292,46 +17297,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17341,7 +17346,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17352,14 +17357,14 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17392,24 +17397,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17474,7 +17479,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17485,27 +17490,27 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17536,7 +17541,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17546,7 +17551,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17557,12 +17562,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17587,7 +17592,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17610,7 +17615,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17625,7 +17630,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17649,7 +17654,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17658,7 +17663,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17668,7 +17673,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17679,7 +17684,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17689,7 +17694,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17700,7 +17705,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17856,7 +17861,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17906,9 +17911,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17916,8 +17921,8 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17935,7 +17940,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation>נקודת מרכז</translation>
     </message>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -19,7 +19,7 @@
         <translation>Tidak dapat membuka peramban bawaan Anda</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished">Dibuat pada %3 at %2 {1 ?}</translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5929,12 +5929,12 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10055,7 +10055,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10134,7 +10134,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
@@ -10448,12 +10448,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10556,7 +10556,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10779,7 +10784,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11427,7 +11432,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12452,7 +12457,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12527,7 +12532,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14479,7 +14484,7 @@ When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17254,13 +17259,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17268,7 +17273,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17277,14 +17282,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17293,46 +17298,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation>Titik tengah:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Radius:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17342,7 +17347,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17353,14 +17358,14 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17393,24 +17398,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17475,7 +17480,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17486,27 +17491,27 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17537,7 +17542,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17547,7 +17552,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17558,12 +17563,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17588,7 +17593,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17611,7 +17616,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17626,7 +17631,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17650,7 +17655,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17659,7 +17664,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17669,7 +17674,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17680,7 +17685,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17690,7 +17695,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17701,7 +17706,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17857,7 +17862,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17907,9 +17912,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17917,8 +17922,8 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17936,7 +17941,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation>Titik tengah</translation>
     </message>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -19,7 +19,7 @@
         <translation>Non è possibile aprire il browser predefinito</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Aumentato dall&apos; %1 al %2</translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation>Nessuna immagine</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Cancella immagine</translation>
     </message>
@@ -5929,12 +5929,12 @@ Do you want to download it?</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">px</translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Larghezza:</translation>
     </message>
@@ -10058,7 +10058,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10137,7 +10137,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
@@ -10451,12 +10451,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Lunghezza:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10559,7 +10559,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10782,7 +10787,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11430,7 +11435,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished">Unità di default:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished">L&apos;unità di default è stata aggiornata e verrà utilizzata come impostazione predefinita nella creazione del prossimo modello.</translation>
     </message>
@@ -12455,7 +12460,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12530,7 +12535,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14482,7 +14487,7 @@ When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17258,13 +17263,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">Lunghezza:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17272,7 +17277,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Angolo:</translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17281,14 +17286,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished">Primo punto:</translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17297,46 +17302,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">Punto centrale:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Raggio:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished">Primo angolo:</translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished">Secondo angolo:</translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17346,7 +17351,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17357,14 +17362,14 @@ load in SeamlyME as usual.
         <translation type="unfinished">Colore:</translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished">Terzo punto:</translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17397,24 +17402,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished">Curva:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished">Primo punto della linea:</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished">Secondo punto della linea:</translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished">Centro dell&apos;arco:</translation>
     </message>
@@ -17479,7 +17484,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17490,27 +17495,27 @@ load in SeamlyME as usual.
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17541,7 +17546,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Quarto punto:</translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17551,7 +17556,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17562,12 +17567,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotazione</translation>
     </message>
@@ -17592,7 +17597,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17615,7 +17620,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17630,7 +17635,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordinate</translation>
     </message>
@@ -17654,7 +17659,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17663,7 +17668,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17673,7 +17678,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17684,7 +17689,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17694,7 +17699,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17705,7 +17710,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17861,7 +17866,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17911,9 +17916,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17921,8 +17926,8 @@ load in SeamlyME as usual.
         <translation type="unfinished">Arco_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17940,7 +17945,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Linea_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation>Punto centrale</translation>
     </message>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -19,7 +19,7 @@
         <translation>Kan uw standaard browser niet openen</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Gebouwd op %1 op %2</translation>
@@ -3078,7 +3078,7 @@ p, li { white-space: pre-wrap; }
         <translation>Geen afbeelding</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Verwijder afbeelding</translation>
     </message>
@@ -5934,12 +5934,12 @@ Do you want to download it?</source>
         <translation type="unfinished">Naam:</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished">Geometrie</translation>
     </message>
@@ -5966,13 +5966,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">px</translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5987,7 +5987,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Breedte:</translation>
     </message>
@@ -10063,7 +10063,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation>PatroonDeel</translation>
     </message>
@@ -10142,7 +10142,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation>Geen</translation>
@@ -10456,12 +10456,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation>Pijlen</translation>
     </message>
@@ -10564,7 +10564,12 @@ Press enter to temporarily add it to the list.</source>
         <translation> Breedte:</translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation>Zet lengte pasmarkering terug naar standaard.</translation>
     </message>
@@ -10787,7 +10792,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Alleen achterkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation>Toon pasmarkering op kniplijn.</translation>
     </message>
@@ -11435,7 +11440,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Standaardwaarde eenheid:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation>De standaardwaarde van de eenheid is opgewaardeerd en zal worden gebruikt  als de standaardbasis voor uw volgende patrooncreatie.</translation>
     </message>
@@ -12460,7 +12465,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Labelgegevens (datum/tijd formaat)</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation>Knipje</translation>
     </message>
@@ -12535,7 +12540,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Patroondeel label:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation>Labelsjabloon</translation>
     </message>
@@ -14487,7 +14492,7 @@ You can change this setting in the Seamly2D preferences.</source>
         <translation>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Bedrijf:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Klant:    &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Patroonnaam:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Patroon No:  &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Versie:     &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Eenheden:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Maten:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Beschrijving: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Noten:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Figuur:       &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10&lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation>Info bestanden</translation>
     </message>
@@ -17270,13 +17275,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation>Lengte:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17284,7 +17289,7 @@ load in SeamlyME as usual.
         <translation>Hoek:</translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17293,14 +17298,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation>Eerste punt:</translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17309,46 +17314,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation>Tweede punt:</translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation>Middelste punt:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation>Straal:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation>Eerste hoek:</translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Tweede hoek:</translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17358,7 +17363,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17369,14 +17374,14 @@ load in SeamlyME as usual.
         <translation>Kleur:</translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation>Derde punt:</translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation>Punt 1 label:</translation>
     </message>
@@ -17409,24 +17414,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation>Kromme:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation>Eerste lijnpunt:</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation>Tweede lijnpunt:</translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation>Midden van de boog:</translation>
     </message>
@@ -17491,7 +17496,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17502,27 +17507,27 @@ load in SeamlyME as usual.
         <translation>Naam:</translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation>C1: hoek:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation>C1: lengte:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation>C2: hoek:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation>C2: lengte:</translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17558,7 +17563,7 @@ load in SeamlyME as usual.
         <translation>Vierde punt:</translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17568,7 +17573,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17579,12 +17584,12 @@ load in SeamlyME as usual.
         <translation>Lijnsoort:</translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation>Punt - snijpunt XY</translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation>Draaiing</translation>
     </message>
@@ -17609,7 +17614,7 @@ load in SeamlyME as usual.
         <translation>Spiegel over As</translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17632,7 +17637,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17647,7 +17652,7 @@ load in SeamlyME as usual.
         <translation>Selectie</translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation>Coordinaten</translation>
     </message>
@@ -17671,7 +17676,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17680,7 +17685,7 @@ load in SeamlyME as usual.
         <translation>Geometrie</translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17690,7 +17695,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17701,7 +17706,7 @@ load in SeamlyME as usual.
         <translation>Kenmerken</translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17711,7 +17716,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17722,7 +17727,7 @@ load in SeamlyME as usual.
         <translation>Lijnbreedte:</translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation>Punt - Op Lijn</translation>
     </message>
@@ -17878,7 +17883,7 @@ load in SeamlyME as usual.
         <translation>Kromme - Interactief</translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation>Kromme - Vast</translation>
     </message>
@@ -17923,9 +17928,9 @@ load in SeamlyME as usual.
         <translation>Boog - Ellipsvormig</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17933,8 +17938,8 @@ load in SeamlyME as usual.
         <translation>Boog_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17952,7 +17957,7 @@ load in SeamlyME as usual.
         <translation>Lijn_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation>Middelste punt</translation>
     </message>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -19,7 +19,7 @@
         <translation>Não é possível abrir seu navegador padrão</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Construído de %1 a %2</translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation>Sem imagem</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Remover imagem</translation>
     </message>
@@ -5929,12 +5929,12 @@ Do you want to download it?</source>
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Largura:</translation>
     </message>
@@ -10054,7 +10054,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10133,7 +10133,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished">nenhum</translation>
@@ -10447,12 +10447,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Comprimento:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10555,7 +10555,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10778,7 +10783,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished">Apenas costas</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11426,7 +11431,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Unidade padrão:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished">A unidade padrão foi atuaizada e será usada como padrão para o próximo molde criado.</translation>
     </message>
@@ -12451,7 +12456,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12526,7 +12531,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14478,7 +14483,7 @@ When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17253,13 +17258,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">Comprimento:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17267,7 +17272,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Ângulo:</translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17276,14 +17281,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished">Primeiro ponto:</translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17292,46 +17297,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished">Segundo ponto:</translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">Ponto central:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Raio:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished">Primeiro ângulo:</translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished">Segundo ângulo:</translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17341,7 +17346,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17352,14 +17357,14 @@ load in SeamlyME as usual.
         <translation type="unfinished">Cor:</translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished">Terceiro ponto:</translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17392,24 +17397,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished">Curva:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17474,7 +17479,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17485,27 +17490,27 @@ load in SeamlyME as usual.
         <translation type="unfinished">Nome:</translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17541,7 +17546,7 @@ load in SeamlyME as usual.
         <translation>Quarto ponto:</translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17551,7 +17556,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17562,12 +17567,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Rotação</translation>
     </message>
@@ -17592,7 +17597,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17615,7 +17620,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17630,7 +17635,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17654,7 +17659,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17663,7 +17668,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17673,7 +17678,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17684,7 +17689,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17694,7 +17699,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17705,7 +17710,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17861,7 +17866,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17906,9 +17911,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17916,8 +17921,8 @@ load in SeamlyME as usual.
         <translation type="unfinished">Arco_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17935,7 +17940,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Linha_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation>Ponto central</translation>
     </message>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -19,7 +19,7 @@
         <translation>Nu pot deschide browser-ul implicit</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Construit pe %1 la %2</translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5929,12 +5929,12 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Lățime:</translation>
     </message>
@@ -10054,7 +10054,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10133,7 +10133,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
@@ -10447,12 +10447,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Lungime:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10555,7 +10555,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10778,7 +10783,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11426,7 +11431,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished">Unitate standard:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished">Unitatea standard a fost actualizată și va fi utilizată ca standard pentru modelele viitoare pe care le creați.</translation>
     </message>
@@ -12451,7 +12456,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12526,7 +12531,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14478,7 +14483,7 @@ When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17253,13 +17258,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">Lungime:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17267,7 +17272,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Unghi:</translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17276,14 +17281,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished">Primul Punct:</translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17292,46 +17297,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished">Al doilea punct:</translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">Punct central:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">Rază:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished">Primul unghi:</translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished">Al doilea unghi:</translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17341,7 +17346,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17352,14 +17357,14 @@ load in SeamlyME as usual.
         <translation type="unfinished">Culoare:</translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished">Al treilea punct:</translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17392,24 +17397,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished">Curbă:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17474,7 +17479,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17485,27 +17490,27 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17536,7 +17541,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17546,7 +17551,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17557,12 +17562,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17587,7 +17592,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17610,7 +17615,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17625,7 +17630,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Coordinate</translation>
     </message>
@@ -17649,7 +17654,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17658,7 +17663,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17668,7 +17673,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17679,7 +17684,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17689,7 +17694,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17700,7 +17705,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17856,7 +17861,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17906,9 +17911,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17916,8 +17921,8 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17935,7 +17940,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation>Punct central</translation>
     </message>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -19,7 +19,7 @@
         <translation>Невозможно открыть браузер по умолчанию</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation>Автоматические</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Собрано %1 в %2</translation>
@@ -3096,7 +3096,7 @@ p, li { white-space: pre-wrap; }
         <translation>Нет изображения</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Удалить изображение</translation>
     </message>
@@ -5958,12 +5958,12 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished">Геометрия</translation>
     </message>
@@ -5990,13 +5990,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">px</translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6011,7 +6011,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Ширина:</translation>
     </message>
@@ -10089,7 +10089,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation>Детали Выкройки</translation>
     </message>
@@ -10168,7 +10168,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation>Ничего</translation>
@@ -10482,12 +10482,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation>Стрелки</translation>
     </message>
@@ -10590,7 +10590,12 @@ Press enter to temporarily add it to the list.</source>
         <translation> Ширина:</translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation>Восстановить длину надсечки по умолчанию.</translation>
     </message>
@@ -10813,7 +10818,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Только нижняя</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation>Показать надсечку на линии разреза.</translation>
     </message>
@@ -11461,7 +11466,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Единица измерения по умолчанию:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation>Единицы измерения обновлены и будут применены при следующем создании выкройки.</translation>
     </message>
@@ -12487,7 +12492,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Данные метки (формат даты/времени)</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation>Щель</translation>
     </message>
@@ -12562,7 +12567,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Метка детали:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation>Шаблон метки</translation>
     </message>
@@ -14514,7 +14519,7 @@ You can change this setting in the Seamly2D preferences.</source>
         <translation>&lt;table style=font-size:11pt; font-weight:600&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Компания: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%1&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt; b&gt;Клиент: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Название выкройки:&lt;/b&gt;&lt;/td&gt;&lt;td&gt; %3&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Номер выкройки: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%4&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Версия: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%5&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Единицы измерения: &lt;/b&gt;&lt;/td&gt; &lt;td&gt;%6&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Мерки:&lt;/b&gt;&lt;/td&gt;&lt;td&gt;%7&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt; tr&gt;&lt;td align = right&gt;&lt;b&gt;Описание: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%8&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Примечания: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%9&lt;br&gt;&lt;/td&gt;&lt;tr&gt;&lt;tr&gt;&lt;td align = right&gt;&lt;b&gt;Изображение: &lt;/b&gt;&lt;/td&gt;&lt;td&gt;%10 &lt;/td&gt;&lt;tr&gt;&lt;/table&gt;</translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation>Информационные файлы</translation>
     </message>
@@ -17298,13 +17303,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation>Длина:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17312,7 +17317,7 @@ load in SeamlyME as usual.
         <translation>Угол:</translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17321,14 +17326,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation>Первая точка:</translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17337,46 +17342,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation>Вторая точка:</translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation>Центральная точка:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation>Радиус:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation>Первый угол:</translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Второй угол:</translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17386,7 +17391,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17397,14 +17402,14 @@ load in SeamlyME as usual.
         <translation>Цвет:</translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation>Третья точка:</translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation>Метка точки 1:</translation>
     </message>
@@ -17437,24 +17442,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation>Кривая:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation>Первая точка линии:</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation>Вторая точка линии:</translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation>Центр дуги:</translation>
     </message>
@@ -17519,7 +17524,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17530,27 +17535,27 @@ load in SeamlyME as usual.
         <translation>Название:</translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation>С1: угол:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation>С1: длина:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation>С2: угол:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation>С2: длина:</translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17586,7 +17591,7 @@ load in SeamlyME as usual.
         <translation>Четвертая точка:</translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17596,7 +17601,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17607,12 +17612,12 @@ load in SeamlyME as usual.
         <translation>Тип линии:</translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation>Точка - Пересечения XY</translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation>Вращение</translation>
     </message>
@@ -17637,7 +17642,7 @@ load in SeamlyME as usual.
         <translation>Отражение по Оси</translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17660,7 +17665,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17675,7 +17680,7 @@ load in SeamlyME as usual.
         <translation>Выбрать</translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation>Координаты</translation>
     </message>
@@ -17699,7 +17704,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17708,7 +17713,7 @@ load in SeamlyME as usual.
         <translation>Геометрия</translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17718,7 +17723,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17729,7 +17734,7 @@ load in SeamlyME as usual.
         <translation>Свойства</translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17739,7 +17744,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17750,7 +17755,7 @@ load in SeamlyME as usual.
         <translation>Толщина Линии:</translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation>Точка - на линии</translation>
     </message>
@@ -17906,7 +17911,7 @@ load in SeamlyME as usual.
         <translation>Кривая — Интерактивная</translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation>Кривая - фиксированная</translation>
     </message>
@@ -17951,9 +17956,9 @@ load in SeamlyME as usual.
         <translation>Дуга – Эллиптическая</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17961,8 +17966,8 @@ load in SeamlyME as usual.
         <translation>Дуга_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17980,7 +17985,7 @@ load in SeamlyME as usual.
         <translation>Линия_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation>Центральная точка</translation>
     </message>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -19,7 +19,7 @@
         <translation>Не можу відкрити браузер по замовчуванню</translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished">Автоматична</translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation>Зібрано %1 в %2</translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation>Зображення відсутнє</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation>Видалити зображення</translation>
     </message>
@@ -5929,12 +5929,12 @@ Do you want to download it?</source>
         <translation type="unfinished">Імя:</translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished">піксел</translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">Ширина:</translation>
     </message>
@@ -10057,7 +10057,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10136,7 +10136,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
@@ -10450,12 +10450,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">Довжина:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10558,7 +10558,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10781,7 +10786,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished">Тільки нижня</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11429,7 +11434,7 @@ Press enter to temporarily add it to the list.</source>
         <translation>Одиниця виміру по замовчуванню:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation>Одиниці вимірювання по замовчуванню були оновлені і будуть використанні як основні наступного разу при створенні нової викрійки.</translation>
     </message>
@@ -12454,7 +12459,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12529,7 +12534,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14481,7 +14486,7 @@ When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17258,13 +17263,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation>Довжина:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17272,7 +17277,7 @@ load in SeamlyME as usual.
         <translation>Кут:</translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17281,14 +17286,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation>Перша точка:</translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17297,46 +17302,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation>Друга точка:</translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation>Точка центру:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation>Радіус:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation>Перший кут:</translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation>Другий кут:</translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17346,7 +17351,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17357,14 +17362,14 @@ load in SeamlyME as usual.
         <translation>Колір:</translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation>Третя точка:</translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation>Ім&apos;я точки 1:</translation>
     </message>
@@ -17397,24 +17402,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation>Крива:</translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation>Перша точка лінії:</translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation>Друга точка лінії:</translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation>Центер дуги:</translation>
     </message>
@@ -17479,7 +17484,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17490,27 +17495,27 @@ load in SeamlyME as usual.
         <translation>Імя:</translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation>С1: кут:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation>С1: довжина:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation>С2: кут:</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation>С2: довжина:</translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17546,7 +17551,7 @@ load in SeamlyME as usual.
         <translation>Четверта точка:</translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17556,7 +17561,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17567,12 +17572,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished">Поворот</translation>
     </message>
@@ -17597,7 +17602,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17620,7 +17625,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17635,7 +17640,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished">Координати</translation>
     </message>
@@ -17659,7 +17664,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17668,7 +17673,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17678,7 +17683,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17689,7 +17694,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17699,7 +17704,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17710,7 +17715,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17866,7 +17871,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17911,9 +17916,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17921,8 +17926,8 @@ load in SeamlyME as usual.
         <translation type="unfinished">Дуга_</translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17940,7 +17945,7 @@ load in SeamlyME as usual.
         <translation type="unfinished">Лінія_</translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation>Точка центру</translation>
     </message>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -19,7 +19,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+49"/>
+        <location line="+50"/>
         <source>Left to right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -34,7 +34,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-75"/>
+        <location line="-76"/>
         <location line="+39"/>
         <source>Built on %1 at %2</source>
         <translation type="unfinished"></translation>
@@ -3073,7 +3073,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+803"/>
+        <location filename="../../src/app/seamly2d/dialogs/dialogpatternproperties.cpp" line="+800"/>
         <source>Delete image</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5929,12 +5929,12 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+44"/>
+        <location line="+28"/>
         <source>Lock Image:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+67"/>
+        <location line="+82"/>
         <source>Geometry</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5961,13 +5961,13 @@ Do you want to download it?</source>
     <message>
         <location line="+33"/>
         <location line="+67"/>
-        <location line="+176"/>
+        <location line="+179"/>
         <location line="+67"/>
         <source>px</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-276"/>
+        <location line="-279"/>
         <source>Y Position:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5982,7 +5982,7 @@ Do you want to download it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+53"/>
+        <location line="+56"/>
         <source>Width:</source>
         <translation type="unfinished">宽度:</translation>
     </message>
@@ -10054,7 +10054,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+22"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1331"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="+1359"/>
         <source>PatternPiece</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10133,7 +10133,7 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <location line="-3488"/>
         <location line="+69"/>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2634"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp" line="-2662"/>
         <location line="+2152"/>
         <source>None</source>
         <translation type="unfinished"></translation>
@@ -10447,12 +10447,12 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <location line="+259"/>
-        <location line="+1029"/>
+        <location line="+1032"/>
         <source>Length:</source>
         <translation type="unfinished">长度:</translation>
     </message>
     <message>
-        <location line="-699"/>
+        <location line="-702"/>
         <source>Arrows</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10555,7 +10555,12 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
+        <location line="+68"/>
+        <source>  °</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+71"/>
         <source>Reset notch length to default.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10778,7 +10783,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-436"/>
+        <location filename="../../src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui" line="-439"/>
         <source>Show notch on the cut line.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11426,7 +11431,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished">默认单位:</translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+319"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp" line="+316"/>
         <source>The Default unit has been updated and will be used as the default for the next pattern you create.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12451,7 +12456,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+320"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="+341"/>
         <source>Slit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12526,7 +12531,7 @@ Press enter to temporarily add it to the list.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-62"/>
+        <location filename="../../src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp" line="-86"/>
         <source>Label template</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14478,7 +14483,7 @@ When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+100"/>
+        <location line="+97"/>
         <source>Info files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17253,13 +17258,13 @@ load in SeamlyME as usual.
         <location line="+15"/>
         <location line="+68"/>
         <location line="+147"/>
-        <location line="+195"/>
+        <location line="+196"/>
         <source>Length:</source>
         <translation type="unfinished">长度:</translation>
     </message>
     <message>
-        <location line="-564"/>
-        <location line="+506"/>
+        <location line="-565"/>
+        <location line="+507"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17267,7 +17272,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-546"/>
+        <location line="-547"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17276,14 +17281,14 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>First point:</source>
         <translation type="unfinished">第一点:</translation>
     </message>
     <message>
-        <location line="-484"/>
+        <location line="-485"/>
         <location line="+65"/>
         <location line="+103"/>
         <location line="+19"/>
@@ -17292,46 +17297,46 @@ load in SeamlyME as usual.
         <location line="+42"/>
         <location line="+99"/>
         <location line="+25"/>
-        <location line="+44"/>
+        <location line="+45"/>
         <location line="+55"/>
         <location line="+14"/>
         <source>Second point:</source>
         <translation type="unfinished">第二点:</translation>
     </message>
     <message>
-        <location line="-465"/>
+        <location line="-466"/>
         <location line="+22"/>
         <location line="+273"/>
-        <location line="+272"/>
+        <location line="+273"/>
         <source>Center point:</source>
         <translation type="unfinished">中点:</translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
         <location line="+190"/>
         <location line="+49"/>
         <location line="+4"/>
-        <location line="+302"/>
+        <location line="+303"/>
         <location line="+1"/>
         <source>Radius:</source>
         <translation type="unfinished">半径:</translation>
     </message>
     <message>
-        <location line="-567"/>
+        <location line="-568"/>
         <location line="+22"/>
-        <location line="+546"/>
+        <location line="+547"/>
         <source>First angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-567"/>
-        <location line="+568"/>
+        <location line="-568"/>
+        <location line="+569"/>
         <source>Second angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-608"/>
+        <location line="-609"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17341,7 +17346,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17352,14 +17357,14 @@ load in SeamlyME as usual.
         <translation type="unfinished">颜色:</translation>
     </message>
     <message>
-        <location line="-531"/>
+        <location line="-532"/>
         <location line="+282"/>
-        <location line="+69"/>
+        <location line="+70"/>
         <source>Third point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-332"/>
+        <location line="-333"/>
         <source>Point 1 label:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17392,24 +17397,24 @@ load in SeamlyME as usual.
     <message>
         <location line="-215"/>
         <location line="+15"/>
-        <location line="+374"/>
+        <location line="+375"/>
         <source>Curve:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-358"/>
-        <location line="+410"/>
+        <location line="-359"/>
+        <location line="+411"/>
         <source>First line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-409"/>
-        <location line="+410"/>
+        <location line="-410"/>
+        <location line="+411"/>
         <source>Second line point:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-330"/>
+        <location line="-331"/>
         <source>Center of arc:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17474,7 +17479,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17485,27 +17490,27 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-207"/>
+        <location line="-201"/>
         <source>C1: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C1: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="+18"/>
         <source>C2: angle:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+6"/>
+        <location line="-6"/>
         <source>C2: length:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+86"/>
+        <location line="+92"/>
         <location line="+22"/>
         <location line="+68"/>
         <source>Axis point:</source>
@@ -17536,7 +17541,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-432"/>
+        <location line="-433"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17546,7 +17551,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17557,12 +17562,12 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-355"/>
+        <location line="-356"/>
         <source>Point - Intersect XY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+280"/>
+        <location line="+281"/>
         <source>Rotation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17587,7 +17592,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+15"/>
         <location line="+21"/>
         <location line="+21"/>
@@ -17610,7 +17615,7 @@ load in SeamlyME as usual.
         <location line="+17"/>
         <location line="+14"/>
         <location line="+24"/>
-        <location line="+45"/>
+        <location line="+46"/>
         <location line="+22"/>
         <location line="+16"/>
         <location line="+15"/>
@@ -17625,7 +17630,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-621"/>
+        <location line="-622"/>
         <source>Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17649,7 +17654,7 @@ load in SeamlyME as usual.
         <location line="+37"/>
         <location line="+32"/>
         <location line="+24"/>
-        <location line="+113"/>
+        <location line="+114"/>
         <location line="+22"/>
         <location line="+20"/>
         <location line="+15"/>
@@ -17658,7 +17663,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-605"/>
+        <location line="-606"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17668,7 +17673,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17679,7 +17684,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-609"/>
+        <location line="-610"/>
         <location line="+21"/>
         <location line="+22"/>
         <location line="+22"/>
@@ -17689,7 +17694,7 @@ load in SeamlyME as usual.
         <location line="+45"/>
         <location line="+35"/>
         <location line="+103"/>
-        <location line="+46"/>
+        <location line="+47"/>
         <location line="+21"/>
         <location line="+17"/>
         <location line="+16"/>
@@ -17700,7 +17705,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-604"/>
+        <location line="-605"/>
         <source>Point - On Line</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17856,7 +17861,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+46"/>
+        <location line="+47"/>
         <source>Curve - Fixed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17906,9 +17911,9 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-564"/>
+        <location line="-565"/>
         <location line="+22"/>
-        <location line="+545"/>
+        <location line="+546"/>
         <location line="+102"/>
         <location line="+41"/>
         <location line="+895"/>
@@ -17916,8 +17921,8 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-1255"/>
-        <location line="+45"/>
+        <location line="-1256"/>
+        <location line="+46"/>
         <location line="+866"/>
         <location line="+67"/>
         <source>Spl_</source>
@@ -17935,7 +17940,7 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="-3263"/>
+        <location line="-3264"/>
         <source>Center point</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.cpp
@@ -1,29 +1,26 @@
-/******************************************************************************
-*   @file   preferencesconfigurationpage.h
-**  @author Douglas S Caskey
-**  @date   26 Oct, 2023
-**
-**  @brief
-**  @copyright
-**  This source code is part of the Seamly2D project, a pattern making
-**  program to create and model patterns of clothing.
-**  Copyright (C) 2017-2023 Seamly2D project
-**  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
-**
-**  Seamly2D is free software: you can redistribute it and/or modify
-**  it under the terms of the GNU General Public License as published by
-**  the Free Software Foundation, either version 3 of the License, or
-**  (at your option) any later version.
-**
-**  Seamly2D is distributed in the hope that it will be useful,
-**  but WITHOUT ANY WARRANTY; without even the implied warranty of
-**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-**  GNU General Public License for more details.
-**
-**  You should have received a copy of the GNU General Public License
-**  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
-**
-*************************************************************************/
+//  @file   preferencesconfigurationpage.cpp
+//  @author Douglas S Caskey
+//  @date   26 Oct, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2024 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
 
 /************************************************************************
  **
@@ -383,7 +380,7 @@ void PreferencesConfigurationPage::InitUnits()
     ui->unitCombo->addItem(tr("Inches"), unitINCH);
 
     // set default unit
-    const qint32 indexUnit = ui->unitCombo->findData(qApp->Seamly2DSettings()->GetUnit());
+    const qint32 indexUnit = ui->unitCombo->findData(qApp->Seamly2DSettings()->getUnit());
     if (indexUnit != -1)
     {
         ui->unitCombo->setCurrentIndex(indexUnit);

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp
@@ -1,29 +1,26 @@
-/******************************************************************************
-*   @file   preferencespatternpage.h
-**  @author Douglas S Caskey
-**  @date   26 Oct, 2023
-**
-**  @brief
-**  @copyright
-**  This source code is part of the Seamly2D project, a pattern making
-**  program to create and model patterns of clothing.
-**  Copyright (C) 2017-2023 Seamly2D project
-**  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
-**
-**  Seamly2D is free software: you can redistribute it and/or modify
-**  it under the terms of the GNU General Public License as published by
-**  the Free Software Foundation, either version 3 of the License, or
-**  (at your option) any later version.
-**
-**  Seamly2D is distributed in the hope that it will be useful,
-**  but WITHOUT ANY WARRANTY; without even the implied warranty of
-**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-**  GNU General Public License for more details.
-**
-**  You should have received a copy of the GNU General Public License
-**  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
-**
-*************************************************************************/
+//  @file   preferencespatternpage.cpp
+//  @author Douglas S Caskey
+//  @date   26 Oct, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2024 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
 
 /************************************************************************
  **
@@ -169,7 +166,7 @@ void PreferencesPatternPage::initDefaultSeamAllowance()
     ui->hideSeamLine_CheckBox->setChecked(qApp->Seamly2DSettings()->isHideSeamLine());
     ui->showSeamAllowances_CheckBox->setChecked(qApp->Seamly2DSettings()->getDefaultSeamAllowanceVisibilty());
     ui->defaultSeamAllowance_DoubleSpinBox->setValue(qApp->Seamly2DSettings()->GetDefaultSeamAllowance());
-    ui->defaultSeamAllowance_DoubleSpinBox->setSuffix(" " + UnitsToStr(StrToUnits(qApp->Seamly2DSettings()->GetUnit()), true));
+    ui->defaultSeamAllowance_DoubleSpinBox->setSuffix(" " + UnitsToStr(StrToUnits(qApp->Seamly2DSettings()->getUnit()), true));
 
     int index = ui->defaultSeamColor_ComboBox->findData(qApp->Seamly2DSettings()->getDefaultSeamColor());
     if (index != -1)
@@ -288,9 +285,9 @@ void PreferencesPatternPage::initializeLabelsTab()
     ui->showPieceLabels_CheckBox->setChecked(qApp->Seamly2DSettings()->showPieceLabels());
 
     ui->defaultLabelWidth_DoubleSpinBox->setValue(qApp->Seamly2DSettings()->getDefaultLabelWidth());
-    ui->defaultLabelWidth_DoubleSpinBox->setSuffix(" " + UnitsToStr(StrToUnits(qApp->Seamly2DSettings()->GetUnit()), true));
+    ui->defaultLabelWidth_DoubleSpinBox->setSuffix(" " + UnitsToStr(StrToUnits(qApp->Seamly2DSettings()->getUnit()), true));
     ui->defaultLabelHeight_DoubleSpinBox->setValue(qApp->Seamly2DSettings()->getDefaultLabelHeight());
-    ui->defaultLabelHeight_DoubleSpinBox->setSuffix(" " + UnitsToStr(StrToUnits(qApp->Seamly2DSettings()->GetUnit()), true));
+    ui->defaultLabelHeight_DoubleSpinBox->setSuffix(" " + UnitsToStr(StrToUnits(qApp->Seamly2DSettings()->getUnit()), true));
 
     int index = ui->defaultLabelColor_ComboBox->findData(qApp->Seamly2DSettings()->getDefaultLabelColor());
     if (index != -1)
@@ -317,6 +314,30 @@ void PreferencesPatternPage::initializeLabelsTab()
 //---------------------------------------------------------------------------------------------------------------------
 void PreferencesPatternPage::initNotches()
 {
+    const Unit units = StrToUnits(qApp->Seamly2DSettings()->getUnit());
+    switch (units)
+    {
+        case Unit::Cm:
+            {
+                ui->defaultNotchLength_DoubleSpinBox->setMaximum(4);
+                ui->defaultNotchWidth_DoubleSpinBox->setMaximum(1.25);
+                break;
+            }
+        case Unit::Mm:
+            {
+                ui->defaultNotchLength_DoubleSpinBox->setMaximum(40);
+                ui->defaultNotchWidth_DoubleSpinBox->setMaximum(12.50);
+                break;
+            }
+        case Unit::Inch:
+        default:
+            {
+                ui->defaultNotchLength_DoubleSpinBox->setMaximum(1.50);
+                ui->defaultNotchWidth_DoubleSpinBox->setMaximum(.50);
+                break;
+            }
+    }
+
     ui->defaultNotchType_ComboBox->addItem(QIcon(), tr("Slit"),       "slit");
     ui->defaultNotchType_ComboBox->addItem(QIcon(), tr("T Notch"),    "tNotch");
     ui->defaultNotchType_ComboBox->addItem(QIcon(), tr("U Notch"),    "uNotch");
@@ -340,9 +361,9 @@ void PreferencesPatternPage::initNotches()
     ui->showSeamlineNotch_CheckBox->setChecked(qApp->Seamly2DSettings()->showSeamlineNotch());
     ui->showSeamAllowanceNotch_CheckBox->setChecked(qApp->Seamly2DSettings()->showSeamAllowanceNotch());
     ui->defaultNotchLength_DoubleSpinBox->setValue(qApp->Seamly2DSettings()->getDefaultNotchLength());
-    ui->defaultNotchLength_DoubleSpinBox->setSuffix(" " + UnitsToStr(StrToUnits(qApp->Seamly2DSettings()->GetUnit()), true));
+    ui->defaultNotchLength_DoubleSpinBox->setSuffix(" " + UnitsToStr(units, true));
     ui->defaultNotchWidth_DoubleSpinBox->setValue(qApp->Seamly2DSettings()->getDefaultNotchWidth());
-    ui->defaultNotchWidth_DoubleSpinBox->setSuffix(" " + UnitsToStr(StrToUnits(qApp->Seamly2DSettings()->GetUnit()), true));
+    ui->defaultNotchWidth_DoubleSpinBox->setSuffix(" " + UnitsToStr(units, true));
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -351,7 +372,7 @@ void PreferencesPatternPage::initGrainlines()
     ui->showGrainlines_CheckBox->setChecked(qApp->Seamly2DSettings()->getDefaultGrainlineVisibilty());
 
     ui->defaultGrainlineLength_DoubleSpinBox->setValue(qApp->Seamly2DSettings()->getDefaultGrainlineLength());
-    ui->defaultGrainlineLength_DoubleSpinBox->setSuffix(" " + UnitsToStr(StrToUnits(qApp->Seamly2DSettings()->GetUnit()), true));
+    ui->defaultGrainlineLength_DoubleSpinBox->setSuffix(" " + UnitsToStr(StrToUnits(qApp->Seamly2DSettings()->getUnit()), true));
 
     int index = ui->defaultGrainlineColor_ComboBox->findData(qApp->Seamly2DSettings()->getDefaultGrainlineColor());
     if (index != -1)

--- a/src/app/seamly2d/dialogs/dialognewpattern.cpp
+++ b/src/app/seamly2d/dialogs/dialognewpattern.cpp
@@ -1,28 +1,28 @@
-/***************************************************************************
- **  @file   groups_widget.cpp
- **  @author Douglas S Caskey
- **  @date   12 Nov, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************
+//  @file   dialognewpattern.cpp
+//  @author Douglas S Caskey
+//  @date   12 Nov, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2024 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
 
- /************************************************************************
+/************************************************************************
  **
  **  @file   dialognewpattern.cpp
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -83,7 +83,7 @@ DialogNewPattern::DialogNewPattern(VContainer *data, const QString &patternPiece
 
     ui->lineEditName->setText(patternPieceName);
 
-    InitUnits();
+    initUnits();
     CheckState();
     connect(ui->lineEditName, &QLineEdit::textChanged, this, &DialogNewPattern::CheckState);
 }
@@ -95,7 +95,7 @@ DialogNewPattern::~DialogNewPattern()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-Unit DialogNewPattern::PatternUnit() const
+Unit DialogNewPattern::patternUnit() const
 {
     const qint32 index = ui->comboBoxUnits->currentIndex();
     return StrToUnits(ui->comboBoxUnits->itemData(index).toString());
@@ -137,14 +137,14 @@ void DialogNewPattern::showEvent(QShowEvent *event)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void DialogNewPattern::InitUnits()
+void DialogNewPattern::initUnits()
 {
     ui->comboBoxUnits->addItem(tr("Centimeters"), QVariant(UnitsToStr(Unit::Cm)));
     ui->comboBoxUnits->addItem(tr("Millimeters"), QVariant(UnitsToStr(Unit::Mm)));
     ui->comboBoxUnits->addItem(tr("Inches"), QVariant(UnitsToStr(Unit::Inch)));
 
     // set default unit
-    const qint32 indexUnit = ui->comboBoxUnits->findData(qApp->Seamly2DSettings()->GetUnit());
+    const qint32 indexUnit = ui->comboBoxUnits->findData(qApp->Seamly2DSettings()->getUnit());
     if (indexUnit != -1)
     {
         ui->comboBoxUnits->setCurrentIndex(indexUnit);

--- a/src/app/seamly2d/dialogs/dialognewpattern.h
+++ b/src/app/seamly2d/dialogs/dialognewpattern.h
@@ -1,27 +1,28 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//  @file   dialognewpattern.h
+//  @author Douglas S Caskey
+//  @date   12 Nov, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2024 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
 
- ************************************************************************
+/************************************************************************
  **
  **  @file   dialogindividualmeasurements.h
  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
@@ -49,8 +50,8 @@
  **
  *************************************************************************/
 
-#ifndef DIALOGINDIVIDUALMEASUREMENTS_H
-#define DIALOGINDIVIDUALMEASUREMENTS_H
+#ifndef DIALOG_NEWPATTERN_H
+#define DIALOG_NEWPATTERN_H
 
 #include <QDialog>
 
@@ -67,20 +68,24 @@ class DialogNewPattern : public QDialog
 {
     Q_OBJECT
 public:
-    DialogNewPattern(VContainer *data, const QString &patternPieceName, QWidget *parent = nullptr);
-    virtual ~DialogNewPattern();
-    QString name() const;
-    Unit PatternUnit() const;
+                          DialogNewPattern(VContainer *data, const QString &patternPieceName,
+                                           QWidget *parent = nullptr);
+    virtual              ~DialogNewPattern();
+    QString               name() const;
+    Unit                  patternUnit() const;
+
 protected:
-    virtual void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    virtual void          showEvent(QShowEvent *event) override;
+
 private slots:
-    void CheckState();
+    void                  CheckState();
+
 private:
-    Q_DISABLE_COPY(DialogNewPattern)
+                          Q_DISABLE_COPY(DialogNewPattern)
     Ui::DialogNewPattern *ui;
-    VContainer *data;
-    bool isInitialized;
-    void InitUnits();
+    VContainer           *data;
+    bool                  isInitialized;
+    void                  initUnits();
 };
 
-#endif // DIALOGINDIVIDUALMEASUREMENTS_H
+#endif // DIALOG_NEWPATTERN_H

--- a/src/app/seamly2d/dialogs/dialogpatternproperties.cpp
+++ b/src/app/seamly2d/dialogs/dialogpatternproperties.cpp
@@ -1,29 +1,26 @@
-/******************************************************************************
-*   @file  dialogpatternproperties.cpp
-**  @author Douglas S Caskey
-**  @date   3 Sep, 2023
-**
-**  @brief
-**  @copyright
-**  This source code is part of the Seamly2D project, a pattern making
-**  program to create and model patterns of clothing.
-**  Copyright (C) 2017-2023 Seamly2D project
-**  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
-**
-**  Seamly2D is free software: you can redistribute it and/or modify
-**  it under the terms of the GNU General Public License as published by
-**  the Free Software Foundation, either version 3 of the License, or
-**  (at your option) any later version.
-**
-**  Seamly2D is distributed in the hope that it will be useful,
-**  but WITHOUT ANY WARRANTY; without even the implied warranty of
-**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-**  GNU General Public License for more details.
-**
-**  You should have received a copy of the GNU General Public License
-**  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
-**
-*************************************************************************/
+//  @file   dialogpatternproperties.cpp
+//  @author Douglas S Caskey
+//  @date   3 Sep, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2024 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
 
 /************************************************************************
  **

--- a/src/app/seamly2d/dialogs/layoutsettings_dialog.cpp
+++ b/src/app/seamly2d/dialogs/layoutsettings_dialog.cpp
@@ -734,8 +734,8 @@ void LayoutSettingsDialog::InitPaperUnits()
     ui->comboBoxPaperSizeUnit->addItem(tr("Pixels"), QVariant(UnitsToStr(Unit::Px)));
 
     // set default unit
-    oldPaperUnit = StrToUnits(qApp->Seamly2DSettings()->GetUnit());
-    const qint32 indexUnit = ui->comboBoxPaperSizeUnit->findData(qApp->Seamly2DSettings()->GetUnit());
+    oldPaperUnit = StrToUnits(qApp->Seamly2DSettings()->getUnit());
+    const qint32 indexUnit = ui->comboBoxPaperSizeUnit->findData(qApp->Seamly2DSettings()->getUnit());
     if (indexUnit != -1)
     {
         ui->comboBoxPaperSizeUnit->setCurrentIndex(indexUnit);
@@ -750,8 +750,8 @@ void LayoutSettingsDialog::InitLayoutUnits()
     ui->comboBoxLayoutUnit->addItem(tr("Inches"), QVariant(UnitsToStr(Unit::Inch)));
 
     // set default unit
-    oldLayoutUnit = StrToUnits(qApp->Seamly2DSettings()->GetUnit());
-    const qint32 indexUnit = ui->comboBoxLayoutUnit->findData(qApp->Seamly2DSettings()->GetUnit());
+    oldLayoutUnit = StrToUnits(qApp->Seamly2DSettings()->getUnit());
+    const qint32 indexUnit = ui->comboBoxLayoutUnit->findData(qApp->Seamly2DSettings()->getUnit());
     if (indexUnit != -1)
     {
         ui->comboBoxLayoutUnit->setCurrentIndex(indexUnit);

--- a/src/app/seamly2d/dialogs/welcome_dialog.cpp
+++ b/src/app/seamly2d/dialogs/welcome_dialog.cpp
@@ -146,7 +146,7 @@ void SeamlyWelcomeDialog::initUnits(const MeasurementsType &type)
     ui->units_ComboBox->addItem(tr("Inches")     , unitINCH);
 
     // set default unit
-    const qint32 index = ui->units_ComboBox->findData(settings->GetUnit());
+    const qint32 index = ui->units_ComboBox->findData(settings->getUnit());
     if (index != -1)
     {
         ui->units_ComboBox->setCurrentIndex(index);

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -4783,7 +4783,7 @@ void MainWindow::New()
         if (newPattern.exec() == QDialog::Accepted)
         {
             draftBlockName = newPattern.name();
-            qApp->setPatternUnit(newPattern.PatternUnit());
+            qApp->setPatternUnit(newPattern.patternUnit());
             qCDebug(vMainWindow, "Draft Block name: %s", qUtf8Printable(draftBlockName));
         }
         else

--- a/src/app/seamlyme/dialogs/me_welcome_dialog.cpp
+++ b/src/app/seamlyme/dialogs/me_welcome_dialog.cpp
@@ -127,7 +127,7 @@ void SeamlyMeWelcomeDialog::initUnits(const MeasurementsType &type)
     ui->units_ComboBox->addItem(tr("Inches")     , unitINCH);
 
     // set default unit
-    const qint32 index = ui->units_ComboBox->findData(settings->GetUnit());
+    const qint32 index = ui->units_ComboBox->findData(settings->getUnit());
     if (index != -1)
     {
         ui->units_ComboBox->setCurrentIndex(index);

--- a/src/app/seamlyme/dialogs/new_measurements_dialog.cpp
+++ b/src/app/seamlyme/dialogs/new_measurements_dialog.cpp
@@ -241,7 +241,7 @@ void NewMeasurementsDialog::initializeUnits(const MeasurementsType &type)
     if (type == MeasurementsType::Individual)
     {
         ui->comboBoxUnit->addItem(tr("Inches"), static_cast<int>(Unit::Inch));
-        index = ui->comboBoxUnit->findData(static_cast<int>(StrToUnits(qApp->seamlyMeSettings()->GetUnit())));
+        index = ui->comboBoxUnit->findData(static_cast<int>(StrToUnits(qApp->seamlyMeSettings()->getUnit())));
     }
     else
     {

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -1,26 +1,26 @@
-/***************************************************************************
- **  @file   vcommonsettings.cpp
- **  @author Douglas S Caskey
- **  @date   17 Sep, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//  @file   vcommonsettings.cpp
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2024 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
 
 /************************************************************************
  **
@@ -679,7 +679,7 @@ void VCommonSettings::SetPMSystemCode(const QString &value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QString VCommonSettings::GetUnit() const
+QString VCommonSettings::getUnit() const
 {
     return value(settingConfigurationUnit,
                  QLocale().measurementSystem() == QLocale::MetricSystem ? unitCM : unitINCH).toString();
@@ -1510,7 +1510,24 @@ void VCommonSettings::setShowSeamAllowanceNotch(bool value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultNotchLength() const
 {
-   return value(settingDefaultNotchLength, .250).toReal();
+    double maxValue;
+
+    const Unit units = StrToUnits(getUnit());
+
+    switch (units)
+    {
+        case Unit::Mm:
+            maxValue = 40;
+            break;
+        case Unit::Inch:
+            maxValue = 1.5;
+            break;
+        default:
+        case Unit::Cm:
+            maxValue = 4;
+            break;
+   }
+   return value(settingDefaultNotchLength, maxValue).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1522,7 +1539,24 @@ void VCommonSettings::setDefaultNotchLength(const qreal &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultNotchWidth() const
 {
-   return value(settingDefaultNotchWidth, .250).toReal();
+   double maxValue;
+
+   const Unit units = StrToUnits(getUnit());
+
+   switch (units)
+   {
+       case Unit::Mm:
+           maxValue = 12.50;
+           break;
+       case Unit::Inch:
+           maxValue = 0.50;
+           break;
+       default:
+       case Unit::Cm:
+           maxValue = 1.25;
+           break;
+   }
+   return value(settingDefaultNotchWidth, maxValue).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1643,7 +1677,7 @@ QChar VCommonSettings::GetDefCSVSeparator() const
 //---------------------------------------------------------------------------------------------------------------------
 void VCommonSettings::SetDefaultSeamAllowance(double value)
 {
-    setValue(settingPatternDefaultSeamAllowance, UnitConvertor(value, StrToUnits(GetUnit()), Unit::Cm));
+    setValue(settingPatternDefaultSeamAllowance, UnitConvertor(value, StrToUnits(getUnit()), Unit::Cm));
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1655,9 +1689,9 @@ double VCommonSettings::GetDefaultSeamAllowance()
 {
     double defaultValue;
 
-    const Unit globalUnit = StrToUnits(GetUnit());
+    const Unit units = StrToUnits(getUnit());
 
-    switch (globalUnit)
+    switch (units)
     {
         case Unit::Mm:
             defaultValue = 10;
@@ -1686,7 +1720,7 @@ double VCommonSettings::GetDefaultSeamAllowance()
     }
     else
     {
-        val = UnitConvertor(val, Unit::Cm, globalUnit);
+        val = UnitConvertor(val, Unit::Cm, units);
     }
 
     return val;

--- a/src/libs/vmisc/vcommonsettings.h
+++ b/src/libs/vmisc/vcommonsettings.h
@@ -1,29 +1,26 @@
-/******************************************************************************
- *   @file   vcommonsettings.cpp
- **  @author Douglas S Caskey
- **  @date   14 Jul, 2023
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Seamly2D project, a pattern making
- **  program to create and model patterns of clothing.
- **  Copyright (C) 2017-2023 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//  @file   vcommonsettings.h
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2024 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
 
 /************************************************************************
  **
@@ -141,7 +138,7 @@ public:
     QString              GetPMSystemCode() const;
     void                 SetPMSystemCode(const QString &value);
 
-    QString              GetUnit() const;
+    QString              getUnit() const;
     void                 SetUnit(const QString &value);
 
     bool                 getConfirmItemDelete() const;

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -1,26 +1,26 @@
-/***************************************************************************
- **  @file   pattern_piece_dialog.cpp
- **  @author Douglas S Caskey
- **  @date   17 Sep, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2022 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//  @file   pattern_piece_dialog.cpp
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2024 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
 
 /************************************************************************
  **
@@ -2910,7 +2910,7 @@ void PatternPieceDialog::initializeSeamAllowanceTab()
 
     // Initialize the default seam allowance, convert the value if app unit is different than pattern unit
     m_saWidth = UnitConvertor(qApp->Settings()->GetDefaultSeamAllowance(),
-                              StrToUnits(qApp->Settings()->GetUnit()), qApp->patternUnit());
+                              StrToUnits(qApp->Settings()->getUnit()), qApp->patternUnit());
 
     ui->widthFormula_PlainTextEdit->setPlainText(qApp->LocaleToString(m_saWidth));
 
@@ -3179,8 +3179,36 @@ void PatternPieceDialog::initializeNotchesTab()
 {
     initializeNotchesList();
 
-    ui->notchLength_DoubleSpinBox->setValue(qApp->Settings()->getDefaultNotchLength());
-    ui->notchWidth_DoubleSpinBox->setValue(qApp->Settings()->getDefaultNotchWidth());
+    switch (qApp->patternUnit())
+    {
+        case Unit::Cm:
+            {
+                ui->notchLength_DoubleSpinBox->setMaximum(4);
+                ui->notchWidth_DoubleSpinBox->setMaximum(1.25);
+                break;
+            }
+        case Unit::Mm:
+            {
+                ui->notchLength_DoubleSpinBox->setMaximum(40);
+                ui->notchWidth_DoubleSpinBox->setMaximum(12.50);
+                break;
+            }
+        case Unit::Inch:
+        default:
+            {
+                ui->notchLength_DoubleSpinBox->setMaximum(1.50);
+                ui->notchWidth_DoubleSpinBox->setMaximum(.50);
+                break;
+            }
+    }
+    QString unitStr = QString(" " + UnitsToStr(qApp->patternUnit(), true)).left(3);
+    ui->notchLength_DoubleSpinBox->setValue(UnitConvertor(qApp->Settings()->getDefaultNotchLength(),
+                              StrToUnits(qApp->Settings()->getUnit()), qApp->patternUnit()));
+
+    ui->notchLength_DoubleSpinBox->setSuffix(unitStr);
+    ui->notchWidth_DoubleSpinBox->setValue(UnitConvertor(qApp->Settings()->getDefaultNotchWidth(),
+                              StrToUnits(qApp->Settings()->getUnit()), qApp->patternUnit()));
+    ui->notchWidth_DoubleSpinBox->setSuffix(unitStr);
     ui->showNotch_CheckBox->setChecked(qApp->Settings()->showSeamAllowanceNotch());
     ui->showSeamlineNotch_CheckBox->setChecked(qApp->Settings()->showSeamlineNotch());
 

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
@@ -5347,6 +5347,9 @@ QListWidget::item:selected {
                     <property name="keyboardTracking">
                      <bool>false</bool>
                     </property>
+                    <property name="suffix">
+                     <string>  °</string>
+                    </property>
                     <property name="decimals">
                      <number>3</number>
                     </property>
@@ -5703,8 +5706,8 @@ QListWidget::item:selected {
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../../../vmisc/share/resources/icon.qrc"/>
   <include location="../../../../vmisc/share/resources/theme.qrc"/>
+  <include location="../../../../vmisc/share/resources/icon.qrc"/>
  </resources>
  <connections>
   <connection>
@@ -5741,7 +5744,7 @@ QListWidget::item:selected {
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="notchType_ButtonGroup"/>
   <buttongroup name="notchSubType_ButtonGroup"/>
+  <buttongroup name="notchType_ButtonGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
This fixes the issue of the maximum value of the default notch length and width values in the spinboxes. It sets the maximum notch spinbox values in the Prefs and Pattern Piece dialogs based on the units. The max values are as follows:

> Inches:
>     length = 1.500
>     width = .500

> Cm:
>     length = 4.000
>     width = 1.250

 

> Mm:
>     length = 40.000
>     width = 12.500

The Pattern Piece dialog now also displays the pattern units suffix in the spinboxes.

![Screenshot 2024-05-28 120339](https://github.com/FashionFreedom/Seamly2D/assets/31944718/58360301-4884-4873-a764-15c50e9cb5ee)
![Screenshot 2024-05-28 115035](https://github.com/FashionFreedom/Seamly2D/assets/31944718/af36c343-6597-436c-ab8d-5b668a5898f9)

This fixes issue #1117 