### PR TITLE
Svg export is not failing anymore due to the pattern description

### DIFF
--- a/src/libs/vformat/svg_generator.cpp
+++ b/src/libs/vformat/svg_generator.cpp
@@ -112,7 +112,6 @@ void SvgGenerator::addSvgFromScene(QGraphicsScene *scene)
     svgGenerator.setSize(m_paper->rect().size().toSize());
     svgGenerator.setViewBox(m_paper->rect());
     svgGenerator.setTitle(QObject::tr("Pattern"));
-    svgGenerator.setDescription(m_description);
     svgGenerator.setResolution(m_resolution);
 
     QPainter painter;


### PR DESCRIPTION
I noticed that all my Aldrich patterns could be exported in svg but not my Müller & Sohn patterns (an empty svg file was generated)... What a strange behavior 🤣

After a quick investigation, here's the reason:

* The pattern description (in file > pattern preferences > pattern) was written into the svg files.
* The svg files are stored in QDomDocuments in the software in order to modify them and group the pattern pieces.
* The QDomDocuments don't accept every character, for instance they are not allowing... 🥁🥁🥁 the "&" of Müller & Sohn.

At least 3 possible solutions:
* Find a list of all the forbidden characters and replace them before generating the svg.
* Change the svg generator so it doen't use QDomDocuments anymore.
or
* Remove the description from the svg files.

I chose the 3rd option. I may be unaware that this description is useful for some people, but honestly I don't think so. In fact, I couldn't even find a way to read this particular description using Inkscape. The description field of the document preferences stays empty.