### PR TITLE
fix: char can be signed or unsigned depending on platform, make it explicit

### DIFF
--- a/src/libs/vtools/dialogs/tools/dialogtool.h
+++ b/src/libs/vtools/dialogs/tools/dialogtool.h
@@ -97,7 +97,7 @@ class QPlainTextEdit;
 class VAbstractTool;
 
 enum class FillComboBox : char {Whole, NoChildren};
-enum class DialogPosition : char {Offset = -7, BottomRight, BottomLeft, Center, TopRight, TopLeft};
+enum class DialogPosition : signed char {Offset = -7, BottomRight, BottomLeft, Center, TopRight, TopLeft};
 
 /**
  * @brief The DialogTool class parent for all dialog of tools.


### PR DESCRIPTION
chars can be signed or unsigned by default, as we expect signed here, make it
explicit.

Fixes error on arm64:

./../vtools/dialogs/tools/dialogtool.h:100:45: error: enumerator value ‘-7’ is outside the range of underlying type ‘char’
  100 | enum class DialogPosition : char {Offset = -7, BottomRight, BottomLeft, Center, TopRight, TopLeft};
      |
