### PR TITLE
Pattern pieces grouped in exported SVGs

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Opravdu chcete smazat?</translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7193,10 +7205,6 @@ Chcete uložit své změny?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7351,10 +7359,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation>Střih</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9878,6 +9882,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Střih</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -4186,7 +4186,7 @@ for writing</source>
         <translation>Date %1 kann nicht zum schreiben geöffnet werden</translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file
+        <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
@@ -4838,6 +4838,18 @@ Possibly the file is already being downloaded.</source>
         <source>Do you really want to delete?</source>
         <translation>Möchtest Du wirklich löschen?</translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -5295,7 +5307,8 @@ Das Programm wird WIE ES IST, OHNE GEWÄHRLEISTUNG JEGLICHER ART, EINSCHLIESSLIC
         <translation>Millimeter</translation>
     </message>
     <message>
-        <source>Margins go beyond printing.
+        <source>Margins go beyond printing. 
+
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7200,10 +7213,6 @@ Sollen die Änderungen gespeichert werden?</translation>
         <translation>Bilder</translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation>Bilddatei öffnen</translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation>Zoom zum Punkt</translation>
     </message>
@@ -7367,10 +7376,6 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     <message>
         <source>Can&apos;t create a path</source>
         <translation>Ein Verzeichnis kann nicht erstellt werden</translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation>Schnittmuster</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9896,6 +9901,18 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <source>Backward (from end point)</source>
         <translation>Rückwärts (vom Endpunkt)</translation>
     </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished">Bilder</translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished">Bilddatei öffnen</translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Schnittmuster</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -10324,13 +10341,13 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <translation>Zoll</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed.
+        <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10398,13 +10415,13 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Legt den Klickton für die Knotenauswahl fest.</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed.
+        <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Θέλετε σίγουρα να κάνετε διαγραφή;</translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7193,10 +7205,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished">Εικόνες</translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7351,10 +7359,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation>Δεν είναι δυνατή η δημιουργία μονοπατιού</translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation>Πατρόν</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9878,6 +9882,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished">Εικόνες</translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Πατρόν</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Do you really want to delete?</translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7196,10 +7208,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished">Images</translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7354,10 +7362,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation type="unfinished">Pattern</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9881,6 +9885,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished">Images</translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Pattern</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7196,10 +7208,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7354,10 +7362,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation type="unfinished">Pattern</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9881,6 +9885,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Pattern</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Do you really want to delete?</translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7196,10 +7208,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished">Images</translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7354,10 +7362,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation type="unfinished">Pattern</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9881,6 +9885,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished">Images</translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Pattern</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7196,10 +7208,6 @@ Do you want to save your changes?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7354,10 +7362,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation type="unfinished">Pattern</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9881,6 +9885,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Pattern</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -4227,7 +4227,7 @@ Do you want to download it?</source>
 ¿Quiere descargarla?</translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file
+        <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
@@ -4879,6 +4879,18 @@ Possibly the file is already being downloaded.</source>
         <source>Do you really want to delete?</source>
         <translation>¿Realmente quiere eliminarlo?</translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -5336,7 +5348,8 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
         <translation>Ninguno</translation>
     </message>
     <message>
-        <source>Margins go beyond printing.
+        <source>Margins go beyond printing. 
+
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7245,10 +7258,6 @@ Do you want to save your changes?</source>
         <translation>Imágenes</translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation>Abrir archivo de imagen</translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation>Zoom al punto</translation>
     </message>
@@ -7407,10 +7416,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation>No se puede crear un ruta</translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation>Patrón</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9954,6 +9959,18 @@ actualización:</translation>
         <source>Backward (from end point)</source>
         <translation>Hacia atrás (desde el punto final)</translation>
     </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished">Imágenes</translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished">Abrir archivo de imagen</translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Patrón</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -10382,13 +10399,13 @@ actualización:</translation>
         <translation>Pulgadas</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed.
+        <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10456,13 +10473,13 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Establece el sonido del clic de selección del nodo.</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed.
+        <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Haluatko todella poistaa?</translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7193,10 +7205,6 @@ Haluatko tallentaa muutokset?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7351,10 +7359,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation>Kaava</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9878,6 +9882,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Kaava</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Voulez vous vraiment supprimer?</translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7196,10 +7208,6 @@ Voulez-vous sauvegarder les changements?</translation>
         <translation type="unfinished">Images</translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7354,10 +7362,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation>Patron</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9881,6 +9885,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished">Images</translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Patron</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7192,10 +7204,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7349,10 +7357,6 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Can&apos;t create a path</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9876,6 +9880,18 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Backward (from end point)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7193,10 +7205,6 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7351,10 +7359,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation>Pola</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9878,6 +9882,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Pola</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Vuoi veramente cancellare?</translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7196,10 +7208,6 @@ Vuoi salvare i cambiamenti?</translation>
         <translation type="unfinished">Immagini</translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7354,10 +7362,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation>Modello</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9881,6 +9885,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished">Immagini</translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Modello</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -4171,12 +4171,6 @@ for writing</source>
         <translation>Kan bestand %1 niet openen voor schrijven</translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file
-%1
-Possibly the file is already being downloaded.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>File download failed: %1.</source>
         <translation>Download bestand mislukt: %1.</translation>
     </message>
@@ -4192,6 +4186,12 @@ Possibly the file is already being downloaded.</source>
         <source>A new release %1 is available.
 Do you want to download it?</source>
         <translation>Een nieuwe versie %1 is beschikbaar. Wil je het downloaden?</translation>
+    </message>
+    <message>
+        <source>Unable to get exclusive access to file 
+%1
+Possibly the file is already being downloaded.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4840,6 +4840,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Wil je dit echt verwijderen?</translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -5160,12 +5172,6 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Kleiner wordend gebied</translation>
     </message>
     <message>
-        <source>Margins go beyond printing.
-
-Apply settings anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Centimeters</source>
         <translation>Centimeters</translation>
     </message>
@@ -5291,6 +5297,12 @@ Apply settings anyway?</source>
     <message>
         <source>Millimeters</source>
         <translation>Millimeters</translation>
+    </message>
+    <message>
+        <source>Margins go beyond printing. 
+
+Apply settings anyway?</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7201,10 +7213,6 @@ Wil je de veranderingen opslaan?</translation>
         <translation>Afbeeldingen</translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation>Zoom in op Punt</translation>
     </message>
@@ -7359,10 +7367,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation>Kan geen pad maken</translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation>Patroon</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9887,6 +9891,18 @@ Press enter to temporarily add it to the list.</source>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished">Afbeeldingen</translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Patroon</translation>
+    </message>
 </context>
 <context>
     <name>QmuParser</name>
@@ -10287,23 +10303,12 @@ Press enter to temporarily add it to the list.</source>
         <translation>Decimaal scheidingsteken:</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
-When unchecked the period is used.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>GUI language:</source>
         <translation>GUI taal:</translation>
     </message>
     <message>
         <source>Sets the language used for SeamlyMe.</source>
         <translation>Stelt de taal in die wordt gebruikt voor SeamlyMe.</translation>
-    </message>
-    <message>
-        <source>When checked the Welcome window will not be displayed.
-You can change this setting in the SeamlyMe preferences.</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Do not show again</source>
@@ -10324,6 +10329,17 @@ You can change this setting in the SeamlyMe preferences.</source>
     <message>
         <source>Inches</source>
         <translation>Inches</translation>
+    </message>
+    <message>
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
+When unchecked the period is used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When checked the Welcome window will not be displayed. 
+You can change this setting in the SeamlyMe preferences.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10349,19 +10365,8 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Decimaal scheidingsteken:</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
-When unchecked the period is used.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>GUI language:</source>
         <translation>GUI taal:</translation>
-    </message>
-    <message>
-        <source>When checked the Welcome window will not be displayed.
-You can change this setting in the Seamly2D preferences.</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Do not show again</source>
@@ -10398,6 +10403,17 @@ You can change this setting in the Seamly2D preferences.</source>
     <message>
         <source>Sets the node selection click  sound.</source>
         <translation>Stelt het klikgeluid van de knooppuntselectie in.</translation>
+    </message>
+    <message>
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
+When unchecked the period is used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When checked the Welcome window will not be displayed. 
+You can change this setting in the Seamly2D preferences.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7192,10 +7204,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished">Imagens</translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7350,10 +7358,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation>Molde</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9877,6 +9881,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished">Imagens</translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Molde</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7192,10 +7204,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7350,10 +7358,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation>Model</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9877,6 +9881,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Model</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -4864,6 +4864,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Вы точно хотите удалить?</translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7221,10 +7233,6 @@ Do you want to save your changes?</source>
         <translation>Изображения</translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation>Зум до точки</translation>
     </message>
@@ -7383,10 +7391,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation>Невозможно создать контур</translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation>Выкройка</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9913,6 +9917,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished">Изображения</translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Выкройка</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished">Ви дійсно хочете видалити?</translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7195,10 +7207,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished">Зображення</translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7353,10 +7361,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation>Лекало</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9880,6 +9884,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished">Зображення</translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">Лекало</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -4835,6 +4835,18 @@ Do you want to download it?</source>
         <source>Do you really want to delete?</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No image was selected...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>InsertNodesDialog</name>
@@ -7192,10 +7204,6 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Image File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Zoom to Point</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7350,10 +7358,6 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Can&apos;t create a path</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pattern</source>
-        <translation>样板</translation>
     </message>
     <message>
         <source>One or more pattern pieces are bigger than the paper format you selected. Please select a bigger paper format.</source>
@@ -9877,6 +9881,18 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Images</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Image File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pattern</source>
+        <translation type="unfinished">样板</translation>
     </message>
 </context>
 <context>

--- a/src/app/seamly2d/mainwindowsnogui.cpp
+++ b/src/app/seamly2d/mainwindowsnogui.cpp
@@ -894,6 +894,20 @@ void MainWindowsNoGUI::exportSVG(const QString &name, QGraphicsRectItem *paper, 
     svgGenerator.generate();
 }
 
+void MainWindowsNoGUI::exportSVG(const QString &name, QGraphicsRectItem *paper, const QList<QGraphicsItem *> &pieces) const
+{
+    SvgGenerator svgGenerator(paper, name, doc->GetDescription(), static_cast<int>(PrintDPI));
+
+    for (int pieceNb=0; pieceNb<pieces.size(); pieceNb++)
+    {
+        QGraphicsScene *scene = new VMainGraphicsScene();
+        scene->addItem(pieces.at(pieceNb));
+        svgGenerator.addSvgFromScene(scene);
+    }
+
+    svgGenerator.generate();
+}
+
 //---------------------------------------------------------------------------------------------------------------------
 /**
  * @brief exportPNG save layout to png file.
@@ -1622,7 +1636,7 @@ void MainWindowsNoGUI::ExportScene(const ExportLayoutDialog &dialog, const QList
             {
                 case LayoutExportFormat::SVG:
                     paper->setVisible(false);
-                    exportSVG(name, paper, scene);
+                    exportSVG(name, paper, pieces.at(i));
                     paper->setVisible(true);
                     break;
                 case LayoutExportFormat::PDF:

--- a/src/app/seamly2d/mainwindowsnogui.cpp
+++ b/src/app/seamly2d/mainwindowsnogui.cpp
@@ -67,6 +67,7 @@
 #include "../vpatterndb/measurements_def.h"
 #include "../vtools/tools/vabstracttool.h"
 #include "../vtools/tools/pattern_piece_tool.h"
+#include "../../libs/vformat/svg_generator.h"
 
 #include <QFileDialog>
 #include <QFileInfo>
@@ -888,21 +889,9 @@ QList<QGraphicsScene *> MainWindowsNoGUI::CreateScenes(const QList<QGraphicsItem
  */
 void MainWindowsNoGUI::exportSVG(const QString &name, QGraphicsRectItem *paper, QGraphicsScene *scene) const
 {
-    QSvgGenerator generator;
-    generator.setFileName(name);
-    generator.setSize(paper->rect().size().toSize());
-    generator.setViewBox(paper->rect());
-    generator.setTitle(tr("Pattern"));
-    generator.setDescription(doc->GetDescription());
-    generator.setResolution(static_cast<int>(PrintDPI));
-    QPainter painter;
-    painter.begin(&generator);
-    painter.setFont( QFont( "Arial", 8, QFont::Normal ) );
-    painter.setRenderHint(QPainter::Antialiasing, true);
-    //painter.setPen(QPen(Qt::black, widthHairLine, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
-    painter.setBrush ( QBrush ( Qt::NoBrush ) );
-    scene->render(&painter, paper->rect(), paper->rect(), Qt::IgnoreAspectRatio);
-    painter.end();
+    SvgGenerator svgGenerator(paper, name, doc->GetDescription(), static_cast<int>(PrintDPI));
+    svgGenerator.addSvgFromScene(scene);
+    svgGenerator.generate();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/app/seamly2d/mainwindowsnogui.h
+++ b/src/app/seamly2d/mainwindowsnogui.h
@@ -84,6 +84,7 @@ public slots:
     void refreshGrainLines();
     void refreshSeamAllowances();
     void exportSVG(const QString &name, QGraphicsRectItem *paper, QGraphicsScene *scene)const;
+    void exportSVG(const QString &name, QGraphicsRectItem *paper, const QList<QGraphicsItem *> &pieces)const;
     void exportPNG(const QString &name, QGraphicsScene *scene)const;
     void exportTIF(const QString &name, QGraphicsScene *scene)const;
     void exportJPG(const QString &name, QGraphicsScene *scene)const;

--- a/src/libs/vformat/svg_generator.cpp
+++ b/src/libs/vformat/svg_generator.cpp
@@ -4,6 +4,8 @@
  **  @date   September 21, 2024
  **
  **  @brief
+ **  Custom SVG generator to handle groups in SVGs
+ **
  **  @copyright
  **  This source code is part of the Seamly2D project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.
@@ -46,11 +48,14 @@ SvgGenerator::SvgGenerator(QGraphicsRectItem *paper, QString name, QString descr
 
 QDomDocument SvgGenerator::mergeSvgDoms()
 {
-    /* m_domList contains DOM representations of multiple SVGs
-    Assuming each svg contains a main group containing every graphical item of the svg,
-    this function adds to the first svg of the list all the main groups of the other svgs,
-    thus creating a single svg with each svg of the list in it, every svg being in its own group.
-    This function is used in order to create svgs containing groups*/
+    /*@brief Merge all the SVGs in the m_domList list into a single SVG
+     @return The merged SVG as a DOM document
+     @details m_domList contains DOM representations of multiple SVGs
+     Assuming each svg contains a main group containing every graphical item of the svg,
+     this function adds to the first svg of the list all the main groups of the other svgs,
+     thus creating a single svg with each svg of the list in it, every svg being in its own group.
+     This function is used in order to create svgs containing groups
+     */
 
     if (m_domList.isEmpty()) {
         qDebug() << "Error : the SVG list is empty";
@@ -86,6 +91,13 @@ QDomDocument SvgGenerator::mergeSvgDoms()
 
 void SvgGenerator::addSvgFromScene(QGraphicsScene *scene)
 {
+    /*@brief Add a new SVG to the list of SVGs to be merged into a single SVG
+      @param scene : the scene that must be converted to SVG
+      @return void
+      @details This function creates a SVG from the given scene and converts it into
+      a DOM that is added to the m_domList list of SVGs to be merged.
+    */
+
     QByteArray byteArray;
     QBuffer buffer(&byteArray);
     buffer.open(QIODevice::WriteOnly);
@@ -119,6 +131,12 @@ void SvgGenerator::addSvgFromScene(QGraphicsScene *scene)
 
 void SvgGenerator::generate()
 {
+    /*@brief Generate the merged SVG where each previously given scene is grouped separately.
+      @return void
+      @details This function merges the SVGs of the m_domList list and writes the result
+      in a file at the path given in the constructor.
+    */
+
     QDomDocument mergedSvg = mergeSvgDoms();
 
     QFile outputFile(m_filepath);

--- a/src/libs/vformat/svg_generator.cpp
+++ b/src/libs/vformat/svg_generator.cpp
@@ -35,6 +35,8 @@
 #include <QPainter>
 #include <QBuffer>
 
+
+//---------------------------------------------------------------------------------------------------------------------
 SvgGenerator::SvgGenerator(QGraphicsRectItem *paper, QString name, QString description, int resolution):
     m_paper(paper),
     m_filepath(name),
@@ -44,17 +46,18 @@ SvgGenerator::SvgGenerator(QGraphicsRectItem *paper, QString name, QString descr
 }
 
 
+//---------------------------------------------------------------------------------------------------------------------
+/**
+ * @brief Merge all the SVGs in the m_domList list into a single SVG
+ * @return The merged SVG as a DOM document
+ * @details m_domList contains DOM representations of multiple SVGs
+            Assuming each svg contains a main group containing every graphical item of the svg,
+            this function adds to the first svg of the list all the main groups of the other svgs,
+            thus creating a single svg with each svg of the list in it, every svg being in its own group.
+            This function is used in order to create svgs containing groups
+ */
 QDomDocument SvgGenerator::mergeSvgDoms()
 {
-    /*@brief Merge all the SVGs in the m_domList list into a single SVG
-     @return The merged SVG as a DOM document
-     @details m_domList contains DOM representations of multiple SVGs
-     Assuming each svg contains a main group containing every graphical item of the svg,
-     this function adds to the first svg of the list all the main groups of the other svgs,
-     thus creating a single svg with each svg of the list in it, every svg being in its own group.
-     This function is used in order to create svgs containing groups
-     */
-
     if (m_domList.isEmpty()) {
         qDebug() << "Error : the SVG list is empty";
         return QDomDocument();
@@ -87,14 +90,18 @@ QDomDocument SvgGenerator::mergeSvgDoms()
     return mergedSvg;
 }
 
+
+//---------------------------------------------------------------------------------------------------------------------
+/**
+ * @brief Add a new SVG to the list of SVGs to be merged into a single SVG
+ * @param scene : the scene that must be converted to SVG
+ * @return void
+ * @details This function creates a SVG from the given scene and converts it into
+            a DOM that is added to the m_domList list of SVGs to be merged.
+*/
 void SvgGenerator::addSvgFromScene(QGraphicsScene *scene)
 {
-    /*@brief Add a new SVG to the list of SVGs to be merged into a single SVG
-      @param scene : the scene that must be converted to SVG
-      @return void
-      @details This function creates a SVG from the given scene and converts it into
-      a DOM that is added to the m_domList list of SVGs to be merged.
-    */
+
 
     QByteArray byteArray;
     QBuffer buffer(&byteArray);
@@ -127,13 +134,16 @@ void SvgGenerator::addSvgFromScene(QGraphicsScene *scene)
 }
 
 
+//---------------------------------------------------------------------------------------------------------------------
+/**
+ * @brief Generate the merged SVG where each previously given scene is grouped separately.
+ * @return void
+ * @details This function merges the SVGs of the m_domList list and writes the result
+            in a file at the path given in the constructor.
+*/
 void SvgGenerator::generate()
 {
-    /*@brief Generate the merged SVG where each previously given scene is grouped separately.
-      @return void
-      @details This function merges the SVGs of the m_domList list and writes the result
-      in a file at the path given in the constructor.
-    */
+
 
     QDomDocument mergedSvg = mergeSvgDoms();
 

--- a/src/libs/vformat/svg_generator.cpp
+++ b/src/libs/vformat/svg_generator.cpp
@@ -1,0 +1,182 @@
+/******************************************************************************
+ **  @file   svg_generator.cpp
+ **  @author Evans PERRET
+ **  @date   September 21, 2024
+ **
+ **  @brief
+ **  @copyright
+ **  This source code is part of the Seamly2D project, a pattern making
+ **  program, whose allow create and modeling patterns of clothing.
+ **  Copyright (C) 2013-2022 Seamly2D project
+ **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+ **
+ *****************************************************************************/
+
+#include "svg_generator.h"
+#include <QFile>
+#include <QDir>
+#include <QDebug>
+#include <QSvgGenerator>
+#include <QGraphicsItem>
+#include <QPainter>
+#include <QFileInfo>
+
+SvgGenerator::SvgGenerator(QGraphicsRectItem *paper, QString name, QString description, int resolution):
+    m_svgCounter(0),
+    m_paper(paper),
+    m_filepath(name),
+    m_description(description),
+    m_resolution(resolution),
+    m_tempSvgPrefix("tempSvg")
+{
+    QFileInfo fileInfo(m_filepath);
+    m_folderPath = fileInfo.absolutePath();
+    m_name = fileInfo.baseName();
+    m_tempSvgFolderName = m_tempSvgPrefix + "_" + m_name;
+}
+
+
+bool SvgGenerator::loadSvgIntoDom(QDomDocument &domDocument, const QString &filePath)
+{
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        qDebug() << "Error : Impossible to open the SVG file :" << filePath;
+        return false;
+    }
+    if (!domDocument.setContent(&file)) {
+        qDebug() << "Error : Impossible to load the SVG content in the QDomDocument.";
+        file.close();
+        return false;
+    }
+    file.close();
+    return true;
+}
+
+QDomDocument SvgGenerator::mergeSvgDoms(const QList<QDomDocument> &domList)
+{
+    /*domList contains DOM representations of multiple SVG
+    Assuming each svg contains a main group containing every graphical item of the svg,
+    this function adds to the first svg of the list all the main groups of the other svgs,
+    thus creating a single svg with each svg of the list in it, every svg being in its own group.
+    This function is used in order to create svgs containing groups*/
+
+    if (domList.isEmpty()) {
+        qDebug() << "Error : the SVG list is empty";
+        return QDomDocument();
+    }
+
+    QDomDocument mergedSvg = domList.at(0);
+
+    QDomElement mergedSvgRoot = mergedSvg.documentElement();
+    if (mergedSvgRoot.tagName() != "svg") {
+        qDebug() << "Error : the first SVG does not contain a <svg> tag.";
+        return QDomDocument();
+    }
+
+    for (int i = 1; i < domList.size(); ++i) {
+        QDomDocument domSvg = domList.at(i);
+        QDomElement svgRoot = domSvg.documentElement();
+        if (svgRoot.tagName() != "svg") {
+            qDebug() << "Error : the SVG does not contain a <svg> tag.";
+            return QDomDocument();
+        }
+        QDomNodeList svgGroups = svgRoot.elementsByTagName("g");
+        if (svgGroups.isEmpty()) {
+            qDebug() << "Error : the SVG does not contain a <g> tag.";
+            return QDomDocument();
+        }
+        QDomElement mainGroup = svgGroups.at(0).toElement();
+        mergedSvgRoot.appendChild(mainGroup);
+    }
+
+    return mergedSvg;
+}
+
+void SvgGenerator::addSvgFromScene(QGraphicsScene *scene)
+{
+    m_svgCounter++;
+
+    QSvgGenerator svgGenerator;
+    svgGenerator.setFileName(getTempFilePath(m_svgCounter));
+    svgGenerator.setSize(m_paper->rect().size().toSize());
+    svgGenerator.setViewBox(m_paper->rect());
+    svgGenerator.setTitle(QObject::tr("Pattern"));
+    svgGenerator.setDescription(m_description);
+    svgGenerator.setResolution(m_resolution);
+
+    QPainter painter;
+    painter.begin(&svgGenerator);
+    painter.setFont( QFont( "Arial", 8, QFont::Normal ) );
+    painter.setRenderHint(QPainter::Antialiasing, true);
+    painter.setBrush ( QBrush ( Qt::NoBrush ) );
+    scene->render(&painter, m_paper->rect(), m_paper->rect(), Qt::IgnoreAspectRatio);
+    painter.end();
+}
+
+
+void SvgGenerator::generate()
+{
+    QList<QDomDocument> domList;
+
+    for(int i = 1; i <= m_svgCounter; i++)
+    {
+        QDomDocument domDoc;
+        QString path = getTempFilePath(i);
+        QFile file(path);
+        if (!file.exists()) {
+            qDebug() << "Error : the SVG file does not exist.";
+            continue;
+        }
+        loadSvgIntoDom(domDoc, path);
+        domList.append(domDoc);
+
+        if (!file.remove()) {
+            qDebug() << "Error : unable to remove " << path;
+        }
+    }
+
+    QDomDocument mergedSvg = mergeSvgDoms(domList);
+
+    QFile outputFile(m_filepath);
+    if (!outputFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qDebug() << "Error : Couldn't write the output file.";
+    }
+
+    QTextStream stream(&outputFile);
+    stream << mergedSvg.toString();
+    outputFile.close();
+
+    QDir dir(m_folderPath);
+    if(!dir.rmdir(m_tempSvgFolderName))
+    {
+        qDebug() << "Error : Couldn't remove the temp SVG folder.";
+    }
+
+    qDebug() << "Merged SVG Generated!";
+}
+
+
+QString SvgGenerator::getTempFilePath(int id)
+{
+    QDir dir(m_folderPath);
+    if (!dir.cd(m_tempSvgFolderName))
+    {
+        dir.mkdir(m_tempSvgFolderName);
+        dir.cd(m_tempSvgFolderName);
+    }
+
+    return dir.path() + "/" + m_tempSvgPrefix + "_" + m_name + "_" + QString::number(id) + ".svg";
+}

--- a/src/libs/vformat/svg_generator.cpp
+++ b/src/libs/vformat/svg_generator.cpp
@@ -29,12 +29,10 @@
 
 #include "svg_generator.h"
 #include <QFile>
-#include <QDir>
 #include <QDebug>
 #include <QSvgGenerator>
 #include <QGraphicsItem>
 #include <QPainter>
-#include <QFileInfo>
 #include <QBuffer>
 
 SvgGenerator::SvgGenerator(QGraphicsRectItem *paper, QString name, QString description, int resolution):

--- a/src/libs/vformat/svg_generator.h
+++ b/src/libs/vformat/svg_generator.h
@@ -1,0 +1,59 @@
+/******************************************************************************
+ **  @file   svg_generator.h
+ **  @author Evans PERRET
+ **  @date   September 21, 2024
+ **
+ **  @brief
+ **  @copyright
+ **  This source code is part of the Seamly2D project, a pattern making
+ **  program, whose allow create and modeling patterns of clothing.
+ **  Copyright (C) 2013-2022 Seamly2D project
+ **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ **
+ **  Seamly2D is free software: you can redistribute it and/or modify
+ **  it under the terms of the GNU General Public License as published by
+ **  the Free Software Foundation, either version 3 of the License, or
+ **  (at your option) any later version.
+ **
+ **  Seamly2D is distributed in the hope that it will be useful,
+ **  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ **  GNU General Public License for more details.
+ **
+ **  You should have received a copy of the GNU General Public License
+ **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+ **
+ *****************************************************************************/
+
+#ifndef SVG_GENERATOR_H
+#define SVG_GENERATOR_H
+
+#include <QDomDocument>
+#include <QGraphicsScene>
+
+
+class SvgGenerator
+{
+public:
+    SvgGenerator(QGraphicsRectItem *paper, QString name, QString description, int resolution);
+    void addSvgFromScene(QGraphicsScene *scene);
+    void generate();
+
+
+private:
+    bool loadSvgIntoDom(QDomDocument &domDocument, const QString &filePath);
+    QDomDocument mergeSvgDoms(const QList<QDomDocument> &domList);
+    QString getTempFilePath(int id);
+
+    int m_svgCounter;
+    QGraphicsRectItem *m_paper;
+    QString m_filepath;
+    QString m_folderPath;
+    QString m_name;
+    QString m_description;
+    int m_resolution;
+    QString m_tempSvgFolderName;
+    QString m_tempSvgPrefix;
+};
+
+#endif // SVG_GENERATOR_H

--- a/src/libs/vformat/svg_generator.h
+++ b/src/libs/vformat/svg_generator.h
@@ -4,6 +4,8 @@
  **  @date   September 21, 2024
  **
  **  @brief
+ **  Custom SVG generator to handle groups in SVGs
+ **
  **  @copyright
  **  This source code is part of the Seamly2D project, a pattern making
  **  program, whose allow create and modeling patterns of clothing.

--- a/src/libs/vformat/svg_generator.h
+++ b/src/libs/vformat/svg_generator.h
@@ -41,19 +41,14 @@ public:
 
 
 private:
-    bool loadSvgIntoDom(QDomDocument &domDocument, const QString &filePath);
-    QDomDocument mergeSvgDoms(const QList<QDomDocument> &domList);
-    QString getTempFilePath(int id);
+    QDomDocument mergeSvgDoms();
 
-    int m_svgCounter;
     QGraphicsRectItem *m_paper;
     QString m_filepath;
-    QString m_folderPath;
-    QString m_name;
     QString m_description;
     int m_resolution;
-    QString m_tempSvgFolderName;
-    QString m_tempSvgPrefix;
+
+    QList<QDomDocument> m_domList;
 };
 
 #endif // SVG_GENERATOR_H

--- a/src/libs/vformat/vformat.pri
+++ b/src/libs/vformat/vformat.pri
@@ -3,6 +3,7 @@
 
 SOURCES += \
     $$PWD/measurements.cpp \
+    $$PWD/svg_generator.cpp \
     $$PWD/vlabeltemplate.cpp
 
 *msvc*:SOURCES += $$PWD/stable.cpp
@@ -10,4 +11,5 @@ SOURCES += \
 HEADERS += \
     $$PWD/measurements.h \
     $$PWD/stable.h \
+    $$PWD/svg_generator.h \
     $$PWD/vlabeltemplate.h

--- a/src/libs/vformat/vformat.pro
+++ b/src/libs/vformat/vformat.pro
@@ -9,7 +9,7 @@ message("Entering vformat.pro")
 include(../../../common.pri)
 
 # Library work with xml.
-QT       += xml xmlpatterns printsupport
+QT       += xml xmlpatterns printsupport svg
 
 # We don't need gui library.
 QT       -= gui


### PR DESCRIPTION
When a SVG is generated from piece or layout mode, each pattern piece is in its own group.

To achieve that, I decided to manually modify the generated xml files manipulating the corresponding DOM trees, because Qt doesn't allow to add groups into exported SVG files.

When a user exports a SVG named `foo.svg`, the software will create a `tempSvg_foo` directory into the destination directory, create a SVG (`tempSVG_foo_xx.svg`) for each pattern piece to be exported, and then merge all the SVG together to group them separately. After the process, all the temporary files and folders are automatically deleted.

I'm not super happy about the software creating temporary files into the destination directory though... is there another (better) place where I could generate those temporary files ? @DSCaskey 