### PR TITLE
maintenance: correct comments for vcontainer

### DIFF
--- a/src/libs/vpatterndb/vcontainer.cpp
+++ b/src/libs/vpatterndb/vcontainer.cpp
@@ -1185,8 +1185,7 @@ void VContainer::setHeight(qreal height)
  * - The method returns the value of the static member variable `_size`.
  * - This size value is used in various calculations and operations.
  */
-qreal VContainer::
-+
+qreal VContainer::size()
 {
     return _size;
 }

--- a/src/libs/vpatterndb/vcontainer.cpp
+++ b/src/libs/vpatterndb/vcontainer.cpp
@@ -99,12 +99,12 @@ VContainer &VContainer::operator=(VContainer &&data) Q_DECL_NOTHROW
 
 /**
  * @brief Swaps the contents of this VContainer with another.
- * 
+ *
  * This method swaps the internal data pointer of this VContainer with that of another VContainer.
  * This operation is noexcept, meaning it guarantees not to throw any exceptions.
- * 
+ *
  * @param data The other VContainer with which to swap contents.
- * 
+ *
  * @details
  * - This method uses `std::swap` to exchange the data pointers of the two VContainer instances.
  * - It ensures that the swap operation is performed without throwing exceptions.
@@ -114,30 +114,29 @@ void VContainer::Swap(VContainer &data) Q_DECL_NOTHROW
 
 /**
  * @brief Constructs a VContainer with the specified translation variables and pattern unit.
- * 
+ *
  * This constructor initializes a VContainer instance by creating a new VContainerData object
  * with the provided translation variables and pattern unit.
- * 
+ *
  * @param trVars A pointer to the translation variables.
  * @param patternUnit A pointer to the pattern unit.
- * 
+ *
  * @details
  * - The constructor initializes the `d` member with a new VContainerData object.
  * - The `d` member is a shared data pointer, facilitating efficient data management.
  */
-
 VContainer::VContainer(const VTranslateVars *trVars, const Unit *patternUnit)
     :d(new VContainerData(trVars, patternUnit))
 {}
 
 /**
  * @brief Assignment operator for VContainer.
- * 
+ *
  * This operator assigns the contents of another VContainer to this instance.
- * 
+ *
  * @param data The VContainer instance to assign from.
  * @return VContainer& A reference to this VContainer after assignment.
- * 
+ *
  * @details
  * - The method first checks for self-assignment by comparing the address of the passed instance with this instance.
  * - If the addresses are the same, it returns a reference to this instance.
@@ -156,11 +155,11 @@ VContainer &VContainer::operator =(const VContainer &data)
 
 /**
  * @brief Copy constructor for VContainer.
- * 
+ *
  * This constructor initializes a new VContainer instance as a copy of an existing VContainer.
- * 
+ *
  * @param data The VContainer instance to copy from.
- * 
+ *
  * @details
  * - The constructor initializes the shared data pointer `d` with the shared data pointer from the passed instance.
  * - This ensures that the new VContainer instance shares the same underlying data as the original.
@@ -171,9 +170,9 @@ VContainer::VContainer(const VContainer &data)
 
 /**
  * @brief Destructor for VContainer.
- * 
+ *
  * This method handles the cleanup when a VContainer object is destroyed.
- * 
+ *
  * @details
  * - The destructor calls `ClearGObjects()` to clear all geometric objects managed by the container.
  * - It then calls `ClearVariables()` to clear all variables managed by the container.
@@ -187,12 +186,12 @@ VContainer::~VContainer()
 
 /**
  * @brief Retrieves a geometric object with the specified ID.
- * 
+ *
  * This method retrieves a shared pointer to a geometric object of type VGObject from the container using the specified ID.
- * 
+ *
  * @param id The ID of the geometric object to retrieve.
  * @return const QSharedPointer<VGObject> A shared pointer to the geometric object.
- * 
+ *
  * @details
  * - The method delegates to the `GetObject` function, passing the internal hash map of geometric objects and the specified ID.
  * - If the object with the specified ID is found, it returns the shared pointer to the object.
@@ -206,12 +205,12 @@ const QSharedPointer<VGObject> VContainer::GetGObject(quint32 id)const
 
 /**
  * @brief Creates and retrieves a fake geometric object with the specified ID.
- * 
+ *
  * This method creates a new VGObject with the given ID, wraps it in a shared pointer, and returns the shared pointer.
- * 
+ *
  * @param id The ID to assign to the fake geometric object.
  * @return const QSharedPointer<VGObject> A shared pointer to the newly created fake geometric object.
- * 
+ *
  * @details
  * - The method dynamically allocates a new VGObject and sets its ID to the specified value.
  * - It wraps the raw pointer to the new VGObject in a QSharedPointer to manage its lifetime automatically.
@@ -228,18 +227,18 @@ const QSharedPointer<VGObject> VContainer::GetFakeGObject(quint32 id)
 
 /**
  * @brief Retrieves an object with the specified ID from a hash map.
- * 
+ *
  * This template method retrieves an object of type val stored in the hash map
  * with the given key. If the object is not found, it throws an exception.
- * 
+ *
  * @tparam key The type of the key used in the hash map.
  * @tparam val The type of the value stored in the hash map.
  * @param obj The hash map from which to retrieve the object.
  * @param id The key used to retrieve the object.
  * @return const val The object retrieved from the hash map.
- * 
+ *
  * @throws VExceptionBadId if the object with the specified ID cannot be found.
- * 
+ *
  * @details
  * - The method checks if the hash map contains the specified ID.
  * - If the ID is found, it returns the corresponding value.
@@ -260,15 +259,15 @@ const val VContainer::GetObject(const QHash<key, val> &obj, key id) const
 
 /**
  * @brief Retrieves a piece with the specified ID.
- * 
+ *
  * This method attempts to find and return a piece with the given ID from the container.
  * If the piece is not found, it throws an exception.
- * 
+ *
  * @param id The ID of the piece to retrieve.
  * @return VPiece The piece retrieved from the container.
- * 
+ *
  * @throws VExceptionBadId if the piece with the specified ID cannot be found.
- * 
+ *
  * @details
  * - The method checks if the internal hash map of pieces contains the specified ID.
  * - If the ID is found, it returns the corresponding piece.
@@ -288,15 +287,15 @@ VPiece VContainer::GetPiece(quint32 id) const
 
 /**
  * @brief Retrieves a piece path with the specified ID.
- * 
+ *
  * This method attempts to find and return a piece path with the given ID from the container.
  * If the piece path is not found, it throws an exception.
- * 
+ *
  * @param id The ID of the piece path to retrieve.
  * @return VPiecePath The piece path retrieved from the container.
- * 
+ *
  * @throws VExceptionBadId if the piece path with the specified ID cannot be found.
- * 
+ *
  * @details
  * - The method checks if the internal hash map of piece paths contains the specified ID.
  * - If the ID is found, it returns the corresponding piece path.
@@ -316,12 +315,12 @@ VPiecePath VContainer::GetPiecePath(quint32 id) const
 
 /**
  * @brief Adds a new geometric object to the container.
- * 
+ *
  * This method adds a new geometric object to the container and returns its ID.
- * 
+ *
  * @param obj A pointer to the new geometric object to add. The object must not be null.
  * @return quint32 The ID of the new object in the container.
- * 
+ *
  * @details
  * - The method asserts that the provided object pointer is not null.
  * - It creates a QSharedPointer from the raw pointer to manage the object's lifetime.
@@ -339,12 +338,12 @@ quint32 VContainer::AddGObject(VGObject *obj)
 
 /**
  * @brief Adds a new piece to the container.
- * 
+ *
  * This method adds a new piece to the container and returns its ID.
- * 
+ *
  * @param piece The piece to add to the container.
  * @return quint32 The ID of the new piece in the container.
- * 
+ *
  * @details
  * - The method generates a new unique ID for the piece by calling `getNextId()`.
  * - It inserts the piece into the internal hash map of pieces using the generated ID.
@@ -359,12 +358,12 @@ quint32 VContainer::AddPiece(const VPiece &piece)
 
 /**
  * @brief Adds a new piece path to the container.
- * 
+ *
  * This method adds a new piece path to the container and returns its ID.
- * 
+ *
  * @param path The piece path to add to the container.
  * @return quint32 The ID of the new piece path in the container.
- * 
+ *
  * @details
  * - The method generates a new unique ID for the piece path by calling `getNextId()`.
  * - It inserts the piece path into the internal hash map of piece paths using the generated ID.
@@ -379,11 +378,11 @@ quint32 VContainer::AddPiecePath(const VPiecePath &path)
 
 /**
  * @brief Retrieves the current unique ID.
- * 
+ *
  * This method returns the current value of the unique ID used for generating new IDs.
- * 
+ *
  * @return quint32 The current unique ID.
- * 
+ *
  * @details
  * - The method returns the value of the static member variable `_id`, which holds the current unique ID.
  */
@@ -394,18 +393,19 @@ quint32 VContainer::getId()
 
 /**
  * @brief Generates and returns the next unique ID.
- * 
+ *
  * This method increments the current unique ID and returns the new value.
- * 
+ *
  * @return quint32 The next unique ID.
- * 
+ *
  * @details
  * - The method first checks if the current ID has reached the maximum value (`UINT_MAX`).
  * - If the maximum value is reached, it logs a critical message indicating that the number of free IDs is exhausted.
  * - It increments the static member variable `_id` to generate the next unique ID.
  * - The method returns the new value of `_id`.
- * 
- * @note Currently, the method simply increments the ID without reusing free IDs. This approach saves time but may need improvement in the future to reuse free IDs within the set of values.
+ *
+ * @note Currently, the method simply increments the ID without reusing free IDs. This approach saves time but may need
+ * improvement in the future to reuse free IDs within the set of values.
  */
 quint32 VContainer::getNextId()
 {
@@ -422,11 +422,11 @@ quint32 VContainer::getNextId()
 
 /**
  * @brief Updates the current unique ID to a new value if it is greater than the current value.
- * 
+ *
  * This method sets the current unique ID to the specified new value if the new value is greater than the current value of `_id`.
- * 
+ *
  * @param newId The new ID to set.
- * 
+ *
  * @details
  * - The method checks if the specified `newId` is greater than the current value of `_id`.
  * - If the condition is met, it updates `_id` to the new value.
@@ -442,10 +442,10 @@ void VContainer::UpdateId(quint32 newId)
 
 /**
  * @brief Clears all data from the container.
- * 
+ *
  * This method clears all data managed by the container, including pieces, piece paths, variables, and geometric objects.
  * It also resets the unique ID and clears the set of unique names.
- * 
+ *
  * @details
  * - The method logs a debug message indicating that the container data is being cleared.
  * - It resets the unique ID to `NULL_ID`.
@@ -468,15 +468,15 @@ void VContainer::Clear()
 
 /**
  * @brief Clears container data in preparation for a full parse.
- * 
+ *
  * This method clears all relevant data from the container to prepare for a full parse operation.
  * It resets the unique ID and clears the set of unique names.
- * 
+ *
  * @details
  * - The method logs a debug message indicating that the container data is being cleared for a full parse.
  * - It resets the unique ID to `NULL_ID`.
  * - It clears the internal hash maps of pieces and piece paths.
- * - It calls `ClearVariables()` multiple times to clear variables of different types: 
+ * - It calls `ClearVariables()` multiple times to clear variables of different types:
  *   `Variable`, `LineAngle`, `LineLength`, `CurveLength`, `CurveCLength`, `ArcRadius`, and `CurveAngle`.
  * - It calls `ClearGObjects()` to clear all geometric objects managed by the container.
  * - It calls `ClearUniqueNames()` to clear the set of unique names.
@@ -501,9 +501,9 @@ void VContainer::ClearForFullParse()
 
 /**
  * @brief Clears all geometric objects from the container.
- * 
+ *
  * This method removes all geometric objects managed by the container by clearing the internal hash map of geometric objects.
- * 
+ *
  * @details
  * - The method clears the `gObjects` hash map, which stores all geometric objects in the container.
  * - After this operation, the container will no longer manage any geometric objects.
@@ -516,9 +516,9 @@ void VContainer::ClearGObjects()
 //---------------------------------------------------------------------------------------------------------------------
 /**
  * @brief Clears all geometric objects marked for calculation from the container.
- * 
+ *
  * This method removes all geometric objects that are marked with the mode `Draw::Calculation` from the container.
- * 
+ *
  * @details
  * - The method first checks if the `gObjects` hash map is not empty.
  * - It iterates over the `gObjects` hash map to identify objects marked with `Draw::Calculation` mode.
@@ -553,11 +553,11 @@ void VContainer::ClearCalculationGObjects()
 
 /**
  * @brief Clears variables of the specified type from the container.
- * 
+ *
  * This method removes variables of the specified type from the container. If the type is `VarType::Unknown`, all variables are cleared.
- * 
+ *
  * @param type The type of variables to clear.
- * 
+ *
  * @details
  * - The method first checks if the `variables` hash map is not empty.
  * - If the specified type is `VarType::Unknown`, it clears the entire `variables` hash map.
@@ -566,7 +566,6 @@ void VContainer::ClearCalculationGObjects()
  * - After the iteration, the method removes the variables with the collected keys from the hash map.
  * - This two-step process ensures that the iterator is not invalidated during the removal of variables.
  */
-
 void VContainer::ClearVariables(const VarType &type)
 {
     if (d->variables.size()>0) //-V807
@@ -595,7 +594,6 @@ void VContainer::ClearVariables(const VarType &type)
     }
 }
 
-//---------------------------------------------------------------------------------------------------------------------
 /**
  * @brief AddLine add line to container
  * @param firstPointId id of first point of line
@@ -615,12 +613,12 @@ void VContainer::AddLine(const quint32 &firstPointId, const quint32 &secondPoint
 
 /**
  * @brief Adds a line defined by two points to the container.
- * 
+ *
  * This method adds a line defined by the IDs of two points to the container. It creates length and angle variables for the line.
- * 
+ *
  * @param firstPointId The ID of the first point defining the line.
  * @param secondPointId The ID of the second point defining the line.
- * 
+ *
  * @details
  * - The method retrieves the geometric objects for the first and second points using their IDs.
  * - It creates a new `VLengthLine` object representing the length of the line between the two points.
@@ -653,16 +651,16 @@ void VContainer::AddArc(const QSharedPointer<VAbstractCurve> &arc, const quint32
 
 /**
  * @brief Adds a curve to the container and creates related variables.
- * 
+ *
  * This method adds a curve to the container and creates length and angle variables for the curve.
  * It supports specific types of curves, such as splines, cubic Bezier curves, arcs, and elliptical arcs.
- * 
+ *
  * @param curve A shared pointer to the curve to add.
  * @param id The ID of the curve.
  * @param parentId The ID of the parent object, if any.
- * 
+ *
  * @throws VException if the curve type is not supported.
- * 
+ *
  * @details
  * - The method first retrieves the type of the curve.
  * - It checks if the curve type is one of the supported types: Spline, SplinePath, CubicBezier, CubicBezierPath, Arc, or EllipticalArc.
@@ -693,13 +691,13 @@ void VContainer::AddCurve(const QSharedPointer<VAbstractCurve> &curve, const qui
 
 /**
  * @brief Adds a spline to the container and creates related variables.
- * 
+ *
  * This method adds a spline to the container and creates length variables for the control points of the spline.
- * 
+ *
  * @param curve A shared pointer to the spline to add.
  * @param id The ID of the spline.
  * @param parentId The ID of the parent object, if any.
- * 
+ *
  * @details
  * - The method first calls `AddCurve` to add the spline and create length and angle variables.
  * - It creates a new `VCurveCLength` object representing the length of the first control point (C1) and adds it as a variable.
@@ -718,13 +716,13 @@ void VContainer::AddSpline(const QSharedPointer<VAbstractBezier> &curve, quint32
 
 /**
  * @brief Adds a cubic Bezier path with segments to the container and creates related variables.
- * 
+ *
  * This method adds a cubic Bezier path to the container and creates length and angle variables for each segment of the path.
- * 
+ *
  * @param curve A shared pointer to the cubic Bezier path to add.
  * @param id The ID of the cubic Bezier path.
  * @param parentId The ID of the parent object, if any.
- * 
+ *
  * @details
  * - The method first calls `AddSpline` to add the cubic Bezier path and create length variables for the control points.
  * - It iterates over each segment of the cubic Bezier path.
@@ -764,11 +762,11 @@ void VContainer::AddCurveWithSegments(const QSharedPointer<VAbstractCubicBezierP
 
 /**
  * @brief Removes a variable with the specified name from the container.
- * 
+ *
  * This method removes a variable identified by its name from the container.
- * 
+ *
  * @param name The name of the variable to remove.
- * 
+ *
  * @details
  * - The method removes the variable with the specified name from the internal hash map of variables.
  * - If the variable with the specified name does not exist, the method does nothing.
@@ -780,11 +778,11 @@ void VContainer::RemoveVariable(const QString &name)
 
 /**
  * @brief Removes a piece with the specified ID from the container.
- * 
+ *
  * This method removes a piece identified by its ID from the container.
- * 
+ *
  * @param id The ID of the piece to remove.
- * 
+ *
  * @details
  * - The method removes the piece with the specified ID from the internal hash map of pieces.
  * - If the piece with the specified ID does not exist, the method does nothing.
@@ -796,15 +794,15 @@ void VContainer::RemovePiece(quint32 id)
 
 /**
  * @brief Adds an object to the specified hash map and assigns it a unique ID.
- * 
+ *
  * This template method adds an object of type val to the specified hash map and assigns it a unique ID.
- * 
+ *
  * @tparam key The type of the key used in the hash map.
  * @tparam val The type of the value stored in the hash map.
  * @param obj The hash map to which the object will be added.
  * @param value The object to add to the hash map.
  * @return quint32 The unique ID assigned to the added object.
- * 
+ *
  * @details
  * - The method asserts that the provided object is not null.
  * - It generates a new unique ID for the object by calling `getNextId()`.
@@ -824,12 +822,12 @@ quint32 VContainer::AddObject(QHash<key, val> &obj, val value)
 
 /**
  * @brief Updates a piece with the specified ID in the container.
- * 
+ *
  * This method updates the piece identified by its ID with the new piece data provided.
- * 
+ *
  * @param id The ID of the piece to update.
  * @param piece The new data for the piece.
- * 
+ *
  * @details
  * - The method asserts that the provided ID is not `NULL_ID`.
  * - It updates the piece with the specified ID in the internal hash map of pieces with the new data.
@@ -844,12 +842,12 @@ void VContainer::UpdatePiece(quint32 id, const VPiece &piece)
 
 /**
  * @brief Updates a piece path with the specified ID in the container.
- * 
+ *
  * This method updates the piece path identified by its ID with the new path data provided.
- * 
+ *
  * @param id The ID of the piece path to update.
  * @param path The new data for the piece path.
- * 
+ *
  * @details
  * - The method asserts that the provided ID is not `NULL_ID`.
  * - It updates the piece path with the specified ID in the internal hash map of piece paths with the new data.
@@ -864,11 +862,11 @@ void VContainer::UpdatePiecePath(quint32 id, const VPiecePath &path)
 
 /**
  * @brief Removes a custom variable with the specified name from the container.
- * 
+ *
  * This method clears and removes a custom variable identified by its name from the container.
- * 
+ *
  * @param name The name of the custom variable to remove.
- * 
+ *
  * @details
  * - The method first clears the shared pointer associated with the specified variable name.
  * - It then removes the variable with the specified name from the internal hash map of variables.
@@ -882,11 +880,11 @@ void VContainer::removeCustomVariable(const QString &name)
 
 /**
  * @brief Retrieves all measurement variables from the container.
- * 
+ *
  * This method returns a map of all measurement variables stored in the container.
- * 
+ *
  * @return QMap<QString, QSharedPointer<MeasurementVariable>> A map of measurement variables keyed by their names.
- * 
+ *
  * @details
  * - The method calls `DataVar` with the type `MeasurementVariable` and the enumeration `VarType::Measurement`.
  * - It returns the map of measurement variables retrieved from the container.
@@ -898,11 +896,11 @@ const QMap<QString, QSharedPointer<MeasurementVariable> > VContainer::DataMeasur
 
 /**
  * @brief Retrieves all custom variables from the container.
- * 
+ *
  * This method returns a map of all custom variables stored in the container.
- * 
+ *
  * @return QMap<QString, QSharedPointer<CustomVariable>> A map of custom variables keyed by their names.
- * 
+ *
  * @details
  * - The method calls `DataVar` with the type `CustomVariable` and the enumeration `VarType::Variable`.
  * - It returns the map of custom variables retrieved from the container.
@@ -914,11 +912,11 @@ const QMap<QString, QSharedPointer<CustomVariable> > VContainer::variablesData()
 
 /**
  * @brief Retrieves all line length variables from the container.
- * 
+ *
  * This method returns a map of all line length variables stored in the container.
- * 
+ *
  * @return QMap<QString, QSharedPointer<VLengthLine>> A map of line length variables keyed by their names.
- * 
+ *
  * @details
  * - The method calls `DataVar` with the type `VLengthLine` and the enumeration `VarType::LineLength`.
  * - It returns the map of line length variables retrieved from the container.
@@ -930,11 +928,11 @@ const QMap<QString, QSharedPointer<VLengthLine> > VContainer::lineLengthsData() 
 
 /**
  * @brief Retrieves all curve length variables from the container.
- * 
+ *
  * This method returns a map of all curve length variables stored in the container.
- * 
+ *
  * @return QMap<QString, QSharedPointer<VCurveLength>> A map of curve length variables keyed by their names.
- * 
+ *
  * @details
  * - The method calls `DataVar` with the type `VCurveLength` and the enumeration `VarType::CurveLength`.
  * - It returns the map of curve length variables retrieved from the container.
@@ -946,11 +944,11 @@ const QMap<QString, QSharedPointer<VCurveLength> > VContainer::curveLengthsData(
 
 /**
  * @brief Retrieves all curve control point length variables from the container.
- * 
+ *
  * This method returns a map of all curve control point length variables stored in the container.
- * 
+ *
  * @return QMap<QString, QSharedPointer<VCurveCLength>> A map of curve control point length variables keyed by their names.
- * 
+ *
  * @details
  * - The method calls `DataVar` with the type `VCurveCLength` and the enumeration `VarType::CurveCLength`.
  * - It returns the map of curve control point length variables retrieved from the container.
@@ -962,11 +960,11 @@ const QMap<QString, QSharedPointer<VCurveCLength> > VContainer::controlPointLeng
 
 /**
  * @brief Retrieves all line angle variables from the container.
- * 
+ *
  * This method returns a map of all line angle variables stored in the container.
- * 
+ *
  * @return QMap<QString, QSharedPointer<VLineAngle>> A map of line angle variables keyed by their names.
- * 
+ *
  * @details
  * - The method calls `DataVar` with the type `VLineAngle` and the enumeration `VarType::LineAngle`.
  * - It returns the map of line angle variables retrieved from the container.
@@ -978,11 +976,11 @@ const QMap<QString, QSharedPointer<VLineAngle> > VContainer::lineAnglesData() co
 
 /**
  * @brief Retrieves all arc radius variables from the container.
- * 
+ *
  * This method returns a map of all arc radius variables stored in the container.
- * 
+ *
  * @return QMap<QString, QSharedPointer<VArcRadius>> A map of arc radius variables keyed by their names.
- * 
+ *
  * @details
  * - The method calls `DataVar` with the type `VArcRadius` and the enumeration `VarType::ArcRadius`.
  * - It returns the map of arc radius variables retrieved from the container.
@@ -994,11 +992,11 @@ const QMap<QString, QSharedPointer<VArcRadius> > VContainer::arcRadiusesData() c
 
 /**
  * @brief Retrieves all curve angle variables from the container.
- * 
+ *
  * This method returns a map of all curve angle variables stored in the container.
- * 
+ *
  * @return QMap<QString, QSharedPointer<VCurveAngle>> A map of curve angle variables keyed by their names.
- * 
+ *
  * @details
  * - The method calls `DataVar` with the type `VCurveAngle` and the enumeration `VarType::CurveAngle`.
  * - It returns the map of curve angle variables retrieved from the container.
@@ -1010,12 +1008,12 @@ const QMap<QString, QSharedPointer<VCurveAngle> > VContainer::curveAnglesData() 
 
 /**
  * @brief Checks if a name is unique within the container.
- * 
+ *
  * This method checks whether a given name is unique, meaning it is not present in the set of unique names or built-in functions.
- * 
+ *
  * @param name The name to check for uniqueness.
  * @return bool True if the name is unique, false otherwise.
- * 
+ *
  * @details
  * - The method returns true if the specified name is not found in the `uniqueNames` set and the `builInFunctions` set.
  * - If the name is found in either set, the method returns false.
@@ -1027,11 +1025,11 @@ bool VContainer::IsUnique(const QString &name)
 
 /**
  * @brief Retrieves a list of all unique names within the container.
- * 
+ *
  * This method returns a list of all unique names, including both built-in function names and custom unique names.
- * 
+ *
  * @return QStringList A list of all unique names.
- * 
+ *
  * @details
  * - The method initializes a QStringList with the names of built-in functions.
  * - It appends the values from the `uniqueNames` set to this list.
@@ -1046,11 +1044,11 @@ QStringList VContainer::AllUniqueNames()
 
 /**
  * @brief Retrieves the pattern unit associated with the container.
- * 
+ *
  * This method returns a pointer to the pattern unit used by the container.
- * 
+ *
  * @return const Unit* A pointer to the pattern unit.
- * 
+ *
  * @details
  * - The method returns the `patternUnit` pointer stored in the shared data pointer `d`.
  */
@@ -1061,11 +1059,11 @@ const Unit *VContainer::GetPatternUnit() const
 
 /**
  * @brief Retrieves the translation variables associated with the container.
- * 
+ *
  * This method returns a pointer to the translation variables used by the container.
- * 
+ *
  * @return const VTranslateVars* A pointer to the translation variables.
- * 
+ *
  * @details
  * - The method returns the `trVars` pointer stored in the shared data pointer `d`.
  */
@@ -1076,13 +1074,13 @@ const VTranslateVars *VContainer::getTranslateVariables() const
 
 /**
  * @brief Retrieves all variables of a specified type from the container.
- * 
+ *
  * This template method returns a map of all variables of the specified type stored in the container.
- * 
+ *
  * @tparam T The type of the variables to retrieve.
  * @param type The type of variables to retrieve, specified as a `VarType`.
  * @return QMap<QString, QSharedPointer<T>> A map of variables of the specified type, keyed by their names.
- * 
+ *
  * @details
  * - The method initializes an empty QMap to store the variables.
  * - It iterates over the `variables` hash map, checking each variable's type.
@@ -1109,9 +1107,9 @@ const QMap<QString, QSharedPointer<T> > VContainer::DataVar(const VarType &type)
 
 /**
  * @brief Clears the set of unique names.
- * 
+ *
  * This method removes all entries from the set of unique names managed by the container.
- * 
+ *
  * @details
  * - The method clears the `uniqueNames` set, which stores the unique names of variables and objects in the container.
  * - After this operation, the container will no longer have any unique names stored.
@@ -1123,9 +1121,9 @@ void VContainer::ClearUniqueNames()
 
 /**
  * @brief Clears and resets the set of unique variable names.
- * 
+ *
  * This method clears the set of unique names and then reinserts only those names that do not start with a '#' character.
- * 
+ *
  * @details
  * - The method first retrieves all unique names as a QList.
  * - It clears the current set of unique names using `ClearUniqueNames()`.
@@ -1147,12 +1145,12 @@ void VContainer::clearUniqueVariableNames()
 }
 
 /**
- * @brief Sets the size of the container.
- * 
- * This method sets the size attribute of the container to the specified value.
- * 
+ * @brief Sets the multisize measurement size.
+ *
+ * This method sets the multisize measurement size to the specified value.
+ *
  * @param size The new size to set.
- * 
+ *
  * @details
  * - The method updates the static member variable `_size` with the provided value.
  */
@@ -1162,12 +1160,12 @@ void VContainer::setSize(qreal size)
 }
 
 /**
- * @brief Sets the height of the container.
- * 
- * This method sets the height attribute of the container to the specified value.
- * 
+ * @brief Sets the multisize measurement height.
+ *
+ * This method sets the multisize measurement height to the specified value.
+ *
  * @param height The new height to set.
- * 
+ *
  * @details
  * - The method updates the static member variable `_height` with the provided value.
  */
@@ -1177,28 +1175,29 @@ void VContainer::setHeight(qreal height)
 }
 
 /**
- * @brief Returns the size of the container.
- * 
- * This method retrieves the current size attribute of the container.
- * 
- * @return qreal The current size of the container.
- * 
+ * @brief Returns the multisize measurement size.
+ *
+ * This method retrieves the current multisize measurement size.
+ *
+ * @return qreal The current multisize measurement size.
+ *
  * @details
  * - The method returns the value of the static member variable `_size`.
- * - This size value is used in various calculations and operations within the container.
+ * - This size value is used in various calculations and operations.
  */
-qreal VContainer::size()
+qreal VContainer::
++
 {
     return _size;
 }
 
 /**
- * @brief Returns a pointer to the size attribute of the container.
- * 
- * This method retrieves a pointer to the current size attribute of the container.
- * 
- * @return qreal* A pointer to the current size of the container.
- * 
+ * @brief Returns a pointer to the multisize measurement size.
+ *
+ * This method retrieves a pointer to the current the multisize measurement size.
+ *
+ * @return qreal* A pointer to the current the multisize measurement size.
+ *
  * @details
  * - The method returns a pointer to the static member variable `_size`.
  */
@@ -1208,14 +1207,15 @@ qreal *VContainer::rsize()
 }
 
 /**
- * @brief Returns the height of the container.
- * 
- * This method retrieves the current height attribute of the container.
- * 
- * @return qreal The current height of the container.
- * 
+ * @brief Returns the multisize measurement height.
+ *
+ * This method retrieves the current multisize measurement height.
+ *
+ * @return qreal The current multisize measurement height.
+ *
  * @details
  * - The method returns the value of the static member variable `_height`.
+ * - This height value is used in various calculations and operations.
  */
 qreal VContainer::height()
 {
@@ -1223,12 +1223,12 @@ qreal VContainer::height()
 }
 
 /**
- * @brief Returns a pointer to the height attribute of the container.
- * 
- * This method retrieves a pointer to the current height attribute of the container.
- * 
- * @return qreal* A pointer to the current height of the container.
- * 
+ * @brief Returns a pointer to the multisize measurement height.
+ *
+ * This method retrieves a pointer to the current multisize measurement height.
+ *
+ * @return qreal* A pointer to the current multisize measurement height.
+ *
  * @details
  * - The method returns a pointer to the static member variable `_height`.
  */
@@ -1238,12 +1238,12 @@ qreal *VContainer::rheight()
 }
 
 /**
- * @brief Returns a pointer to the container of geometric objects.
- * 
+ * @brief Returns a pointer to the the container of geometric objects.
+ *
  * This method returns a pointer to the internal hash map of geometric objects managed by the container.
- * 
+ *
  * @return const QHash<quint32, QSharedPointer<VGObject> >* A pointer to the hash map of geometric objects.
- * 
+ *
  * @details
  * - The method returns a pointer to the `gObjects` hash map stored in the shared data pointer `d`.
  */
@@ -1254,11 +1254,11 @@ const QHash<quint32, QSharedPointer<VGObject> > *VContainer::DataGObjects() cons
 
 /**
  * @brief Returns a pointer to the container of pieces.
- * 
+ *
  * This method returns a pointer to the internal hash map of pieces managed by the container.
- * 
+ *
  * @return const QHash<quint32, VPiece>* A pointer to the hash map of pieces.
- * 
+ *
  * @details
  * - The method returns a pointer to the `pieces` hash map stored in the shared data pointer `d`.
  */
@@ -1269,11 +1269,11 @@ const QHash<quint32, VPiece> *VContainer::DataPieces() const
 
 /**
  * @brief Returns a pointer to the container of variables.
- * 
+ *
  * This method returns a pointer to the internal hash map of variables managed by the container.
- * 
+ *
  * @return const QHash<QString, QSharedPointer<VInternalVariable>>* A pointer to the hash map of variables.
- * 
+ *
  * @details
  * - The method returns a pointer to the `variables` hash map stored in the shared data pointer `d`.
  */
@@ -1284,9 +1284,9 @@ const QHash<QString, QSharedPointer<VInternalVariable> > *VContainer::DataVariab
 
 /**
  * @brief Destructor for VContainerData.
- * 
+ *
  * This method handles cleanup when a VContainerData object is destroyed.
- * 
+ *
  * @details
  * - The destructor is defined but currently does not perform any specific actions.
  */


### PR DESCRIPTION
This corrects some incorrect comments in vcontainer.cpp.

Mainly the  size(), rsize(), and height() refer to the current multisize measurement size & height, not the container size and height. The VContainer itself has no size() or height(). 