### PR TITLE
bug: fix draggable menu items in pattern pieces & pref dialogs

### DIFF
--- a/src/app/seamly2d/dialogs/dialogpreferences.ui
+++ b/src/app/seamly2d/dialogs/dialogpreferences.ui
@@ -129,6 +129,9 @@
          <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
           <normaloff>:/icon/graphics_view_config.png</normaloff>:/icon/graphics_view_config.png</iconset>
         </property>
+        <property name="flags">
+         <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
+        </property>
        </item>
       </widget>
      </item>
@@ -179,8 +182,8 @@
   </layout>
  </widget>
  <resources>
-  <include location="../../../libs/vmisc/share/resources/theme.qrc"/>
   <include location="../../../libs/vmisc/share/resources/icon.qrc"/>
+  <include location="../../../libs/vmisc/share/resources/theme.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
@@ -135,6 +135,9 @@ QListWidget::item:selected {
          <iconset resource="../../../../vmisc/share/resources/icon.qrc">
           <normaloff>:/icon/160x64/properties.png</normaloff>:/icon/160x64/properties.png</iconset>
         </property>
+        <property name="flags">
+         <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
+        </property>
        </item>
        <item>
         <property name="text">
@@ -161,6 +164,9 @@ QListWidget::item:selected {
          <iconset resource="../../../../vmisc/share/resources/icon.qrc">
           <normaloff>:/icon/160x64/paths.png</normaloff>:/icon/160x64/paths.png</iconset>
         </property>
+        <property name="flags">
+         <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
+        </property>
        </item>
        <item>
         <property name="text">
@@ -181,6 +187,9 @@ QListWidget::item:selected {
         <property name="icon">
          <iconset resource="../../../../vmisc/share/resources/icon.qrc">
           <normaloff>:/icon/160x64/seam_allowance.png</normaloff>:/icon/160x64/seam_allowance.png</iconset>
+        </property>
+        <property name="flags">
+         <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
         </property>
        </item>
        <item>
@@ -208,6 +217,9 @@ QListWidget::item:selected {
          <iconset resource="../../../../vmisc/share/resources/icon.qrc">
           <normaloff>:/icon/160x64/labels.png</normaloff>:/icon/160x64/labels.png</iconset>
         </property>
+        <property name="flags">
+         <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
+        </property>
        </item>
        <item>
         <property name="text">
@@ -233,6 +245,9 @@ QListWidget::item:selected {
         <property name="icon">
          <iconset resource="../../../../vmisc/share/resources/icon.qrc">
           <normaloff>:/icon/160x64/anchor_point.png</normaloff>:/icon/160x64/anchor_point.png</iconset>
+        </property>
+        <property name="flags">
+         <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
         </property>
        </item>
        <item>
@@ -260,6 +275,9 @@ QListWidget::item:selected {
          <iconset resource="../../../../vmisc/share/resources/icon.qrc">
           <normaloff>:/icon/160x64/grainlines.png</normaloff>:/icon/160x64/grainlines.png</iconset>
         </property>
+        <property name="flags">
+         <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
+        </property>
        </item>
        <item>
         <property name="text">
@@ -285,6 +303,9 @@ QListWidget::item:selected {
         <property name="icon">
          <iconset resource="../../../../vmisc/share/resources/icon.qrc">
           <normaloff>:/icon/160x64/notches.png</normaloff>:/icon/160x64/notches.png</iconset>
+        </property>
+        <property name="flags">
+         <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled</set>
         </property>
        </item>
       </widget>
@@ -4776,8 +4797,8 @@ QListWidget::item:selected {
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>362</width>
-              <height>558</height>
+              <width>264</width>
+              <height>486</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -5706,8 +5727,8 @@ QListWidget::item:selected {
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../../../vmisc/share/resources/theme.qrc"/>
   <include location="../../../../vmisc/share/resources/icon.qrc"/>
+  <include location="../../../../vmisc/share/resources/theme.qrc"/>
  </resources>
  <connections>
   <connection>
@@ -5744,7 +5765,7 @@ QListWidget::item:selected {
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="notchSubType_ButtonGroup"/>
   <buttongroup name="notchType_ButtonGroup"/>
+  <buttongroup name="notchSubType_ButtonGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
This PR disables dragging the menu items in the Preferences and Pattern Piece dialogs which prevents them from dragging and dropping. 

closes issue#1205