### PR TITLE
bug: fix file errors when running collection

### DIFF
--- a/src/libs/ifc/xml/abstract_converter.cpp
+++ b/src/libs/ifc/xml/abstract_converter.cpp
@@ -226,15 +226,15 @@ void VAbstractConverter::saveBackupFile() const
     {
         QString error;
         const QFileInfo info(removeBakExtension(m_convertedFileName));
-        const QString baseFileName = info.baseName();
+        QString baseFileName = info.baseName();
+
+        // replace any spaces in filename with underscore to pevent
+        // errors when opening file in Linux through the command line.
+        baseFileName.replace(" ", "_");
 
         const QString path = qApp->Settings()->getBackupFilePath();
         QString backupFileName;
-        backupFileName = QString("%1/%2%3.%4")
-                                .arg(path)
-                                .arg(baseFileName)
-                                .arg(" (Backup)")
-                                .arg(info.completeSuffix());
+        backupFileName = QString("%1/%2%3.%4").arg(path, baseFileName, "_(backup)", info.completeSuffix());
 
         if (!SafeCopy(m_convertedFileName, backupFileName, error))
         {

--- a/src/libs/ifc/xml/abstract_converter.cpp
+++ b/src/libs/ifc/xml/abstract_converter.cpp
@@ -232,7 +232,11 @@ void VAbstractConverter::saveBackupFile() const
         // errors when opening file in Linux through the command line.
         baseFileName.replace(" ", "_");
 
-        const QString path = qApp->Settings()->getBackupFilePath();
+        QString path = qApp->Settings()->getBackupFilePath();
+        if (!info.exists(path))
+        {
+            path = info.absoluteDir().absolutePath();
+        }
         QString backupFileName;
         backupFileName = QString("%1/%2%3.%4").arg(path, baseFileName, "_(backup)", info.completeSuffix());
 


### PR DESCRIPTION
This fixes the file errors when running the collection tests that prevent chrono CI builds. 

- Check if backup file path exists, if not use path of source file. 
- Replaces any spaces in backup filename with underscores to prevent errors when opening files from command line - such as when running tests. 

![image](https://github.com/FashionFreedom/Seamly2D/assets/31944718/8482b454-a68c-40e0-85f6-fb939920b3f0)
