### PR TITLE
Auto scroll when moving pattern piece is now independent from the piece's size

### DIFF
--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -1050,21 +1050,12 @@ QVariant PatternPieceTool::itemChange(QGraphicsItem::GraphicsItemChange change, 
                     const QRectF viewRect = VMainGraphicsView::SceneVisibleArea(view);
                     const QRectF itemRect = mapToScene(boundingRect()|childrenBoundingRect()).boundingRect();
 
-                    // If item's rect is bigger than view's rect ensureVisible works very unstable.
-                    if (itemRect.height() + 2*ymargin < viewRect.height() &&
-                        itemRect.width() + 2*xmargin < viewRect.width())
-                    {
-                        view->ensureVisible(itemRect, xmargin, ymargin);
-                    }
-                    else
-                    {
-                        // Ensure visible only small rect around a cursor
-                        VMainGraphicsScene *currentScene = qobject_cast<VMainGraphicsScene *>(scene());
-                        SCASSERT(currentScene);
-                        const QPointF cursorPosition = currentScene->getScenePos();
-                        view->ensureVisible(QRectF(cursorPosition.x()-5/scale, cursorPosition.y()-5/scale,
-                                                   10/scale, 10/scale));
-                    }
+                    // Ensure visible only small rect around a cursor
+                    VMainGraphicsScene *currentScene = qobject_cast<VMainGraphicsScene *>(scene());
+                    SCASSERT(currentScene);
+                    const QPointF cursorPosition = currentScene->getScenePos();
+                    view->ensureVisible(QRectF(cursorPosition.x()-5/scale, cursorPosition.y()-5/scale,
+                                               10/scale, 10/scale));
                 }
             }
 


### PR DESCRIPTION
Addresses issue #1152 

In piece mode, the view starts to pan automatically with a different threshold depending on if the moved pattern piece is visible in its entirety or if we are zoomed on it. This causes the auto-pan sensibility to be quite random: it's easy to move a pattern piece very far away by mistake. And since the current auto-pan behavior depends on the size of the pattern piece moved, the auto-pan is much more sensible when moving pieces that are big on the screen than it is with small pieces.

The modification I propose here modifies this behavior so that the auto-pan threshold is independent from the pattern piece moved and only depends on the position of the mouse on the screen, like in other softwares.