### PR TITLE
fix: issue with parsed image ids solved

### DIFF
--- a/src/app/seamly2d/xml/vpattern.cpp
+++ b/src/app/seamly2d/xml/vpattern.cpp
@@ -969,6 +969,8 @@ void VPattern::parseImageElement(QDomElement &domElement, const Document &parse)
     image.basepoint = GetParametrUInt(domElement, AttrBasepoint, 0);
     image.visible = getParameterBool(domElement, AttrVisible, trueStr);
 
+    VContainer::UpdateId(image.id);
+
     if(parse == Document::FullParse)
     {
         ImageTool *image_tool = new ImageTool(this, this, draftScene, image);


### PR DESCRIPTION
The "_id" value was not updated when images were parsed.
If the image was the last item to be parsed, the next item to be created was taking the same id as the image, thus creating issues.

Fixes #1184 