### PR TITLE
feature: use current pen preference

### DIFF
--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
@@ -204,6 +204,9 @@ PreferencesGraphicsViewPage::PreferencesGraphicsViewPage (QWidget *parent)
     // Pan Zoom while Space Key pressed
     ui->panActiveSpacePressed_CheckBox->setChecked(qApp->Seamly2DSettings()->isPanActiveSpaceKey());
 
+    // Always use current pen
+    ui->useCurrentPen_checkBox->setChecked(qApp->Seamly2DSettings()->useCurrentPen());
+
 // Font preferences
     // Pattern piece labels font
     //QFont labelFont = qApp->Seamly2DSettings()->getLabelFont();
@@ -377,6 +380,9 @@ void PreferencesGraphicsViewPage::Apply()
 
     // Pan Zoom while Space key pressed
     settings->setPanActiveSpaceKey(ui->panActiveSpacePressed_CheckBox->isChecked());
+
+    // Always use current pen
+    settings->setUseCurrentPen(ui->useCurrentPen_checkBox->isChecked());
 
     //Fonts
     settings->setLabelFont(ui->labelFont_ComboBox->currentFont());

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
@@ -75,7 +75,7 @@
       <enum>QTabWidget::West</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="appearanceTab">
       <attribute name="title">
@@ -2453,7 +2453,7 @@ border-radius: 4px;
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_16">
        <item>
-        <widget class="QGroupBox" name="constainGroupBox">
+        <widget class="QGroupBox" name="constaints_GroupBox">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -2602,7 +2602,7 @@ border-radius: 4px;
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox">
+        <widget class="QGroupBox" name="zoom_GroupBox">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -2850,6 +2850,33 @@ border-radius: 4px;
              </layout>
             </item>
            </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="pen_GroupBox">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="title">
+          <string>Pen</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_23">
+          <item>
+           <widget class="QCheckBox" name="useCurrentPen_checkBox">
+            <property name="text">
+             <string>Always use current pen</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -136,6 +136,7 @@ const QString settingGraphicsViewAngleDelta              = QStringLiteral("graph
 const QString settingGraphicsViewZoomModKey              = QStringLiteral("graphicsview/zoomModKey");
 const QString settingGraphicsViewZoomDoubleClick         = QStringLiteral("graphicsview/zoomDoubleClick");
 const QString settingGraphicsViewPanActiveSpaceKey       = QStringLiteral("graphicsview/panActiveSpaceKey");
+const QString settingGraphicsViewUseDefaultPen       = QStringLiteral("graphicsview/useCurrentPen");
 const QString settingGraphicsViewZoomSpeedFactor         = QStringLiteral("graphicsview/zoomSpeedFactor");
 const QString settingGraphicsViewExportQuality           = QStringLiteral("graphicsview/exportQuality");
 const QString settingGraphicsViewZoomRBPositiveColor     = QStringLiteral("graphicsview/zoomRBPositiveColor");
@@ -1012,6 +1013,18 @@ bool VCommonSettings::isPanActiveSpaceKey() const
 void VCommonSettings::setPanActiveSpaceKey(const bool &value)
 {
     setValue(settingGraphicsViewPanActiveSpaceKey, value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+bool VCommonSettings::useCurrentPen() const
+{
+    return value(settingGraphicsViewUseDefaultPen, false).toBool();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VCommonSettings::setUseCurrentPen(const bool &value)
+{
+    setValue(settingGraphicsViewUseDefaultPen, value);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vmisc/vcommonsettings.h
+++ b/src/libs/vmisc/vcommonsettings.h
@@ -220,6 +220,9 @@ public:
     bool                 isPanActiveSpaceKey() const;
     void                 setPanActiveSpaceKey(const bool &value);
 
+    bool                 useCurrentPen() const;
+    void                 setUseCurrentPen(const bool &value);
+
     int                  getZoomSpeedFactor() const;
     void                 setZoomSpeedFactor(const int &factor);
 

--- a/src/libs/vtools/dialogs/tools/dialogalongline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogalongline.cpp
@@ -135,9 +135,13 @@ DialogAlongLine::DialogAlongLine(const VContainer *data, const quint32 &toolId, 
 
     vis = new VisToolAlongLine(data);
 
-    // Call after initialization vis!!!!
-    setLineType(LineTypeNone);//By default don't show line
-    setLineWeight("0.35");
+    // Call after visual initialized.
+    // If true current pen overides the default tool pen
+    if(!qApp->Settings()->useCurrentPen())
+    {
+        setLineType(LineTypeNone);  //By default don't show line
+        setLineWeight("0.35");
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogbisector.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogbisector.cpp
@@ -132,9 +132,13 @@ DialogBisector::DialogBisector(const VContainer *data, const quint32 &toolId, QW
 
     vis = new VisToolBisector(data);
 
-    // Call after initialization vis!!!!
-    setLineType(LineTypeDashLine);
-    setLineWeight("0.35");
+    // Call after visual initialized.
+    // If true current pen overides the default tool pen
+    if(!qApp->Settings()->useCurrentPen())
+    {
+        setLineType(LineTypeDashLine);
+        setLineWeight("0.35");
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogheight.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogheight.cpp
@@ -122,9 +122,13 @@ DialogHeight::DialogHeight(const VContainer *data, const quint32 &toolId, QWidge
     connect(ui->comboBoxP2Line,    &QComboBox::currentTextChanged, this, &DialogHeight::PointNameChanged);
 
     vis = new VisToolHeight(data);
-    // Call after initialization vis!!!!
-    setLineType(LineTypeDashLine);
-    setLineWeight("0.35");
+    // Call after visual initialized.
+    // If true current pen overides the default tool pen
+    if(!qApp->Settings()->useCurrentPen())
+    {
+        setLineType(LineTypeDashLine);
+        setLineWeight("0.35");
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialognormal.cpp
+++ b/src/libs/vtools/dialogs/tools/dialognormal.cpp
@@ -131,9 +131,13 @@ DialogNormal::DialogNormal(const VContainer *data, const quint32 &toolId, QWidge
 
     vis = new VisToolNormal(data);
 
-    // Call after initialization vis!!!!
-    setLineType(LineTypeDashLine);
-    setLineWeight("0.35");
+    // Call after visual initialized.
+    // If true current pen overides the default tool pen
+    if(!qApp->Settings()->useCurrentPen())
+    {
+        setLineType(LineTypeDashLine);
+        setLineWeight("0.35");
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp
@@ -131,9 +131,13 @@ DialogShoulderPoint::DialogShoulderPoint(const VContainer *data, const quint32 &
 
     vis = new VisToolShoulderPoint(data);
 
-    // Call after initialization vis!!!!
-    setLineType(LineTypeDashLine);
-    setLineWeight("0.35");
+    // Call after visual initialized.
+    // If true current pen overides the default tool pen
+    if(!qApp->Settings()->useCurrentPen())
+    {
+        setLineType(LineTypeDashLine);
+        setLineWeight("0.35");
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp
@@ -96,9 +96,13 @@ PointIntersectXYDialog::PointIntersectXYDialog(const VContainer *data, const qui
     vis = new PointIntersectXYVisual(data);
     vis->VisualMode(NULL_ID);//Show vertical axis
 
-    // Call after initialization vis!!!!
-    setLineType(LineTypeDashLine);
-    setLineWeight("0.35");
+    // Call after visual initialized.
+    // If true current pen overides the default tool pen
+    if(!qApp->Settings()->useCurrentPen())
+    {
+        setLineType(LineTypeDashLine);
+        setLineWeight("0.35");
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds a preference to always use the current pen, which will override the hardcoded default pen of a few select tools. 
 
![Screenshot 2024-07-02 064939](https://github.com/FashionFreedom/Seamly2D/assets/31944718/64f2209e-7237-4655-b0ac-edbcd1935975)

Closes issue #1131
