### PR TITLE
bug: Fix linetype combobox in prop editor

### DIFF
--- a/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
+++ b/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
@@ -688,7 +688,7 @@ void VToolOptionsPropertyBrowser::addPropertyLineType(Tool *tool, const QString 
     QMap<QString, QString> lineTypes = lineTypeList();
     if (tool->type() == VToolLine::Type)
     {
-        lineTypes.remove(LineTypeNone);
+        lineTypes = lineTypeNoPenRemovedList();
     }
     lineTypeProperty->setLineTypes(lineTypes);
 
@@ -706,8 +706,8 @@ template<class Tool>
 void VToolOptionsPropertyBrowser::addPropertyCurveLineType(Tool *tool, const QString &propertyName)
 {
     VPE::LineTypeProperty *penStyleProperty = new VPE::LineTypeProperty(propertyName);
-    penStyleProperty->setLineTypes(curveLineTypeList());
-    const qint32 index = VPE::LineTypeProperty::indexOfLineType(curveLineTypeList(), tool->GetPenStyle());
+    penStyleProperty->setLineTypes(lineTypeNoPenRemovedList());
+    const qint32 index = VPE::LineTypeProperty::indexOfLineType(lineTypeNoPenRemovedList(), tool->GetPenStyle());
     if (index == -1)
     {
         qWarning() << "Can't find line type" << tool->getLineType() <<  "in list";
@@ -750,7 +750,7 @@ void VToolOptionsPropertyBrowser::addPropertyLineColor(Tool *tool, const QString
 //
 // Adds a direction combobox property to the Property Editor form widget. Gets the combobox index to
 // the tool's direction. Throws a warning if the property is not found in the combobox item list.
-// If the index exists it sets the combobox index to the tool's direction. 
+// If the index exists it sets the combobox index to the tool's direction.
 //
 // @tparam tool Tool of the property.
 // @param propertyName Name of the property.
@@ -2606,7 +2606,7 @@ void VToolOptionsPropertyBrowser::showOptionsToolLine(QGraphicsItem *item)
     formView->setTitle(tr("Line"));
 
     addPropertyLabel(tr("Selection"), AttrName);
-    addPropertyLineName(tool, AttrObjName, true);
+    addPropertyLineName(tool, tr("Name:"), true);
     addObjectProperty(tool, tool->FirstPointName(), tr("First point:"), AttrFirstPoint, GOType::Point);
     addObjectProperty(tool, tool->SecondPointName(), tr("Second point:"), AttrSecondPoint, GOType::Point);
 
@@ -3155,7 +3155,7 @@ void VToolOptionsPropertyBrowser::updateOptionsToolArc()
     }
 
     {
-        const qint32 index = VPE::LineTypeProperty::indexOfLineType(curveLineTypeList(), tool->GetPenStyle());
+        const qint32 index = VPE::LineTypeProperty::indexOfLineType(lineTypeNoPenRemovedList(), tool->GetPenStyle());
         idToProperty[AttrPenStyle]->setValue(index);
     }
 
@@ -3196,7 +3196,7 @@ void VToolOptionsPropertyBrowser::updateOptionsToolArcWithLength()
     }
 
     {
-        const qint32 index = VPE::LineTypeProperty::indexOfLineType(curveLineTypeList(), tool->GetPenStyle());
+        const qint32 index = VPE::LineTypeProperty::indexOfLineType(lineTypeNoPenRemovedList(), tool->GetPenStyle());
         idToProperty[AttrPenStyle]->setValue(index);
     }
 
@@ -3409,7 +3409,7 @@ void VToolOptionsPropertyBrowser::updateOptionsToolLine()
     }
 
     {
-        const qint32 index = VPE::LineTypeProperty::indexOfLineType(lineTypeList(), tool->getLineType());
+        const qint32 index = VPE::LineTypeProperty::indexOfLineType(lineTypeNoPenRemovedList(), tool->getLineType());
         idToProperty[AttrLineType]->setValue(index);
     }
 
@@ -3788,7 +3788,7 @@ void VToolOptionsPropertyBrowser::updateOptionsToolSpline()
                                                                             tool->getLineColor()));
 
     {
-        const qint32 index = VPE::LineTypeProperty::indexOfLineType(curveLineTypeList(), tool->GetPenStyle());
+        const qint32 index = VPE::LineTypeProperty::indexOfLineType(lineTypeNoPenRemovedList(), tool->GetPenStyle());
         idToProperty[AttrPenStyle]->setValue(index);
     }
 
@@ -3809,7 +3809,7 @@ void VToolOptionsPropertyBrowser::updateOptionsToolCubicBezier()
                                                                             tool->getLineColor()));
 
     {
-        const qint32 index = VPE::LineTypeProperty::indexOfLineType(curveLineTypeList(), tool->GetPenStyle());
+        const qint32 index = VPE::LineTypeProperty::indexOfLineType(lineTypeNoPenRemovedList(), tool->GetPenStyle());
         idToProperty[AttrPenStyle]->setValue(index);
     }
 
@@ -3854,7 +3854,7 @@ void VToolOptionsPropertyBrowser::updateOptionsToolSplinePath()
                                                                             tool->getLineColor()));
 
     {
-        const qint32 index = VPE::LineTypeProperty::indexOfLineType(curveLineTypeList(), tool->GetPenStyle());
+        const qint32 index = VPE::LineTypeProperty::indexOfLineType(lineTypeNoPenRemovedList(), tool->GetPenStyle());
         idToProperty[AttrPenStyle]->setValue(index);
     }
 
@@ -3876,7 +3876,7 @@ void VToolOptionsPropertyBrowser::updateOptionsToolCubicBezierPath()
                                                                             tool->getLineColor()));
 
     {
-        const qint32 index = VPE::LineTypeProperty::indexOfLineType(curveLineTypeList(), tool->GetPenStyle());
+        const qint32 index = VPE::LineTypeProperty::indexOfLineType(lineTypeNoPenRemovedList(), tool->GetPenStyle());
         idToProperty[AttrPenStyle]->setValue(index);
     }
 
@@ -4114,7 +4114,7 @@ void VToolOptionsPropertyBrowser::updateOptionsToolEllipticalArc()
     }
 
     {
-        const qint32 index = VPE::LineTypeProperty::indexOfLineType(curveLineTypeList(), tool->GetPenStyle());
+        const qint32 index = VPE::LineTypeProperty::indexOfLineType(lineTypeNoPenRemovedList(), tool->GetPenStyle());
         idToProperty[AttrPenStyle]->setValue(index);
     }
 

--- a/src/libs/ifc/ifcdef.cpp
+++ b/src/libs/ifc/ifcdef.cpp
@@ -229,7 +229,7 @@ QString PenStyleToLineType(Qt::PenStyle penStyle)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QMap<QString, QString> curveLineTypeList()
+QMap<QString, QString> lineTypeNoPenRemovedList()
 {
     QMap<QString, QString> map = lineTypeList();
     map.remove(LineTypeNone);

--- a/src/libs/ifc/ifcdef.h
+++ b/src/libs/ifc/ifcdef.h
@@ -188,7 +188,7 @@ QStringList            LineTypes();
 Qt::PenStyle           lineTypeToPenStyle(const QString &lineType);
 QString                PenStyleToLineType(Qt::PenStyle penStyle);
 QMap<QString, QString> lineTypeList();
-QMap<QString, QString> curveLineTypeList();
+QMap<QString, QString> lineTypeNoPenRemovedList();
 
 QMap<QString, QString> lineWeightList();
 QMap<QString, QString> directionList();

--- a/src/libs/vtools/dialogs/tools/dialogalongline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogalongline.cpp
@@ -204,7 +204,7 @@ DialogAlongLine::~DialogAlongLine()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialogarc.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogarc.cpp
@@ -325,7 +325,7 @@ void DialogArc::setRadius(const QString &value)
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialogbisector.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogbisector.cpp
@@ -206,7 +206,7 @@ DialogBisector::~DialogBisector()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialogcutarc.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcutarc.cpp
@@ -149,7 +149,7 @@ DialogCutArc::~DialogCutArc()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialogcutspline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcutspline.cpp
@@ -181,7 +181,7 @@ void DialogCutSpline::setSplineId(const quint32 &value)
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp
@@ -177,7 +177,7 @@ void DialogCutSplinePath::setSplinePathId(const quint32 &value)
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp
@@ -696,7 +696,7 @@ void DialogEllipticalArc::DeployRotationAngleTextEdit()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialogendline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogendline.cpp
@@ -215,7 +215,7 @@ void DialogEndLine::FXLength()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialogheight.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogheight.cpp
@@ -246,7 +246,7 @@ void DialogHeight::SetP2LineId(const quint32 &value)
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialogline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogline.cpp
@@ -262,7 +262,7 @@ void DialogLine::SaveData()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialoglineintersect.cpp
+++ b/src/libs/vtools/dialogs/tools/dialoglineintersect.cpp
@@ -117,7 +117,7 @@ DialogLineIntersect::~DialogLineIntersect()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialognormal.cpp
+++ b/src/libs/vtools/dialogs/tools/dialognormal.cpp
@@ -199,7 +199,7 @@ DialogNormal::~DialogNormal()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogpointofcontact.cpp
@@ -180,7 +180,7 @@ void DialogPointOfContact::DeployFormulaTextEdit()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp
@@ -205,7 +205,7 @@ DialogShoulderPoint::~DialogShoulderPoint()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialogspline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogspline.cpp
@@ -192,7 +192,7 @@ DialogSpline::~DialogSpline()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/dialogsplinepath.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogsplinepath.cpp
@@ -262,7 +262,7 @@ void DialogSplinePath::setLineColor(const QString &value)
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type don't show this id in list
  */

--- a/src/libs/vtools/dialogs/tools/dialogtriangle.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogtriangle.cpp
@@ -109,7 +109,7 @@ DialogTriangle::~DialogTriangle()
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp
@@ -236,7 +236,7 @@ void PointIntersectXYDialog::setLineColor(const QString &value)
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save right data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
  * @param id id of point or detail
  * @param type type of object
  */

--- a/src/libs/vtools/dialogs/tools/union_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/union_dialog.cpp
@@ -99,7 +99,7 @@ bool UnionDialog::retainPieces() const
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief ChoosedObject gets id and type of selected object. Save correct data and ignore wrong.
+ * @brief ChosenObject gets id and type of selected object. Save correct data and ignore wrong.
  * @param id id of point or piece
  * @param type type of object
  */

--- a/src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp
+++ b/src/libs/vtools/tools/drawTools/operation/vabstractoperation.cpp
@@ -633,7 +633,7 @@ void VAbstractOperation::InitCurve(quint32 id, VContainer *data, GOType curveTyp
     {
         showContextMenu(event, id);
     });
-    connect(curve, &VSimpleCurve::Choosed, this, [this, sceneType](quint32 id)
+    connect(curve, &VSimpleCurve::Chosen, this, [this, sceneType](quint32 id)
     {
         emit chosenTool(id, sceneType);
     });
@@ -701,7 +701,7 @@ QT_WARNING_DISABLE_GCC("-Wswitch-default")
                 point->setParentItem(this);
                 point->SetType(GOType::Point);
                 point->setToolTip(complexPointToolTip(item.id));
-                connect(point, &VSimplePoint::Choosed, this, [this](quint32 id)
+                connect(point, &VSimplePoint::Chosen, this, [this](quint32 id)
                 {
                     emit chosenTool(id, SceneObject::Point);
                 });

--- a/src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.cpp
@@ -90,7 +90,7 @@ VToolDoublePoint::VToolDoublePoint(VAbstractPattern *doc, VContainer *data, quin
     firstPoint = new VSimplePoint(p1id, QColor(qApp->Settings()->getPointNameColor()));
     firstPoint->setParentItem(this);
     firstPoint->setToolTip(complexToolTip(p1id));
-    connect(firstPoint, &VSimplePoint::Choosed, this, &VToolDoublePoint::point1Chosen);
+    connect(firstPoint, &VSimplePoint::Chosen, this, &VToolDoublePoint::point1Chosen);
     connect(firstPoint, &VSimplePoint::Selected, this, &VToolDoublePoint::point1Selected);
     connect(firstPoint, &VSimplePoint::showContextMenu, this, &VToolDoublePoint::showContextMenu);
     connect(firstPoint, &VSimplePoint::Delete, this, &VToolDoublePoint::deletePoint);
@@ -100,7 +100,7 @@ VToolDoublePoint::VToolDoublePoint(VAbstractPattern *doc, VContainer *data, quin
     secondPoint = new VSimplePoint(p2id, QColor(qApp->Settings()->getPointNameColor()));
     secondPoint->setParentItem(this);
     secondPoint->setToolTip(complexToolTip(p2id));
-    connect(secondPoint, &VSimplePoint::Choosed, this, &VToolDoublePoint::point2Chosen);
+    connect(secondPoint, &VSimplePoint::Chosen, this, &VToolDoublePoint::point2Chosen);
     connect(secondPoint, &VSimplePoint::Selected, this, &VToolDoublePoint::point2Selected);
     connect(secondPoint, &VSimplePoint::showContextMenu, this, &VToolDoublePoint::showContextMenu);
     connect(secondPoint, &VSimplePoint::Delete, this, &VToolDoublePoint::deletePoint);

--- a/src/libs/vwidgets/vmaingraphicsscene.h
+++ b/src/libs/vwidgets/vmaingraphicsscene.h
@@ -135,7 +135,7 @@ signals:
     void          ItemClicked(QGraphicsItem* pItem);
 
     /**
-     * @brief ChosenObject send option choosed object.
+     * @brief ChosenObject send option Chosen object.
      * @param id object id.
      * @param type object scene type.
      */

--- a/src/libs/vwidgets/vsimplecurve.cpp
+++ b/src/libs/vwidgets/vsimplecurve.cpp
@@ -99,9 +99,9 @@ void VSimpleCurve::RefreshGeometry(const QSharedPointer<VAbstractCurve> &curve)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VSimpleCurve::CurveChoosed()
+void VSimpleCurve::CurveChosen()
 {
-    emit Choosed(id);
+    emit Chosen(id);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -130,7 +130,7 @@ void VSimpleCurve::mousePressEvent(QGraphicsSceneMouseEvent *event)
     {
         if (event->button() == Qt::LeftButton)
         {
-            emit Choosed(id);
+            emit Chosen(id);
         }
     }
 }
@@ -142,7 +142,7 @@ void VSimpleCurve::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
     {
         if (event->button() == Qt::LeftButton)
         {
-            emit Choosed(id);
+            emit Chosen(id);
         }
     }
     QGraphicsPathItem::mouseReleaseEvent(event);

--- a/src/libs/vwidgets/vsimplecurve.h
+++ b/src/libs/vwidgets/vsimplecurve.h
@@ -82,14 +82,14 @@ public:
     void RefreshGeometry(const QSharedPointer<VAbstractCurve> &curve);
 signals:
     /**
-     * @brief Choosed send id when clicked.
+     * @brief Chosen send id when clicked.
      * @param id point id.
      */
-    void Choosed(quint32 id);
+    void Chosen(quint32 id);
     void Selected(bool selected, quint32 id);
 
 public slots:
-    void CurveChoosed();
+    void CurveChosen();
     void CurveSelected(bool selected);
 
 protected:

--- a/src/libs/vwidgets/vsimplepoint.cpp
+++ b/src/libs/vwidgets/vsimplepoint.cpp
@@ -146,7 +146,7 @@ void VSimplePoint::deletePoint()
 //---------------------------------------------------------------------------------------------------------------------
 void VSimplePoint::pointChosen()
 {
-    emit Choosed(id);
+    emit Chosen(id);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -187,7 +187,7 @@ void VSimplePoint::mousePressEvent(QGraphicsSceneMouseEvent *event)
         {
             if (event->button() == Qt::LeftButton)
             {
-                emit Choosed(id);
+                emit Chosen(id);
             }
         }
     }
@@ -202,7 +202,7 @@ void VSimplePoint::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
         {
             if (event->button() == Qt::LeftButton)
             {
-                emit Choosed(id);
+                emit Chosen(id);
             }
         }
         VScenePoint::mouseReleaseEvent(event);

--- a/src/libs/vwidgets/vsimplepoint.h
+++ b/src/libs/vwidgets/vsimplepoint.h
@@ -95,10 +95,10 @@ public:
 
 signals:
     /**
-     * @brief Choosed send id when clicked.
+     * @brief Chosen send id when clicked.
      * @param id point id.
      */
-    void Choosed(quint32 id);
+    void Chosen(quint32 id);
     void Selected(bool selected, quint32 id);
     void nameChangedPosition(const QPointF &pos, quint32 id);
 


### PR DESCRIPTION
This PR fixes the issue with the linetype combobox in the Properties Editor with the Line tool. 

The tool now updates properly when the Dash Dot Dot linetype is selected. 

Closes issue #1179 