### PR TITLE
No more warning popup when using a math function with a semicolon

### DIFF
--- a/src/libs/qmuparser/qmuparsertokenreader.cpp
+++ b/src/libs/qmuparser/qmuparsertokenreader.cpp
@@ -524,6 +524,7 @@ bool QmuParserTokenReader::IsArgSep ( token_type &a_Tok )
     {
         // copy the separator into null terminated string
         QString szSep;
+        szSep.resize(2);
         szSep[0] = m_cArgSep;
         szSep[1] = 0;
 


### PR DESCRIPTION
solves #1153 