### PR TITLE
maintenance: update wiki URL

### DIFF
--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -6154,7 +6154,7 @@ void MainWindow::createActions()
     connect(ui->wiki_Action, &QAction::triggered, this, []()
     {
         qCDebug(vMainWindow, "Showing online help");
-        QDesktopServices::openUrl(QUrl(QStringLiteral("https://wiki.seamly.net/wiki/Main_Page")));
+        QDesktopServices::openUrl(QUrl(QStringLiteral("https://wiki.seamly.io/wiki/Main_Page")));
     });
 
     connect(ui->forum_Action, &QAction::triggered, this, []()


### PR DESCRIPTION
Updates the wiki URL to the new https://wiki.seamly.io/wiki/Main_Page from the old https://wiki.seamly.net/wiki/Main_Page

closes issue #1122 