### PR TITLE
bug: limit fx dialog tabs by parent dialog

### DIFF
--- a/src/app/seamly2d/core/vformulapropertyeditor.cpp
+++ b/src/app/seamly2d/core/vformulapropertyeditor.cpp
@@ -119,7 +119,7 @@ void VFormulaPropertyEditor::SetFormula(const VFormula& formula)
 void VFormulaPropertyEditor::onToolButtonClicked()
 {
     EditFormulaDialog* dialog = new EditFormulaDialog(formula.getData(), formula.getToolId(),
-                                                                qApp->getMainWindow());
+                                                      ToolDialog, qApp->getMainWindow());
     dialog->setCheckZero(formula.getCheckZero());
     dialog->setPostfix(formula.getPostfix());
     dialog->SetFormula(formula.GetFormula(FormulaType::FromUser));

--- a/src/app/seamly2d/dialogs/dialogvariables.cpp
+++ b/src/app/seamly2d/dialogs/dialogvariables.cpp
@@ -850,7 +850,7 @@ void DialogVariables::Fx()
     const QTableWidgetItem *name = ui->variables_TableWidget->item(row, 0);
     QSharedPointer<CustomVariable> variable = data->getVariable<CustomVariable>(name->text());
 
-    EditFormulaDialog *dialog = new EditFormulaDialog(variable->GetData(), NULL_ID, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(variable->GetData(), NULL_ID, VariableDialog, this);
     dialog->setWindowTitle(tr("Edit variable"));
     dialog->SetFormula(qApp->translateVariables()->TryFormulaFromUser(ui->formula_PlainTextEdit->toPlainText().replace("\n", " "),
                                                           qApp->Settings()->getOsSeparator()));

--- a/src/app/seamlyme/tmainwindow.cpp
+++ b/src/app/seamlyme/tmainwindow.cpp
@@ -1518,7 +1518,7 @@ void TMainWindow::Fx()
 		return;
 	}
 
-	EditFormulaDialog *dialog = new EditFormulaDialog(meash->GetData(), NULL_ID, this);
+	EditFormulaDialog *dialog = new EditFormulaDialog(meash->GetData(), NULL_ID, MeasurementDialog, this);
 	dialog->setWindowTitle(tr("Edit measurement"));
 	dialog->SetFormula(qApp->translateVariables()->TryFormulaFromUser(ui->plainTextEditFormula->toPlainText().replace("\n", " "),
 														  true));

--- a/src/libs/vmisc/def.h
+++ b/src/libs/vmisc/def.h
@@ -62,6 +62,14 @@ class QGraphicsItem;
 
 #define HANDLE_SIZE 12
 
+// Bit flags to identify parent dialog type for the Edit Formula dialog and which tabs to hide
+enum DialogSource : quint16
+{
+    ToolDialog        = 511, // 0000 0001 1111 1111
+    VariableDialog    = 259, // 0000 0001 0000 0011
+    MeasurementDialog = 257  // 0000 0001 0000 0001
+};
+
 enum class Position : char
 {
     TopLeft = 0,

--- a/src/libs/vtools/dialogs/support/edit_formula_dialog.cpp
+++ b/src/libs/vtools/dialogs/support/edit_formula_dialog.cpp
@@ -108,7 +108,8 @@ template <class T> class QSharedPointer;
 enum {ColumnName = 0, ColumnFullName};
 
 //---------------------------------------------------------------------------------------------------------------------
-EditFormulaDialog::EditFormulaDialog(const VContainer *data, const quint32 &toolId, QWidget *parent)
+EditFormulaDialog::EditFormulaDialog(const VContainer *data, const quint32 &toolId, const quint16 &source,
+                                     QWidget *parent)
     : DialogTool(data, toolId, parent)
     , ui(new Ui::EditFormulaDialog)
     , m_formula(QString())
@@ -117,6 +118,7 @@ EditFormulaDialog::EditFormulaDialog(const VContainer *data, const quint32 &tool
     , m_checkLessThanZero(false)
     , m_postfix(QString())
     , m_restoreCursor(false)
+    , m_source(source)
 {
     ui->setupUi(this);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -564,10 +566,14 @@ void EditFormulaDialog::initializeVariables()
     connect(ui->menuTab_ListWidget,  &QListWidget::currentRowChanged, this, ClearFilterFormulaInputs);
     connect(ui->checkBoxHideEmpty,   &QCheckBox::stateChanged,        this, &EditFormulaDialog::measurements);
 
-    // Set the selection highlight rect larger than just the item text
+
     for (int i = 0; i < ui->menuTab_ListWidget->count(); ++i)
     {
+        // Set the selection highlight rect larger than just the item text
         ui->menuTab_ListWidget->item(i)->setSizeHint(QSize(ui->menuTab_ListWidget->width(), 50));
+
+        // Set the visibility of tab item depending on source i.e., the parent dialog.
+        ui->menuTab_ListWidget->item(i)->setHidden(!(m_source & (1 << i)));
     }
 }
 

--- a/src/libs/vtools/dialogs/support/edit_formula_dialog.h
+++ b/src/libs/vtools/dialogs/support/edit_formula_dialog.h
@@ -89,7 +89,8 @@ class EditFormulaDialog : public DialogTool
 {
     Q_OBJECT
 public:
-                 EditFormulaDialog(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
+                 EditFormulaDialog(const VContainer *data, const quint32 &toolId,
+                                   const quint16 &source, QWidget *parent = nullptr);
     virtual     ~EditFormulaDialog() Q_DECL_OVERRIDE;
 
     QString      GetFormula() const;
@@ -135,6 +136,7 @@ private:
     bool         m_checkLessThanZero;
     QString      m_postfix;
     bool         m_restoreCursor;
+    quint16      m_source;
 
     void         initializeVariables();
 

--- a/src/libs/vtools/dialogs/tools/dialogalongline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogalongline.cpp
@@ -173,7 +173,7 @@ void DialogAlongLine::PointChanged()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogAlongLine::FXLength()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit length"));
     dialog->SetFormula(GetFormula());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));

--- a/src/libs/vtools/dialogs/tools/dialogarc.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogarc.cpp
@@ -418,7 +418,7 @@ void DialogArc::F2Changed()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogArc::FXRadius()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit radius"));
     dialog->SetFormula(getRadius());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));
@@ -432,7 +432,7 @@ void DialogArc::FXRadius()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogArc::FXF1()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit first angle"));
     dialog->SetFormula(getF1());
     dialog->setPostfix(degreeSymbol);
@@ -446,7 +446,7 @@ void DialogArc::FXF1()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogArc::FXF2()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit second angle"));
     dialog->SetFormula(getF2());
     dialog->setPostfix(degreeSymbol);

--- a/src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp
@@ -370,7 +370,7 @@ void DialogArcWithLength::LengthChanged()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogArcWithLength::FXRadius()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit radius"));
     dialog->SetFormula(GetRadius());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));
@@ -384,7 +384,7 @@ void DialogArcWithLength::FXRadius()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogArcWithLength::FXF1()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit the first angle"));
     dialog->SetFormula(GetF1());
     dialog->setPostfix(degreeSymbol);
@@ -398,7 +398,7 @@ void DialogArcWithLength::FXF1()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogArcWithLength::FXLength()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit the arc length"));
     dialog->SetFormula(GetLength());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));

--- a/src/libs/vtools/dialogs/tools/dialogbisector.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogbisector.cpp
@@ -175,7 +175,7 @@ void DialogBisector::PointNameChanged()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogBisector::FXLength()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit length"));
     dialog->SetFormula(GetFormula());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));

--- a/src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp
@@ -356,7 +356,7 @@ void DialogCurveIntersectAxis::DeployAngleTextEdit()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogCurveIntersectAxis::FXAngle()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit angle"));
     dialog->SetFormula(GetAngle());
     dialog->setPostfix(degreeSymbol);

--- a/src/libs/vtools/dialogs/tools/dialogcutarc.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcutarc.cpp
@@ -118,7 +118,7 @@ void DialogCutArc::FormulaTextChanged()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogCutArc::FXLength()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit length"));
     dialog->SetFormula(GetFormula());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));

--- a/src/libs/vtools/dialogs/tools/dialogcutspline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcutspline.cpp
@@ -234,7 +234,7 @@ void DialogCutSpline::DeployFormulaTextEdit()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogCutSpline::FXLength()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit length"));
     dialog->SetFormula(GetFormula());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));

--- a/src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp
@@ -230,7 +230,7 @@ void DialogCutSplinePath::DeployFormulaTextEdit()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogCutSplinePath::FXLength()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit length"));
     dialog->SetFormula(GetFormula());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));

--- a/src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp
@@ -520,7 +520,7 @@ void DialogEllipticalArc::CheckAngles()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogEllipticalArc::FXRadius1()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit radius1"));
     dialog->SetFormula(GetRadius1());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));
@@ -534,7 +534,7 @@ void DialogEllipticalArc::FXRadius1()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogEllipticalArc::FXRadius2()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit radius2"));
     dialog->SetFormula(GetRadius2());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));
@@ -548,7 +548,7 @@ void DialogEllipticalArc::FXRadius2()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogEllipticalArc::FXF1()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit first angle"));
     dialog->SetFormula(GetF1());
     dialog->setPostfix(degreeSymbol);
@@ -562,7 +562,7 @@ void DialogEllipticalArc::FXF1()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogEllipticalArc::FXF2()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit second angle"));
     dialog->SetFormula(GetF2());
     dialog->setPostfix(degreeSymbol);
@@ -576,7 +576,7 @@ void DialogEllipticalArc::FXF2()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogEllipticalArc::FXRotationAngle()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit rotation angle"));
     dialog->SetFormula(GetRotationAngle());
     dialog->setPostfix(degreeSymbol);

--- a/src/libs/vtools/dialogs/tools/dialogendline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogendline.cpp
@@ -188,7 +188,7 @@ void DialogEndLine::DeployAngleTextEdit()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogEndLine::FXAngle()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit angle"));
     dialog->SetFormula(GetAngle());
     dialog->setPostfix(degreeSymbol);
@@ -202,7 +202,7 @@ void DialogEndLine::FXAngle()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogEndLine::FXLength()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit length"));
     dialog->SetFormula(GetFormula());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));

--- a/src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp
+++ b/src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp
@@ -416,7 +416,7 @@ void DialogLineIntersectAxis::PointNameChanged()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogLineIntersectAxis::FXAngle()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit angle"));
     dialog->SetFormula(GetAngle());
     dialog->setPostfix(degreeSymbol);

--- a/src/libs/vtools/dialogs/tools/dialogmove.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogmove.cpp
@@ -402,7 +402,7 @@ void DialogMove::rotationChanged()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogMove::editAngleFormula()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit angle"));
     dialog->SetFormula(GetAngle());
     dialog->setPostfix(degreeSymbol);
@@ -416,7 +416,7 @@ void DialogMove::editAngleFormula()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogMove::editLengthFormula()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit length"));
     dialog->SetFormula(GetLength());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));
@@ -430,7 +430,7 @@ void DialogMove::editLengthFormula()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogMove::editRotationFormula()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit rotation"));
     dialog->SetFormula(getRotation());
     dialog->setPostfix(degreeSymbol);

--- a/src/libs/vtools/dialogs/tools/dialognormal.cpp
+++ b/src/libs/vtools/dialogs/tools/dialognormal.cpp
@@ -168,7 +168,7 @@ void DialogNormal::PointNameChanged()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogNormal::FXLength()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit length"));
     dialog->SetFormula(GetFormula());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));

--- a/src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp
@@ -155,7 +155,7 @@ void DialogPointOfContact::PointNameChanged()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogPointOfContact::FXRadius()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit radius"));
     dialog->SetFormula(getRadius());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));

--- a/src/libs/vtools/dialogs/tools/dialogrotation.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogrotation.cpp
@@ -350,7 +350,7 @@ void DialogRotation::angleChanged()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogRotation::editAngleFormula()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit angle"));
     dialog->SetFormula(GetAngle());
     dialog->setPostfix(degreeSymbol);

--- a/src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp
@@ -174,7 +174,7 @@ void DialogShoulderPoint::PointNameChanged()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogShoulderPoint::FXLength()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit length"));
     dialog->SetFormula(GetFormula());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));

--- a/src/libs/vtools/dialogs/tools/dialogspline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogspline.cpp
@@ -329,7 +329,7 @@ void DialogSpline::Length2Changed()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogSpline::FXAngle1()
 {
-    auto dialog = new EditFormulaDialog(data, toolId, this);
+    auto dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit first control point angle"));
     QString angle1F = qApp->translateVariables()->TryFormulaFromUser(ui->plainTextEditAngle1F->toPlainText(),
                                                          qApp->Settings()->getOsSeparator());
@@ -352,7 +352,7 @@ void DialogSpline::FXAngle1()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogSpline::FXAngle2()
 {
-    auto dialog = new EditFormulaDialog(data, toolId, this);
+    auto dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit second control point angle"));
     QString angle2F = qApp->translateVariables()->TryFormulaFromUser(ui->plainTextEditAngle2F->toPlainText(),
                                                          qApp->Settings()->getOsSeparator());
@@ -375,7 +375,7 @@ void DialogSpline::FXAngle2()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogSpline::FXLength1()
 {
-    auto dialog = new EditFormulaDialog(data, toolId, this);
+    auto dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit first control point length"));
     QString length1F = qApp->translateVariables()->TryFormulaFromUser(ui->plainTextEditLength1F->toPlainText(),
                                                           qApp->Settings()->getOsSeparator());
@@ -398,7 +398,7 @@ void DialogSpline::FXLength1()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogSpline::FXLength2()
 {
-    auto dialog = new EditFormulaDialog(data, toolId, this);
+    auto dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit second control point length"));
     QString length2F = qApp->translateVariables()->TryFormulaFromUser(ui->plainTextEditLength2F->toPlainText(),
                                                           qApp->Settings()->getOsSeparator());

--- a/src/libs/vtools/dialogs/tools/dialogsplinepath.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogsplinepath.cpp
@@ -546,7 +546,7 @@ void DialogSplinePath::Length2Changed()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogSplinePath::FXAngle1()
 {
-    auto dialog = new EditFormulaDialog(data, toolId, this);
+    auto dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit first control point angle"));
 
     QString angle1F = qApp->translateVariables()->TryFormulaFromUser(ui->plainTextEditAngle1F->toPlainText().replace("\n", " "),
@@ -571,7 +571,7 @@ void DialogSplinePath::FXAngle1()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogSplinePath::FXAngle2()
 {
-    auto dialog = new EditFormulaDialog(data, toolId, this);
+    auto dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit second control point angle"));
 
     QString angle2F = qApp->translateVariables()->TryFormulaFromUser(ui->plainTextEditAngle2F->toPlainText().replace("\n", " "),
@@ -596,7 +596,7 @@ void DialogSplinePath::FXAngle2()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogSplinePath::FXLength1()
 {
-    auto dialog = new EditFormulaDialog(data, toolId, this);
+    auto dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit first control point length"));
 
     QString length1F = qApp->translateVariables()->TryFormulaFromUser(ui->plainTextEditLength1F->toPlainText().replace("\n", " "),
@@ -621,7 +621,7 @@ void DialogSplinePath::FXLength1()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogSplinePath::FXLength2()
 {
-    auto dialog = new EditFormulaDialog(data, toolId, this);
+    auto dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit second control point length"));
 
     QString length2F = qApp->translateVariables()->TryFormulaFromUser(ui->plainTextEditLength2F->toPlainText().replace("\n", " "),

--- a/src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/intersect_circles_dialog.cpp
@@ -304,7 +304,7 @@ void IntersectCirclesDialog::Circle2RadiusChanged()
 //---------------------------------------------------------------------------------------------------------------------
 void IntersectCirclesDialog::FXCircle1Radius()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit first circle radius"));
     dialog->SetFormula(GetFirstCircleRadius());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));
@@ -318,7 +318,7 @@ void IntersectCirclesDialog::FXCircle1Radius()
 //---------------------------------------------------------------------------------------------------------------------
 void IntersectCirclesDialog::FXCircle2Radius()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit second circle radius"));
     dialog->SetFormula(GetSecondCircleRadius());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));

--- a/src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.cpp
@@ -272,7 +272,7 @@ void IntersectCircleTangentDialog::CircleRadiusChanged()
 //---------------------------------------------------------------------------------------------------------------------
 void IntersectCircleTangentDialog::FXCircleRadius()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit radius"));
     dialog->SetFormula(GetCircleRadius());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));

--- a/src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/dialoginternalpath.cpp
@@ -665,7 +665,7 @@ void DialogInternalPath::evaluateAfterWidth()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogInternalPath::editDefaultSeamAllowanceWidth()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit seam allowance width"));
     dialog->SetFormula(getSeamAllowanceWidthFormula());
     dialog->setCheckLessThanZero(true);
@@ -680,7 +680,7 @@ void DialogInternalPath::editDefaultSeamAllowanceWidth()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogInternalPath::editBeforeSeamAllowanceWidth()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit seam allowance width before"));
     dialog->SetFormula(getSeamAllowanceWidthFormulaBefore());
     dialog->setCheckLessThanZero(true);
@@ -695,7 +695,7 @@ void DialogInternalPath::editBeforeSeamAllowanceWidth()
 //---------------------------------------------------------------------------------------------------------------------
 void DialogInternalPath::editAfterSeamAllowanceWidth()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit seam allowance width after"));
     dialog->SetFormula(getSeamAllowanceWidthFormulaAfter());
     dialog->setCheckLessThanZero(true);

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -1981,7 +1981,7 @@ void PatternPieceDialog::editGrainlineFormula()
         return;
     }
 
-    EditFormulaDialog dialog(data, NULL_ID, this);
+    EditFormulaDialog dialog(data, NULL_ID, ToolDialog, this);
     dialog.setWindowTitle(title);
     dialog.SetFormula(qApp->translateVariables()->TryFormulaFromUser(labelFormula->toPlainText(), qApp->Settings()->getOsSeparator()));
     dialog.setCheckZero(checkForZero);
@@ -2038,7 +2038,7 @@ void PatternPieceDialog::editPieceLabelFormula()
         return;
     }
 
-    EditFormulaDialog dialog(data, NULL_ID, this);
+    EditFormulaDialog dialog(data, NULL_ID, ToolDialog, this);
     dialog.setWindowTitle(title);
     dialog.SetFormula(qApp->translateVariables()->TryFormulaFromUser(labelFormula->toPlainText(), qApp->Settings()->getOsSeparator()));
     dialog.setCheckZero(checkForZero);
@@ -2098,7 +2098,7 @@ void PatternPieceDialog::editPatternLabelFormula()
         return;
     }
 
-    EditFormulaDialog dialog(data, NULL_ID, this);
+    EditFormulaDialog dialog(data, NULL_ID, ToolDialog, this);
     dialog.setWindowTitle(title);
     dialog.SetFormula(qApp->translateVariables()->TryFormulaFromUser(labelFormula->toPlainText(), qApp->Settings()->getOsSeparator()));
     dialog.setCheckZero(checkForZero);
@@ -2208,7 +2208,7 @@ void PatternPieceDialog::evaluateAfterWidth()
 //---------------------------------------------------------------------------------------------------------------------
 void PatternPieceDialog::editDefaultSeamAllowanceWidth()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit seam allowance width"));
     dialog->SetFormula(getSeamAllowanceWidthFormula());
     dialog->setCheckLessThanZero(true);
@@ -2223,7 +2223,7 @@ void PatternPieceDialog::editDefaultSeamAllowanceWidth()
 //---------------------------------------------------------------------------------------------------------------------
 void PatternPieceDialog::editBeforeSeamAllowanceWidth()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit seam allowance width before"));
     dialog->SetFormula(getFormulaFromUser(ui->beforeWidthFormula_PlainTextEdit));
     dialog->setCheckLessThanZero(true);
@@ -2238,7 +2238,7 @@ void PatternPieceDialog::editBeforeSeamAllowanceWidth()
 //---------------------------------------------------------------------------------------------------------------------
 void PatternPieceDialog::editAfterSeamAllowanceWidth()
 {
-    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, this);
+    EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit seam allowance width after"));
     dialog->SetFormula(getFormulaFromUser(ui->afterWidthFormula_PlainTextEdit));
     dialog->setCheckLessThanZero(true);

--- a/src/libs/vtools/tools/vabstracttool.cpp
+++ b/src/libs/vtools/tools/vabstracttool.cpp
@@ -212,7 +212,7 @@ qreal VAbstractTool::CheckFormula(const quint32 &toolId, QString &formula, VCont
                     const UndoButton resultUndo = dialogUndo->Result();
                     if (resultUndo == UndoButton::Fix)
                     {
-                        auto *dialog = new EditFormulaDialog(data, toolId, qApp->getMainWindow());
+                        auto *dialog = new EditFormulaDialog(data, toolId, ToolDialog, qApp->getMainWindow());
                         dialog->setWindowTitle(tr("Edit wrong formula"));
                         dialog->SetFormula(formula);
                         if (dialog->exec() == QDialog::Accepted)


### PR DESCRIPTION
This fixes the fx dialog usable tabs depending on the parent dialog. 

If the FX dialog is opened from the Variables table the Tool Variables are removed:

![Screenshot 2024-08-20 100751](https://github.com/user-attachments/assets/09572f32-e245-48ca-a093-f2be760b84d0)


If the F dialog is opened in SeamlyMe the Custom Variables and the Tool Variables are removed. 

![Screenshot 2024-08-20 100826](https://github.com/user-attachments/assets/f8e2cac8-ccc2-4cf5-aa13-60678a794bd6)


closes issue #1178 