### PR TITLE
qt6: fix macos, mingw ci build, temporarily disable signing on msvc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
       - name: sign installer
         env:
           PFX_BASE64: ${{ secrets.pfx_base64 }}
-        if: ${{ env.PFX_BASE64 }}
+        if: false # temporarily disable signing until #1104 is solved, then revert to ${{ env.PFX_BASE64 }}        run: |
         run: |
           cd ..\windows-build\
           SignTool sign /fd SHA256 /f ${{ steps.setup_signing.outputs.filePath }} /p ${{ secrets.pfx_password }} /t http://timestamp.sectigo.com Seamly2D-installer.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
   contents: write
 
 env:
-  QT_VERSION: '6.5.2' # quotes required or YAML parser will interpret as float
+  QT_VERSION: '6.5.3' # quotes required or YAML parser will interpret as float
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,13 +258,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Remove preinstalled mingw
-        # we use the same mingw from Qt tools instead of the github actions hosted runner one, so that its as close as possible to developer setup
-        # in addition, the code was not compiling with the provided one and just failing with a nondescript "error 1"
-        shell: bash
-        run: |
-          choco uninstall mingw -y
-
       - uses: jurplel/install-qt-action@v3
         with:
           version: ${{ env.QT_VERSION }}


### PR DESCRIPTION
mingw is no longer preinstalled on windows-latest, so trying to remove it fails, so just dont try.

Xcode 15 (which is default on macos-lastest now) requires at least Qt 6.5.3, see https://bugreports.qt.io/browse/QTBUG-117225

Temporarily disable windows signing as well, see #1107 for the same on main branch