### PR TITLE
bug: Fix grainline arrows

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -9743,6 +9743,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -4186,7 +4186,7 @@ for writing</source>
         <translation>Date %1 kann nicht zum schreiben geöffnet werden</translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file 
+        <source>Unable to get exclusive access to file
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
@@ -5307,7 +5307,7 @@ Das Programm wird WIE ES IST, OHNE GEWÄHRLEISTUNG JEGLICHER ART, EINSCHLIESSLIC
         <translation>Millimeter</translation>
     </message>
     <message>
-        <source>Margins go beyond printing. 
+        <source>Margins go beyond printing.
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
@@ -9761,6 +9761,14 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <source>Hide Seam Line</source>
         <translation>Nahtlinie ausblenden</translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation>Länge der Pfeile</translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation"> px</translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>
@@ -10341,13 +10349,13 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <translation>Zoll</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10415,13 +10423,13 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Legt den Klickton für die Knotenauswahl fest.</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -9763,11 +9763,11 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     </message>
     <message>
         <source>Arrow length:</source>
-        <translation>Länge der Pfeile</translation>
+        <translation>Länge der Pfeile:</translation>
     </message>
     <message>
         <source> px</source>
-        <translation"> px</translation>
+        <translation> px</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -9743,6 +9743,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -9746,6 +9746,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -9746,6 +9746,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -9746,6 +9746,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -9746,6 +9746,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -9820,11 +9820,11 @@ actualización:</translation>
     </message>
     <message>
         <source>Arrow length:</source>
-        <translation>Longitud de flecha</translation>
+        <translation>Longitud de flecha:</translation>
     </message>
     <message>
         <source> px</source>
-        <translation type="unfinished"> px</translation>
+        <translation> px</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -4227,7 +4227,7 @@ Do you want to download it?</source>
 ¿Quiere descargarla?</translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file 
+        <source>Unable to get exclusive access to file
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
@@ -5348,7 +5348,7 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
         <translation>Ninguno</translation>
     </message>
     <message>
-        <source>Margins go beyond printing. 
+        <source>Margins go beyond printing.
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
@@ -9818,6 +9818,14 @@ actualización:</translation>
         <source>Hide Seam Line</source>
         <translation>Ocultar línea de costura</translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation>Longitud de flecha</translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"> px</translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>
@@ -10399,13 +10407,13 @@ actualización:</translation>
         <translation>Pulgadas</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10473,13 +10481,13 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Establece el sonido del clic de selección del nodo.</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -9743,6 +9743,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -9746,6 +9746,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -9742,6 +9742,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -9743,6 +9743,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -9746,6 +9746,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -9751,6 +9751,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation>Verberg Stiklijn</translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"> px</translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -9742,6 +9742,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -9742,6 +9742,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -9778,6 +9778,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation>Скрыть линию шва</translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"> пиксели</translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -9745,6 +9745,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -9742,6 +9742,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Hide Seam Line</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Arrow length:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> px</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>QCoreApplication</name>

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp
@@ -145,7 +145,7 @@ void PreferencesPatternPage::Apply()
     settings->setDefaultGrainlineLength(ui->defaultGrainlineLength_DoubleSpinBox->value());
     settings->setDefaultGrainlineColor(ui->defaultGrainlineColor_ComboBox->currentData().toString());
     settings->setDefaultGrainlineLineweight(ui->defaultGrainlineLineweight_ComboBox->currentData().toReal());
-
+    settings->setDefaultArrowLength(ui->defaultArrowLength_DoubleSpinBox->value());
 
     settings->setShowPatternLabels(ui->showPatternLabels_CheckBox->isChecked());
     settings->setShowPieceLabels(ui->showPieceLabels_CheckBox->isChecked());
@@ -384,7 +384,10 @@ void PreferencesPatternPage::initGrainlines()
     {
         ui->defaultGrainlineLineweight_ComboBox->setCurrentIndex(index);
     }
+
+    ui->defaultArrowLength_DoubleSpinBox->setValue(qApp->Seamly2DSettings()->getDefaultArrowLength());
 }
+
 //---------------------------------------------------------------------------------------------------------------------
 void PreferencesPatternPage::initComboBoxFormats(QComboBox *box, const QStringList &items, const QString &currentFormat)
 {

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
@@ -34,57 +34,614 @@
   <property name="styleSheet">
    <string notr="true">background-color: rgb(240, 240, 240);</string>
   </property>
-  <widget class="QTabWidget" name="tabWidget_2">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>10</y>
-     <width>465</width>
-     <height>555</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="minimumSize">
-    <size>
-     <width>465</width>
-     <height>0</height>
-    </size>
-   </property>
-   <property name="maximumSize">
-    <size>
-     <width>16777215</width>
-     <height>16777215</height>
-    </size>
-   </property>
-   <property name="font">
-    <font>
-     <pointsize>9</pointsize>
-    </font>
-   </property>
-   <property name="tabPosition">
-    <enum>QTabWidget::West</enum>
-   </property>
-   <property name="currentIndex">
-    <number>0</number>
-   </property>
-   <widget class="QWidget" name="tab_4">
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <attribute name="title">
-     <string>Pattern Piece</string>
-    </attribute>
-    <layout class="QVBoxLayout" name="verticalLayout_15">
-     <item>
-      <widget class="QGroupBox" name="WorkPiece_GroupBox">
+  <layout class="QVBoxLayout" name="verticalLayout_25">
+   <item>
+    <widget class="QTabWidget" name="tabWidget_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>465</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>9</pointsize>
+      </font>
+     </property>
+     <property name="tabPosition">
+      <enum>QTabWidget::West</enum>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="tab_4">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <attribute name="title">
+       <string>Pattern Piece</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_15">
+       <item>
+        <widget class="QGroupBox" name="WorkPiece_GroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>420</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>9</pointsize>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="title">
+          <string>Properties</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_9">
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_7">
+            <item>
+             <widget class="QCheckBox" name="showSeamAllowances_CheckBox">
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string>Show Cut Line</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="hideSeamLine_CheckBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string>By default hide the main path if the seam allowance was enabled</string>
+              </property>
+              <property name="text">
+               <string>Hide Seam Line</string>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="forbidFlipping_CheckBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="toolTip">
+               <string>By default forbid flipping for all new created workpieces</string>
+              </property>
+              <property name="text">
+               <string>Forbid flipping</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>440</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_5">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <attribute name="title">
+       <string>Notches</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QGroupBox" name="notchPorperties_GroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>420</width>
+           <height>80</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>9</pointsize>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="title">
+          <string>Properties</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <item>
+           <widget class="QCheckBox" name="showSeamAllowanceNotch_CheckBox">
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Show notch on Cut Line</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="showSeamlineNotch_CheckBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="toolTip">
+             <string>Show notch on both the seam allowance and seam line.</string>
+            </property>
+            <property name="text">
+             <string>Show notch on Seam Line</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="Attribute_GroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>150</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="title">
+          <string>Attributes</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_14">
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_5">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_4">
+              <item>
+               <widget class="QLabel" name="defaultNotchType_Label">
+                <property name="minimumSize">
+                 <size>
+                  <width>120</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Type:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="defaultNotchType_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>120</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="currentIndex">
+                 <number>-1</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_6">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>147</width>
+                  <height>13</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_6">
+              <item>
+               <widget class="QLabel" name="notchColor_Label">
+                <property name="minimumSize">
+                 <size>
+                  <width>120</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Color:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="ColorComboBox" name="defaultNotchColor_ComboBox">
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font/>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_8">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>160</width>
+                  <height>15</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_5">
+              <item>
+               <widget class="QLabel" name="defaultNotchLength_Label">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>120</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Length:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QDoubleSpinBox" name="defaultNotchLength_DoubleSpinBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>120</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">background-color: rgb(255, 255, 255);</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="minimum">
+                 <double>0.125000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>1.500000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+                <property name="value">
+                 <double>0.125000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>160</width>
+                  <height>15</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_7">
+              <item>
+               <widget class="QLabel" name="defaultNotchWidth_Label">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>120</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Width:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QDoubleSpinBox" name="defaultNotchWidth_DoubleSpinBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>120</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true">background-color: rgb(255, 255, 255);</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="decimals">
+                 <number>3</number>
+                </property>
+                <property name="singleStep">
+                 <double>0.050000000000000</double>
+                </property>
+                <property name="value">
+                 <double>0.250000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_7">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>160</width>
+                  <height>15</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>354</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_10">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <attribute name="title">
+       <string>Grainlines</string>
+      </attribute>
+      <widget class="QGroupBox" name="grainlineProperties_GroupBox">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>10</y>
+         <width>420</width>
+         <height>174</height>
+        </rect>
+       </property>
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -94,7 +651,7 @@
        <property name="minimumSize">
         <size>
          <width>420</width>
-         <height>0</height>
+         <height>160</height>
         </size>
        </property>
        <property name="maximumSize">
@@ -112,53 +669,11 @@
        <property name="title">
         <string>Properties</string>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_9">
+       <layout class="QVBoxLayout" name="verticalLayout_20">
         <item>
-         <layout class="QVBoxLayout" name="verticalLayout_7">
+         <layout class="QVBoxLayout" name="verticalLayout_21">
           <item>
-           <widget class="QCheckBox" name="showSeamAllowances_CheckBox">
-            <property name="font">
-             <font>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Show Cut Line</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="hideSeamLine_CheckBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>By default hide the main path if the seam allowance was enabled</string>
-            </property>
-            <property name="text">
-             <string>Hide Seam Line</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="forbidFlipping_CheckBox">
+           <widget class="QCheckBox" name="showGrainlines_CheckBox">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
               <horstretch>0</horstretch>
@@ -174,43 +689,336 @@
              <string>By default forbid flipping for all new created workpieces</string>
             </property>
             <property name="text">
-             <string>Forbid flipping</string>
+             <string>Show grainlines</string>
             </property>
            </widget>
           </item>
          </layout>
         </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_8">
+          <item>
+           <widget class="QLabel" name="grainlineLength_Label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>120</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>120</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Length:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDoubleSpinBox" name="defaultGrainlineLength_DoubleSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>200</width>
+              <height>20</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">background-color: rgb(255, 255, 255);</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="minimum">
+             <double>1.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>20.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>2.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_24">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>58</width>
+              <height>17</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_21">
+          <item>
+           <widget class="QLabel" name="grainlineColor_Label">
+            <property name="minimumSize">
+             <size>
+              <width>120</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>120</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Color:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="ColorComboBox" name="defaultGrainlineColor_ComboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>200</width>
+              <height>20</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_21">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>160</width>
+              <height>15</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_22">
+          <item>
+           <widget class="QLabel" name="grainlinelLineweight_Label">
+            <property name="minimumSize">
+             <size>
+              <width>120</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>120</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Lineweight:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="LineWeightComboBox" name="defaultGrainlineLineweight_ComboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>200</width>
+              <height>20</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>x 3</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_22">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_26">
+          <item>
+           <widget class="QLabel" name="defaultArrowLength_Label">
+            <property name="minimumSize">
+             <size>
+              <width>120</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Arrow length:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDoubleSpinBox" name="defaultArrowLength_DoubleSpinBox">
+            <property name="minimumSize">
+             <size>
+              <width>200</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+            <property name="suffix">
+             <string> px</string>
+            </property>
+            <property name="decimals">
+             <number>0</number>
+            </property>
+            <property name="minimum">
+             <double>25.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>200.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>70.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
        </layout>
       </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
+     </widget>
+     <widget class="QWidget" name="tab_6">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <attribute name="title">
+       <string>Paths</string>
+      </attribute>
+      <widget class="QGroupBox" name="seamAllowance_GroupBox">
+       <property name="geometry">
+        <rect>
+         <x>9</x>
+         <y>9</y>
+         <width>420</width>
+         <height>60</height>
+        </rect>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>440</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </widget>
-   <widget class="QWidget" name="tab_5">
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <attribute name="title">
-     <string>Notches</string>
-    </attribute>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-     <item>
-      <widget class="QGroupBox" name="notchPorperties_GroupBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -220,7 +1028,7 @@
        <property name="minimumSize">
         <size>
          <width>420</width>
-         <height>80</height>
+         <height>60</height>
         </size>
        </property>
        <property name="maximumSize">
@@ -236,47 +1044,103 @@
         </font>
        </property>
        <property name="title">
-        <string>Properties</string>
+        <string>Seam allowance</string>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_6">
+       <layout class="QVBoxLayout" name="verticalLayout_23">
         <item>
-         <widget class="QCheckBox" name="showSeamAllowanceNotch_CheckBox">
-          <property name="font">
-           <font>
-            <pointsize>9</pointsize>
-           </font>
-          </property>
-          <property name="text">
-           <string>Show notch on Cut Line</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="showSeamlineNotch_CheckBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>9</pointsize>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>Show notch on both the seam allowance and seam line.</string>
-          </property>
-          <property name="text">
-           <string>Show notch on Seam Line</string>
-          </property>
-         </widget>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QLabel" name="defaultSeamAllowance_Label">
+            <property name="minimumSize">
+             <size>
+              <width>120</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="text">
+             <string>Default value:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QDoubleSpinBox" name="defaultSeamAllowance_DoubleSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>200</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>120</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">background-color: rgb(255, 255, 255);</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="maximum">
+             <double>100.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
        </layout>
       </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="Attribute_GroupBox">
+      <widget class="QGroupBox" name="groupBox">
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>80</y>
+         <width>421</width>
+         <height>160</height>
+        </rect>
+       </property>
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -286,7 +1150,7 @@
        <property name="minimumSize">
         <size>
          <width>0</width>
-         <height>150</height>
+         <height>160</height>
         </size>
        </property>
        <property name="font">
@@ -295,134 +1159,969 @@
         </font>
        </property>
        <property name="title">
-        <string>Attributes</string>
+        <string>Paths</string>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_14">
-        <item>
-         <layout class="QVBoxLayout" name="verticalLayout_5">
+       <widget class="QTabWidget" name="tabWidget">
+        <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>20</y>
+          <width>411</width>
+          <height>126</height>
+         </rect>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>100</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>140</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <pointsize>9</pointsize>
+         </font>
+        </property>
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <widget class="QWidget" name="tab">
+         <attribute name="title">
+          <string>Seam Line</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout_11">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
+           <layout class="QVBoxLayout" name="verticalLayout_10">
             <item>
-             <widget class="QLabel" name="defaultNotchType_Label">
-              <property name="minimumSize">
-               <size>
-                <width>120</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Type:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
+             <layout class="QHBoxLayout" name="horizontalLayout_9">
+              <item>
+               <widget class="QLabel" name="seamColor_Label">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>65</width>
+                  <height>18</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Color:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="ColorComboBox" name="defaultSeamColor_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_9">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
             </item>
             <item>
-             <widget class="QComboBox" name="defaultNotchType_ComboBox">
+             <layout class="QHBoxLayout" name="horizontalLayout_10">
+              <item>
+               <widget class="QLabel" name="seamlLinetype_Label">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>65</width>
+                  <height>18</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>LInetype:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="LineTypeComboBox" name="defaultSeamLinetype_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_10">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_14">
+              <item>
+               <widget class="QLabel" name="seamlLineweight_Label">
+                <property name="minimumSize">
+                 <size>
+                  <width>65</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>65</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Lineweight</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="LineWeightComboBox" name="defaultSeamLineweight_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_14">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="tab_2">
+         <attribute name="title">
+          <string>Cut Line</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout_12">
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_11">
+              <item>
+               <widget class="QLabel" name="cutColor_Label">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>65</width>
+                  <height>18</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Color:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="ColorComboBox" name="defaultCutColor_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_11">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_12">
+              <item>
+               <widget class="QLabel" name="cutLineType_Label">
+                <property name="minimumSize">
+                 <size>
+                  <width>65</width>
+                  <height>18</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>LInetype:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="LineTypeComboBox" name="defaultCutLinetype_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_12">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_13">
+              <item>
+               <widget class="QLabel" name="cutLineWeight_Labe">
+                <property name="minimumSize">
+                 <size>
+                  <width>65</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>65</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Lineweight</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="LineWeightComboBox" name="defaultCutLineweight_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_13">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="tab_8">
+         <attribute name="title">
+          <string>Internals</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout_18">
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_13">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_15">
+              <item>
+               <widget class="QLabel" name="internalColor_Label">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>120</width>
+                  <height>18</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Color:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="ColorComboBox" name="defaultInternalColor_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_15">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_16">
+              <item>
+               <widget class="QLabel" name="internalLinetype_Label">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>120</width>
+                  <height>18</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>LInetype:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="LineTypeComboBox" name="defaultInternalLinetype_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_16">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_17">
+              <item>
+               <widget class="QLabel" name="internalLineweight_Label">
+                <property name="minimumSize">
+                 <size>
+                  <width>120</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>65</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Lineweight</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="LineWeightComboBox" name="defaultInternalLineweight_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_17">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="tab_9">
+         <attribute name="title">
+          <string>Cutouts</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout_19">
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_16">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_18">
+              <item>
+               <widget class="QLabel" name="cutoutColor_Label">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>65</width>
+                  <height>18</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Color:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="ColorComboBox" name="defaultCutoutColor_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_18">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_19">
+              <item>
+               <widget class="QLabel" name="cutoutLinetype_Label">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>65</width>
+                  <height>18</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>LInetype:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="LineTypeComboBox" name="defaultCutoutLinetype_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_19">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_20">
+              <item>
+               <widget class="QLabel" name="cutoutlLineweight_Label">
+                <property name="minimumSize">
+                 <size>
+                  <width>65</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>65</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Lineweight</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="LineWeightComboBox" name="defaultCutoutLineweight_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>200</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_20">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </widget>
+     </widget>
+     <widget class="QWidget" name="tab_7">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <attribute name="title">
+       <string>Labels</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_17">
+       <item>
+        <widget class="QGroupBox" name="labelsProperties_GroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>420</width>
+           <height>170</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>9</pointsize>
+          </font>
+         </property>
+         <property name="title">
+          <string>Properties</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_22">
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_24">
+            <item>
+             <widget class="QCheckBox" name="showPatternLabels_CheckBox">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>120</width>
-                <height>16777215</height>
-               </size>
-              </property>
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
                </font>
               </property>
-              <property name="currentIndex">
-               <number>-1</number>
+              <property name="toolTip">
+               <string>By default forbid flipping for all new created workpieces</string>
+              </property>
+              <property name="text">
+               <string>Show pattern labels</string>
               </property>
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_6">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>147</width>
-                <height>13</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_6">
-            <item>
-             <widget class="QLabel" name="notchColor_Label">
-              <property name="minimumSize">
-               <size>
-                <width>120</width>
-                <height>0</height>
-               </size>
-              </property>
+             <widget class="QCheckBox" name="showPieceLabels_CheckBox">
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
                </font>
               </property>
               <property name="text">
-               <string>Color:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               <string>Show piece labels</string>
               </property>
              </widget>
-            </item>
-            <item>
-             <widget class="ColorComboBox" name="defaultNotchColor_ComboBox">
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="font">
-               <font/>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_8">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>160</width>
-                <height>15</height>
-               </size>
-              </property>
-             </spacer>
             </item>
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <layout class="QHBoxLayout" name="horizontalLayout_24">
             <item>
-             <widget class="QLabel" name="defaultNotchLength_Label">
+             <widget class="QLabel" name="labelWidth_Label">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                 <horstretch>0</horstretch>
@@ -447,7 +2146,7 @@
                </font>
               </property>
               <property name="text">
-               <string>Length:</string>
+               <string>Width</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -455,7 +2154,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QDoubleSpinBox" name="defaultNotchLength_DoubleSpinBox">
+             <widget class="QDoubleSpinBox" name="defaultLabelWidth_DoubleSpinBox">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -489,28 +2188,28 @@
                <number>3</number>
               </property>
               <property name="minimum">
-               <double>0.125000000000000</double>
+               <double>1.000000000000000</double>
               </property>
               <property name="maximum">
-               <double>1.500000000000000</double>
+               <double>20.000000000000000</double>
               </property>
               <property name="singleStep">
-               <double>0.010000000000000</double>
+               <double>0.100000000000000</double>
               </property>
               <property name="value">
-               <double>0.125000000000000</double>
+               <double>3.000000000000000</double>
               </property>
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_2">
+             <spacer name="horizontalSpacer_25">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>160</width>
-                <height>15</height>
+                <width>58</width>
+                <height>17</height>
                </size>
               </property>
              </spacer>
@@ -518,9 +2217,9 @@
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_7">
+           <layout class="QHBoxLayout" name="horizontalLayout_25">
             <item>
-             <widget class="QLabel" name="defaultNotchWidth_Label">
+             <widget class="QLabel" name="labelHeight_Label">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                 <horstretch>0</horstretch>
@@ -545,7 +2244,7 @@
                </font>
               </property>
               <property name="text">
-               <string>Width:</string>
+               <string>Height</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -553,7 +2252,7 @@
              </widget>
             </item>
             <item>
-             <widget class="QDoubleSpinBox" name="defaultNotchWidth_DoubleSpinBox">
+             <widget class="QDoubleSpinBox" name="defaultLabelHeight_DoubleSpinBox">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -586,16 +2285,75 @@
               <property name="decimals">
                <number>3</number>
               </property>
+              <property name="minimum">
+               <double>1.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>20.000000000000000</double>
+              </property>
               <property name="singleStep">
-               <double>0.050000000000000</double>
+               <double>0.100000000000000</double>
               </property>
               <property name="value">
-               <double>0.250000000000000</double>
+               <double>2.000000000000000</double>
               </property>
              </widget>
             </item>
             <item>
-             <spacer name="horizontalSpacer_7">
+             <spacer name="horizontalSpacer_26">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>58</width>
+                <height>17</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_23">
+            <item>
+             <widget class="QLabel" name="labelsColor_Label">
+              <property name="minimumSize">
+               <size>
+                <width>120</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string>Color:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="ColorComboBox" name="defaultLabelColor_ComboBox">
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>20</height>
+               </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_23">
               <property name="orientation">
                <enum>Qt::Horizontal</enum>
               </property>
@@ -610,894 +2368,276 @@
            </layout>
           </item>
          </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer_5">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>354</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </widget>
-   <widget class="QWidget" name="tab_10">
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <attribute name="title">
-     <string>Grainlines</string>
-    </attribute>
-    <widget class="QGroupBox" name="grainlineProperties_GroupBox">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>10</y>
-       <width>420</width>
-       <height>138</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>420</width>
-       <height>120</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>9</pointsize>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="title">
-      <string>Properties</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_20">
-      <item>
-       <layout class="QVBoxLayout" name="verticalLayout_21">
-        <item>
-         <widget class="QCheckBox" name="showGrainlines_CheckBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>9</pointsize>
-           </font>
-          </property>
-          <property name="toolTip">
-           <string>By default forbid flipping for all new created workpieces</string>
-          </property>
-          <property name="text">
-           <string>Show grainlines</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_8">
-        <item>
-         <widget class="QLabel" name="grainlineLength_Label">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>120</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>120</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>9</pointsize>
-           </font>
-          </property>
-          <property name="text">
-           <string>Length:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QDoubleSpinBox" name="defaultGrainlineLength_DoubleSpinBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>9</pointsize>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="decimals">
-           <number>3</number>
-          </property>
-          <property name="minimum">
-           <double>1.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>20.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="value">
-           <double>2.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_24">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>58</width>
-            <height>17</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_21">
-        <item>
-         <widget class="QLabel" name="grainlineColor_Label">
-          <property name="minimumSize">
-           <size>
-            <width>120</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>120</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>9</pointsize>
-           </font>
-          </property>
-          <property name="text">
-           <string>Color:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="ColorComboBox" name="defaultGrainlineColor_ComboBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>9</pointsize>
-           </font>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_21">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>160</width>
-            <height>15</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_22">
-        <item>
-         <widget class="QLabel" name="grainlinelLineweight_Label">
-          <property name="minimumSize">
-           <size>
-            <width>120</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>120</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>9</pointsize>
-           </font>
-          </property>
-          <property name="text">
-           <string>Lineweight:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="LineWeightComboBox" name="defaultGrainlineLineweight_ComboBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>20</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>9</pointsize>
-           </font>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>x 3</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_22">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-   </widget>
-   <widget class="QWidget" name="tab_6">
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <attribute name="title">
-     <string>Paths</string>
-    </attribute>
-    <widget class="QGroupBox" name="seamAllowance_GroupBox">
-     <property name="geometry">
-      <rect>
-       <x>9</x>
-       <y>9</y>
-       <width>420</width>
-       <height>60</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>420</width>
-       <height>60</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>9</pointsize>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="title">
-      <string>Seam allowance</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_23">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QLabel" name="defaultSeamAllowance_Label">
-          <property name="minimumSize">
-           <size>
-            <width>120</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>9</pointsize>
-           </font>
-          </property>
-          <property name="text">
-           <string>Default value:</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QDoubleSpinBox" name="defaultSeamAllowance_DoubleSpinBox">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>200</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>120</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="font">
-           <font>
-            <pointsize>9</pointsize>
-           </font>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">background-color: rgb(255, 255, 255);</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="decimals">
-           <number>3</number>
-          </property>
-          <property name="maximum">
-           <double>100.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
-      </item>
-     </layout>
-    </widget>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="geometry">
-      <rect>
-       <x>10</x>
-       <y>80</y>
-       <width>421</width>
-       <height>160</height>
-      </rect>
-     </property>
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>160</height>
-      </size>
-     </property>
-     <property name="font">
-      <font>
-       <bold>true</bold>
-      </font>
-     </property>
-     <property name="title">
-      <string>Paths</string>
-     </property>
-     <widget class="QTabWidget" name="tabWidget">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>20</y>
-        <width>411</width>
-        <height>126</height>
-       </rect>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>100</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>16777215</width>
-        <height>140</height>
-       </size>
-      </property>
-      <property name="font">
-       <font>
-        <pointsize>9</pointsize>
-       </font>
-      </property>
-      <property name="currentIndex">
-       <number>0</number>
-      </property>
-      <widget class="QWidget" name="tab">
-       <attribute name="title">
-        <string>Seam Line</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_11">
-        <item>
-         <layout class="QVBoxLayout" name="verticalLayout_10">
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="Formats_GroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>420</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>9</pointsize>
+          </font>
+         </property>
+         <property name="title">
+          <string>Label data (date/time format)</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_9">
+           <layout class="QVBoxLayout" name="verticalLayout_3">
             <item>
-             <widget class="QLabel" name="seamColor_Label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>65</width>
-                <height>18</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Color:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
+             <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <item>
+               <widget class="QLabel" name="dateFormats_Label">
+                <property name="minimumSize">
+                 <size>
+                  <width>120</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Date:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="dateFormats_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>120</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>120</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="editDateFormats_PushButton">
+                <property name="minimumSize">
+                 <size>
+                  <width>75</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Edit formats</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_4">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>37</width>
+                  <height>17</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
             </item>
             <item>
-             <widget class="ColorComboBox" name="defaultSeamColor_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_9">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_10">
-            <item>
-             <widget class="QLabel" name="seamlLinetype_Label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>65</width>
-                <height>18</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>LInetype:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="LineTypeComboBox" name="defaultSeamLinetype_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_10">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_14">
-            <item>
-             <widget class="QLabel" name="seamlLineweight_Label">
-              <property name="minimumSize">
-               <size>
-                <width>65</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>65</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Lineweight</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="LineWeightComboBox" name="defaultSeamLineweight_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_14">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
+             <layout class="QHBoxLayout" name="horizontalLayout_3">
+              <item>
+               <widget class="QLabel" name="timeFormats_Label">
+                <property name="minimumSize">
+                 <size>
+                  <width>120</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Time:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="timeFormats_ComboBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>120</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>120</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="editTimeFormats_PushButton">
+                <property name="minimumSize">
+                 <size>
+                  <width>75</width>
+                  <height>20</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Edit formats</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_5">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
             </item>
            </layout>
           </item>
          </layout>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="tab_2">
-       <attribute name="title">
-        <string>Cut Line</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_12">
-        <item>
-         <layout class="QVBoxLayout" name="verticalLayout">
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox_2">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>100</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>9</pointsize>
+          </font>
+         </property>
+         <property name="title">
+          <string>Templates</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_8">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_11">
-            <item>
-             <widget class="QLabel" name="cutColor_Label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
+           <layout class="QGridLayout" name="gridLayout">
+            <item row="0" column="0">
+             <widget class="QLabel" name="patternTemplate_Label">
               <property name="minimumSize">
                <size>
-                <width>65</width>
-                <height>18</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Color:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="ColorComboBox" name="defaultCutColor_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_11">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_12">
-            <item>
-             <widget class="QLabel" name="cutLineType_Label">
-              <property name="minimumSize">
-               <size>
-                <width>65</width>
-                <height>18</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>LInetype:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="LineTypeComboBox" name="defaultCutLinetype_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_12">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_13">
-            <item>
-             <widget class="QLabel" name="cutLineWeight_Labe">
-              <property name="minimumSize">
-               <size>
-                <width>65</width>
+                <width>80</width>
                 <height>0</height>
                </size>
               </property>
-              <property name="maximumSize">
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+               </font>
+              </property>
+              <property name="text">
+               <string>Pattern label:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="patternTemplate_LineEdit"/>
+            </item>
+            <item row="0" column="2">
+             <widget class="QToolButton" name="patternTemplate_ToolButton">
+              <property name="text">
+               <string notr="true">...</string>
+              </property>
+              <property name="icon">
+               <iconset resource="../../../../libs/vmisc/share/resources/theme.qrc">
+                <normaloff>:/icons/win.icon.theme/24x24/actions/document-open.png</normaloff>:/icons/win.icon.theme/24x24/actions/document-open.png</iconset>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="pieceTemplate_Label">
+              <property name="minimumSize">
                <size>
-                <width>65</width>
-                <height>16777215</height>
+                <width>80</width>
+                <height>0</height>
                </size>
               </property>
               <property name="font">
@@ -1506,1133 +2646,50 @@
                </font>
               </property>
               <property name="text">
-               <string>Lineweight</string>
+               <string>Piece label:</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
               </property>
              </widget>
             </item>
-            <item>
-             <widget class="LineWeightComboBox" name="defaultCutLineweight_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
+            <item row="1" column="1">
+             <widget class="QLineEdit" name="pieceTemplate_LineEdit"/>
+            </item>
+            <item row="1" column="2">
+             <widget class="QToolButton" name="pieceTemplate_ToolButton">
+              <property name="text">
+               <string notr="true">...</string>
               </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
+              <property name="icon">
+               <iconset resource="../../../../libs/vmisc/share/resources/theme.qrc">
+                <normaloff>:/icons/win.icon.theme/24x24/actions/document-open.png</normaloff>:/icons/win.icon.theme/24x24/actions/document-open.png</iconset>
               </property>
              </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_13">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
             </item>
            </layout>
           </item>
          </layout>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="tab_8">
-       <attribute name="title">
-        <string>Internals</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_18">
-        <item>
-         <layout class="QVBoxLayout" name="verticalLayout_13">
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_15">
-            <item>
-             <widget class="QLabel" name="internalColor_Label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>120</width>
-                <height>18</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Color:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="ColorComboBox" name="defaultInternalColor_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_15">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_16">
-            <item>
-             <widget class="QLabel" name="internalLinetype_Label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>120</width>
-                <height>18</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>LInetype:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="LineTypeComboBox" name="defaultInternalLinetype_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_16">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_17">
-            <item>
-             <widget class="QLabel" name="internalLineweight_Label">
-              <property name="minimumSize">
-               <size>
-                <width>120</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>65</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Lineweight</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="LineWeightComboBox" name="defaultInternalLineweight_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_17">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="tab_9">
-       <attribute name="title">
-        <string>Cutouts</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_19">
-        <item>
-         <layout class="QVBoxLayout" name="verticalLayout_16">
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_18">
-            <item>
-             <widget class="QLabel" name="cutoutColor_Label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>65</width>
-                <height>18</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Color:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="ColorComboBox" name="defaultCutoutColor_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_18">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_19">
-            <item>
-             <widget class="QLabel" name="cutoutLinetype_Label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>65</width>
-                <height>18</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>LInetype:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="LineTypeComboBox" name="defaultCutoutLinetype_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_19">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_20">
-            <item>
-             <widget class="QLabel" name="cutoutlLineweight_Label">
-              <property name="minimumSize">
-               <size>
-                <width>65</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>65</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Lineweight</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="LineWeightComboBox" name="defaultCutoutLineweight_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_20">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>425</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </widget>
     </widget>
-   </widget>
-   <widget class="QWidget" name="tab_7">
-    <property name="sizePolicy">
-     <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-      <horstretch>0</horstretch>
-      <verstretch>0</verstretch>
-     </sizepolicy>
-    </property>
-    <attribute name="title">
-     <string>Labels</string>
-    </attribute>
-    <layout class="QVBoxLayout" name="verticalLayout_17">
-     <item>
-      <widget class="QGroupBox" name="labelsProperties_GroupBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>420</width>
-         <height>170</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <pointsize>9</pointsize>
-        </font>
-       </property>
-       <property name="title">
-        <string>Properties</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_22">
-        <item>
-         <layout class="QVBoxLayout" name="verticalLayout_24">
-          <item>
-           <widget class="QCheckBox" name="showPatternLabels_CheckBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="toolTip">
-             <string>By default forbid flipping for all new created workpieces</string>
-            </property>
-            <property name="text">
-             <string>Show pattern labels</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="showPieceLabels_CheckBox">
-            <property name="font">
-             <font>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Show piece labels</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_24">
-          <item>
-           <widget class="QLabel" name="labelWidth_Label">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>120</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Width</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QDoubleSpinBox" name="defaultLabelWidth_DoubleSpinBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>200</width>
-              <height>20</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>120</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">background-color: rgb(255, 255, 255);</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="decimals">
-             <number>3</number>
-            </property>
-            <property name="minimum">
-             <double>1.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>20.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>3.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_25">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>58</width>
-              <height>17</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_25">
-          <item>
-           <widget class="QLabel" name="labelHeight_Label">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>120</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Height</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QDoubleSpinBox" name="defaultLabelHeight_DoubleSpinBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>200</width>
-              <height>20</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>120</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">background-color: rgb(255, 255, 255);</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="decimals">
-             <number>3</number>
-            </property>
-            <property name="minimum">
-             <double>1.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>20.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>2.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_26">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>58</width>
-              <height>17</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_23">
-          <item>
-           <widget class="QLabel" name="labelsColor_Label">
-            <property name="minimumSize">
-             <size>
-              <width>120</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Color:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="ColorComboBox" name="defaultLabelColor_ComboBox">
-            <property name="minimumSize">
-             <size>
-              <width>200</width>
-              <height>20</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_23">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>160</width>
-              <height>15</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="Formats_GroupBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>420</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <pointsize>9</pointsize>
-        </font>
-       </property>
-       <property name="title">
-        <string>Label data (date/time format)</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_4">
-        <item>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <item>
-             <widget class="QLabel" name="dateFormats_Label">
-              <property name="minimumSize">
-               <size>
-                <width>120</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Date:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="dateFormats_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>120</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>120</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="editDateFormats_PushButton">
-              <property name="minimumSize">
-               <size>
-                <width>75</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Edit formats</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>37</width>
-                <height>17</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <item>
-             <widget class="QLabel" name="timeFormats_Label">
-              <property name="minimumSize">
-               <size>
-                <width>120</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Time:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="timeFormats_ComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>120</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>120</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="editTimeFormats_PushButton">
-              <property name="minimumSize">
-               <size>
-                <width>75</width>
-                <height>20</height>
-               </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>9</pointsize>
-               </font>
-              </property>
-              <property name="text">
-               <string>Edit formats</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_5">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox_2">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>100</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <pointsize>9</pointsize>
-        </font>
-       </property>
-       <property name="title">
-        <string>Templates</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_8">
-        <item>
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="patternTemplate_Label">
-            <property name="minimumSize">
-             <size>
-              <width>80</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Pattern label:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="patternTemplate_LineEdit"/>
-          </item>
-          <item row="0" column="2">
-           <widget class="QToolButton" name="patternTemplate_ToolButton">
-            <property name="text">
-             <string notr="true">...</string>
-            </property>
-            <property name="icon">
-             <iconset resource="../../../../libs/vmisc/share/resources/theme.qrc">
-              <normaloff>:/icons/win.icon.theme/24x24/actions/document-open.png</normaloff>:/icons/win.icon.theme/24x24/actions/document-open.png</iconset>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="pieceTemplate_Label">
-            <property name="minimumSize">
-             <size>
-              <width>80</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="font">
-             <font>
-              <pointsize>9</pointsize>
-             </font>
-            </property>
-            <property name="text">
-             <string>Piece label:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="pieceTemplate_LineEdit"/>
-          </item>
-          <item row="1" column="2">
-           <widget class="QToolButton" name="pieceTemplate_ToolButton">
-            <property name="text">
-             <string notr="true">...</string>
-            </property>
-            <property name="icon">
-             <iconset resource="../../../../libs/vmisc/share/resources/theme.qrc">
-              <normaloff>:/icons/win.icon.theme/24x24/actions/document-open.png</normaloff>:/icons/win.icon.theme/24x24/actions/document-open.png</iconset>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>425</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </widget>
-  </widget>
+   </item>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/app/seamly2d/xml/vpattern.cpp
+++ b/src/app/seamly2d/xml/vpattern.cpp
@@ -1054,9 +1054,9 @@ void VPattern::ParsePieceGrainline(const QDomElement &domElement, VPiece &piece)
     VGrainlineData &gGeometry = piece.GetGrainlineGeometry();
     gGeometry.SetVisible(getParameterBool(domElement, AttrVisible, falseStr));
     gGeometry.SetPos(QPointF(GetParametrDouble(domElement, AttrMx, "0"), GetParametrDouble(domElement, AttrMy, "0")));
-    gGeometry.SetLength(GetParametrString(domElement, AttrLength, "1"));
-    gGeometry.SetRotation(GetParametrString(domElement, AttrRotation, "90"));
-    gGeometry.SetArrowType(static_cast<ArrowType>(GetParametrUInt(domElement, AttrArrows, "0")));
+    gGeometry.setLength(GetParametrString(domElement, AttrLength, "1"));
+    gGeometry.setRotation(GetParametrString(domElement, AttrRotation, "90"));
+    gGeometry.setArrowType(static_cast<ArrowType>(GetParametrUInt(domElement, AttrArrows, "0")));
     gGeometry.setCenterAnchorPoint(GetParametrUInt(domElement, PatternPieceTool::AttrCenterAnchor, NULL_ID_STR));
     gGeometry.setTopAnchorPoint(GetParametrUInt(domElement, PatternPieceTool::AttrTopAnchorPoint, NULL_ID_STR));
     gGeometry.setBottomAnchorPoint(GetParametrUInt(domElement, PatternPieceTool::AttrBottomAnchorPoint, NULL_ID_STR));

--- a/src/libs/vlayout/vlayoutpiece.cpp
+++ b/src/libs/vlayout/vlayoutpiece.cpp
@@ -228,11 +228,11 @@ bool FindGrainlineGeometry(const VGrainlineData& data, const VContainer *pattern
     try
     {
         Calculator cal1;
-        rotationAngle = cal1.EvalFormula(pattern->DataVariables(), data.GetRotation());
+        rotationAngle = cal1.EvalFormula(pattern->DataVariables(), data.getRotation());
         rotationAngle = qDegreesToRadians(rotationAngle);
 
         Calculator cal2;
-        length = cal2.EvalFormula(pattern->DataVariables(), data.GetLength());
+        length = cal2.EvalFormula(pattern->DataVariables(), data.getLength());
         length = ToPixel(length, *pattern->GetPatternUnit());
     }
     catch(qmu::QmuParserError &error)
@@ -655,7 +655,7 @@ void VLayoutPiece::setGrainline(const VGrainlineData& data, const VContainer* pa
 
     QVector<QPointF> v;
     v << pt2;
-    if (data.GetArrowType() != ArrowType::atFront)
+    if (data.getArrowType() != ArrowType::Top)
     {
         v << QPointF(pt1.x() + arrowLength * qCos(rotationAngle + arrowAngle),
                      pt1.y() - arrowLength * qSin(rotationAngle + arrowAngle));
@@ -666,7 +666,7 @@ void VLayoutPiece::setGrainline(const VGrainlineData& data, const VContainer* pa
     }
 
     v << pt4;
-    if (data.GetArrowType() != ArrowType::atRear)
+    if (data.getArrowType() != ArrowType::Bottom)
     {
         rotationAngle += M_PI;
         v << QPointF(pt3.x() + arrowLength * qCos(rotationAngle + arrowAngle),

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -201,6 +201,7 @@ const QString settingDefaultGrainlineVisibilty           = QStringLiteral("patte
 const QString settingDefaultGrainlineLength              = QStringLiteral("pattern/defaultGrainlineLength");
 const QString settingDefaultGrainlineColor               = QStringLiteral("pattern/defaultGrainlineColor");
 const QString settingDefaultGrainlineLineweight          = QStringLiteral("pattern/defaultGrainlineLineweight");
+const QString settingDefaultArrowLength                  = QStringLiteral("pattern/defaultArrowLength");
 
 const QString settingShowLabels                          = QStringLiteral("pattern/showLabels");
 const QString settingShowPatternLabels                   = QStringLiteral("pattern/showPatternLabels");
@@ -2051,6 +2052,18 @@ qreal VCommonSettings::getDefaultGrainlineLineweight() const
 void VCommonSettings::setDefaultGrainlineLineweight(const qreal &value)
 {
     setValue(settingDefaultGrainlineLineweight, value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+qreal VCommonSettings::getDefaultArrowLength() const
+{
+   return value(settingDefaultArrowLength, 0.70).toReal();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VCommonSettings::setDefaultArrowLength(const qreal &value)
+{
+    setValue(settingDefaultArrowLength, value);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vmisc/vcommonsettings.h
+++ b/src/libs/vmisc/vcommonsettings.h
@@ -449,6 +449,9 @@ public:
     qreal                getDefaultGrainlineLineweight() const;
     void                 setDefaultGrainlineLineweight(const qreal &value);
 
+    qreal                getDefaultArrowLength() const;
+    void                 setDefaultArrowLength(const qreal &value);
+
     bool                 showLabels() const;
     void                 setShowLabels(const bool &value);
 

--- a/src/libs/vpatterndb/floatItemData/floatitemdef.h
+++ b/src/libs/vpatterndb/floatItemData/floatitemdef.h
@@ -58,10 +58,9 @@
 // denotes the type of arrow for the grainline
 enum class ArrowType : char
 {
-    atBoth,
-    atFront,
-    atRear
+    Both,
+    Top,
+    Bottom
 };
 
 #endif // FLOATITEMDEF_H
-

--- a/src/libs/vpatterndb/floatItemData/vgrainlinedata.cpp
+++ b/src/libs/vpatterndb/floatItemData/vgrainlinedata.cpp
@@ -1,30 +1,52 @@
-/************************************************************************
- **
- **  @file   vgrainlinedata.cpp
- **  @author Bojan Kverh
- **  @date   September 06, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vgrainlinedata.cpp
+//  @author Douglas S Caskey
+//  @date   11 Nov, 2024
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vgrainlinedata.cpp
+//  @author Bojan Kverh
+//  @date   September 06, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2015 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #include <QPointF>
 
@@ -40,14 +62,14 @@ void VGrainlineData::Swap(VGrainlineData &data) Q_DECL_NOTHROW
 
 //---------------------------------------------------------------------------------------------------------------------
 VGrainlineData::VGrainlineData()
-    : VAbstractFloatItemData(),
-      d(new VGrainlineDataPrivate())
+    : VAbstractFloatItemData()
+    , d(new VGrainlineDataPrivate())
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
 VGrainlineData::VGrainlineData(const VGrainlineData &data)
-    : VAbstractFloatItemData(data),
-      d (data.d)
+    : VAbstractFloatItemData(data)
+    , d (data.d)
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -67,39 +89,39 @@ VGrainlineData::~VGrainlineData()
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
-QString VGrainlineData::GetLength() const
+QString VGrainlineData::getLength() const
 {
-    return d->m_qsLength;
+    return d->m_length;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VGrainlineData::SetLength(const QString& qsLen)
+void VGrainlineData::setLength(const QString& length)
 {
-    d->m_qsLength = qsLen;
+    d->m_length = length;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QString VGrainlineData::GetRotation() const
+QString VGrainlineData::getRotation() const
 {
-    return d->m_dRotation;
+    return d->m_rotation;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VGrainlineData::SetRotation(const QString& qsRot)
+void VGrainlineData::setRotation(const QString& rotation)
 {
-    d->m_dRotation = qsRot;
+    d->m_rotation = rotation;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-ArrowType VGrainlineData::GetArrowType() const
+ArrowType VGrainlineData::getArrowType() const
 {
-    return d->m_eArrowType;
+    return d->m_arrowType;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VGrainlineData::SetArrowType(ArrowType eAT)
+void VGrainlineData::setArrowType(ArrowType type)
 {
-    d->m_eArrowType = eAT;
+    d->m_arrowType = type;
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/floatItemData/vgrainlinedata.h
+++ b/src/libs/vpatterndb/floatItemData/vgrainlinedata.h
@@ -1,30 +1,52 @@
-/************************************************************************
- **
- **  @file   vgrainlinedata.h
- **  @author Bojan Kverh
- **  @date   September 06, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vgrainlinedata.h
+//  @author Douglas S Caskey
+//  @date   11 Nov, 2024
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vgrainlinedata.h
+//  @author Bojan Kverh
+//  @date   September 06, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2015 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #ifndef VGRAINLINEGEOMETRY_H
 #define VGRAINLINEGEOMETRY_H
@@ -37,47 +59,46 @@
 
 class VGrainlineDataPrivate;
 
-/**
- * @brief The VGrainlineData class holds information about a grainline like
- * position, size, rotation and visibility
- */
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief The VGrainlineData class holds information about a grainline like
+/// position, size, rotation and visibility
+//---------------------------------------------------------------------------------------------------------------------
 class VGrainlineData : public VAbstractFloatItemData
 {
 public:
-    VGrainlineData();
-    VGrainlineData(const VGrainlineData &data);
+                    VGrainlineData();
+                    VGrainlineData(const VGrainlineData &data);
 
-    virtual ~VGrainlineData();
+    virtual        ~VGrainlineData();
 
     VGrainlineData &operator=(const VGrainlineData &data);
 #ifdef Q_COMPILER_RVALUE_REFS
 	VGrainlineData &operator=(VGrainlineData &&data) Q_DECL_NOTHROW;
 #endif
 
-	void Swap(VGrainlineData &data) Q_DECL_NOTHROW;
+	void            Swap(VGrainlineData &data) Q_DECL_NOTHROW;
 
     // methods, which set and return values of different parameters
-    QString GetLength() const;
-    void    SetLength(const QString& qsLen);
+    QString         getLength() const;
+    void            setLength(const QString& length);
 
-    QString GetRotation() const;
-    void    SetRotation(const QString& qsRot);
+    QString         getRotation() const;
+    void            setRotation(const QString& rotation);
 
-    ArrowType GetArrowType() const;
-    void      SetArrowType(ArrowType eAT);
+    ArrowType       getArrowType() const;
+    void            setArrowType(ArrowType type);
 
-    quint32 centerAnchorPoint() const;
-    void    setCenterAnchorPoint(quint32 centerAnchor);
+    quint32         centerAnchorPoint() const;
+    void            setCenterAnchorPoint(quint32 centerAnchor);
 
-    quint32 topAnchorPoint() const;
-    void    setTopAnchorPoint(quint32 topAnchorPoint);
+    quint32         topAnchorPoint() const;
+    void            setTopAnchorPoint(quint32 topAnchorPoint);
 
-    quint32 bottomAnchorPoint() const;
-    void    setBottomAnchorPoint(quint32 bottomAnchorPoint);
+    quint32         bottomAnchorPoint() const;
+    void            setBottomAnchorPoint(quint32 bottomAnchorPoint);
 
 private:
     QSharedDataPointer<VGrainlineDataPrivate> d;
 };
 
 #endif // VGRAINLINEGEOMETRY_H
-

--- a/src/libs/vpatterndb/floatItemData/vgrainlinedata_p.h
+++ b/src/libs/vpatterndb/floatItemData/vgrainlinedata_p.h
@@ -1,30 +1,52 @@
-/************************************************************************
- **
- **  @file
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   23 2, 2017
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013 - 2022 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vgrainlinedata_p.h
+//  @author Douglas S Caskey
+//  @date   11 Nov, 2024
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vgrainlinedata_p.h
+//  @author Bojan Kverh
+//  @date   September 06, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2015 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #ifndef VGRAINLINEDATA_P_H
 #define VGRAINLINEDATA_P_H
@@ -44,9 +66,9 @@ class VGrainlineDataPrivate : public QSharedData
 {
 public:
     VGrainlineDataPrivate()
-        : m_qsLength()
-        , m_dRotation()
-        , m_eArrowType(ArrowType::atBoth)
+        : m_length()
+        , m_rotation()
+        , m_arrowType(ArrowType::Both)
         , m_centerAnchorPoint(NULL_ID)
         , m_topAnchorPoint(NULL_ID)
         , m_bottomAnchorPoint(NULL_ID)
@@ -54,9 +76,9 @@ public:
 
     VGrainlineDataPrivate(const VGrainlineDataPrivate &data)
         : QSharedData(data)
-        , m_qsLength(data.m_qsLength)
-        , m_dRotation(data.m_dRotation)
-        , m_eArrowType(data.m_eArrowType)
+        , m_length(data.m_length)
+        , m_rotation(data.m_rotation)
+        , m_arrowType(data.m_arrowType)
         , m_centerAnchorPoint(data.m_centerAnchorPoint)
         , m_topAnchorPoint(data.m_topAnchorPoint)
         , m_bottomAnchorPoint(data.m_bottomAnchorPoint)
@@ -64,9 +86,9 @@ public:
 
     ~VGrainlineDataPrivate() Q_DECL_EQ_DEFAULT;
 
-    QString   m_qsLength;          /** @brief m_dLength formula to calculate the length of grainline */
-    QString   m_dRotation;         /** @brief m_dRotation formula to calculate the rotation of grainline in [degrees] */
-    ArrowType m_eArrowType;        /** @brief m_eArrowType type of arrow on the grainline */
+    QString   m_length;            /** @brief m_dLength formula to calculate the length of grainline */
+    QString   m_rotation;          /** @brief m_rotation formula to calculate the rotation of grainline in [degrees] */
+    ArrowType m_arrowType;         /** @brief m_arrowType type of arrow on the grainline */
     quint32   m_centerAnchorPoint; /** @brief m_centerAnchorPoint center anchor point id */
     quint32   m_topAnchorPoint;    /** @brief m_topAnchorPoint top anchor point id */
     quint32   m_bottomAnchorPoint; /** @brief m_bottomAnchorPoint bottom anchor point id */

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -316,7 +316,7 @@ void PatternPieceDialog::SetPiece(const VPiece &piece)
     ui->fold_CheckBox->setChecked(m_oldData.IsOnFold());
     m_pieceLabelLines = m_oldData.GetLabelTemplate();
 
-    ui->arrow_ComboBox->setCurrentIndex(int(piece.GetGrainlineGeometry().GetArrowType()));
+    ui->arrow_ComboBox->setCurrentIndex(int(piece.GetGrainlineGeometry().getArrowType()));
 
     ui->pieceLabel_GroupBox->setChecked(m_oldData.IsVisible());
     ChangeCurrentData(ui->pieceLabelCenterAnchor_ComboBox, m_oldData.centerAnchorPoint());
@@ -340,8 +340,8 @@ void PatternPieceDialog::SetPiece(const VPiece &piece)
     ChangeCurrentData(ui->grainlineCenterAnchor_ComboBox, m_oldGrainline.centerAnchorPoint());
     ChangeCurrentData(ui->grainlineTopAnchor_ComboBox, m_oldGrainline.topAnchorPoint());
     ChangeCurrentData(ui->grainlineBottomAnchor_ComboBox, m_oldGrainline.bottomAnchorPoint());
-    setGrainlineAngle(m_oldGrainline.GetRotation());
-    setGrainlineLength(m_oldGrainline.GetLength());
+    setGrainlineAngle(m_oldGrainline.getRotation());
+    setGrainlineLength(m_oldGrainline.getLength());
 
     validateObjects(isMainPathValid());
     enabledGrainline();
@@ -2457,9 +2457,9 @@ VPiece PatternPieceDialog::CreatePiece() const
 
     piece.GetGrainlineGeometry() = m_oldGrainline;
     piece.GetGrainlineGeometry().SetVisible(ui->grainline_GroupBox->isChecked());
-    piece.GetGrainlineGeometry().SetRotation(getFormulaFromUser(ui->rotationFormula_LineEdit));
-    piece.GetGrainlineGeometry().SetLength(getFormulaFromUser(ui->lengthFormula_LineEdit));
-    piece.GetGrainlineGeometry().SetArrowType(static_cast<ArrowType>(ui->arrow_ComboBox->currentIndex()));
+    piece.GetGrainlineGeometry().setRotation(getFormulaFromUser(ui->rotationFormula_LineEdit));
+    piece.GetGrainlineGeometry().setLength(getFormulaFromUser(ui->lengthFormula_LineEdit));
+    piece.GetGrainlineGeometry().setArrowType(static_cast<ArrowType>(ui->arrow_ComboBox->currentIndex()));
     piece.GetGrainlineGeometry().setCenterAnchorPoint(getCurrentObjectId(ui->grainlineCenterAnchor_ComboBox));
     piece.GetGrainlineGeometry().setTopAnchorPoint(getCurrentObjectId(ui->grainlineTopAnchor_ComboBox));
     piece.GetGrainlineGeometry().setBottomAnchorPoint(getCurrentObjectId(ui->grainlineBottomAnchor_ComboBox));

--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -123,9 +123,9 @@ const QString PatternPieceTool::AttrBottomAnchorPoint    = QStringLiteral("botto
 PatternPieceTool *PatternPieceTool::Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene,
                                                VAbstractPattern *doc, VContainer *data)
 {
-    SCASSERT(not dialog.isNull());
+    SCASSERT(!dialog.isNull());
     QSharedPointer<PatternPieceDialog> dialogTool = dialog.objectCast<PatternPieceDialog>();
-    SCASSERT(not dialogTool.isNull())
+    SCASSERT(!dialogTool.isNull())
     VPiece piece = dialogTool->GetPiece();
     QString width = piece.getSeamAllowanceWidthFormula();
     qApp->getUndoStack()->beginMacro("add pattern piece");
@@ -445,9 +445,9 @@ void PatternPieceTool::AddGrainline(VAbstractPattern *doc, QDomElement &domEleme
     doc->SetAttribute(domData, VAbstractPattern::AttrVisible,  data.IsVisible());
     doc->SetAttribute(domData, AttrMx,                         data.GetPos().x());
     doc->SetAttribute(domData, AttrMy,                         data.GetPos().y());
-    doc->SetAttribute(domData, AttrLength,                     data.GetLength());
-    doc->SetAttribute(domData, VAbstractPattern::AttrRotation, data.GetRotation());
-    doc->SetAttribute(domData, VAbstractPattern::AttrArrows,   int(data.GetArrowType()));
+    doc->SetAttribute(domData, AttrLength,                     data.getLength());
+    doc->SetAttribute(domData, VAbstractPattern::AttrRotation, data.getRotation());
+    doc->SetAttribute(domData, VAbstractPattern::AttrArrows,   int(data.getArrowType()));
 
     if (data.centerAnchorPoint() > NULL_ID)
     {
@@ -573,14 +573,14 @@ void PatternPieceTool::ResetChildren(QGraphicsItem *pItem)
     {
         if (piece.GetPatternPieceData().IsVisible())
         {
-            m_dataLabel->Reset();
+            m_dataLabel->reset();
         }
     }
     if (pVGI != m_patternInfo)
     {
         if (piece.GetPatternInfo().IsVisible())
         {
-            m_patternInfo->Reset();
+            m_patternInfo->reset();
         }
     }
     VGrainlineItem *pGLI = qgraphicsitem_cast<VGrainlineItem*>(pItem);
@@ -588,7 +588,7 @@ void PatternPieceTool::ResetChildren(QGraphicsItem *pItem)
     {
         if (piece.GetGrainlineGeometry().IsVisible())
         {
-            m_grainLine->Reset();
+            m_grainLine->reset();
         }
     }
 
@@ -702,9 +702,9 @@ void PatternPieceTool::UpdateGrainline()
             return;
         }
 
-        m_grainLine->SetMoveType(type);
-        m_grainLine->UpdateGeometry(pos, dRotation, ToPixel(dLength, *VDataTool::data.GetPatternUnit()),
-                                    data.GetArrowType());
+        m_grainLine->setMoveType(type);
+        m_grainLine->updateGeometry(pos, dRotation, ToPixel(dLength, *VDataTool::data.GetPatternUnit()),
+                                    data.getArrowType());
         m_grainLine->show();
     }
     else
@@ -853,7 +853,7 @@ void PatternPieceTool::SaveResizeGrainline(qreal dLength)
 
     dLength = FromPixel(dLength, *VDataTool::data.GetPatternUnit());
     newPiece.GetGrainlineGeometry().SetPos(m_grainLine->pos());
-    newPiece.GetGrainlineGeometry().SetLength(QString().setNum(dLength));
+    newPiece.GetGrainlineGeometry().setLength(QString().setNum(dLength));
     SavePieceOptions *resizeCommand = new SavePieceOptions(oldPiece, newPiece, doc, m_id);
     resizeCommand->setText(tr("resize grainline"));
     connect(resizeCommand, &SavePieceOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
@@ -866,7 +866,7 @@ void PatternPieceTool::SaveRotateGrainline(qreal dRot, const QPointF &ptPos)
     VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
     VPiece newPiece = oldPiece;
 
-    newPiece.GetGrainlineGeometry().SetRotation(QString().setNum(qRadiansToDegrees(dRot)));
+    newPiece.GetGrainlineGeometry().setRotation(QString().setNum(qRadiansToDegrees(dRot)));
     newPiece.GetGrainlineGeometry().SetPos(ptPos);
     SavePieceOptions *rotateCommand = new SavePieceOptions(oldPiece, newPiece, doc, m_id);
     rotateCommand->setText(tr("rotate grainline"));
@@ -928,9 +928,9 @@ void PatternPieceTool::paint(QPainter *painter, const QStyleOptionGraphicsItem *
                            Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
 
 
-    if ((m_dataLabel->IsIdle() == false
-            || m_patternInfo->IsIdle() == false
-            || m_grainLine->IsIdle() == false) && not isSelected())
+    if ((m_dataLabel->isIdle() == false
+            || m_patternInfo->isIdle() == false
+            || m_grainLine->isIdle() == false) && not isSelected())
     {
         setSelected(true);
     }
@@ -1039,7 +1039,7 @@ QVariant PatternPieceTool::itemChange(QGraphicsItem::GraphicsItemChange change, 
             qApp->getUndoStack()->push(cmd);
 
             const QList<QGraphicsView *> viewList = scene()->views();
-            if (not viewList.isEmpty())
+            if (!viewList.isEmpty())
             {
                 if (VMainGraphicsView *view = qobject_cast<VMainGraphicsView *>(viewList.at(0)))
                 {
@@ -1094,7 +1094,7 @@ void PatternPieceTool::mousePressEvent(QGraphicsSceneMouseEvent *event)
     QGraphicsPathItem::mousePressEvent(event);
 
     // Somehow clicking on notselectable object do not clean previous selections.
-    if (not (flags() & ItemIsSelectable) && scene())
+    if (!(flags() & ItemIsSelectable) && scene())
     {
         scene()->clearSelection();
     }
@@ -1417,9 +1417,9 @@ void PatternPieceTool::keyReleaseEvent(QKeyEvent *event)
 //---------------------------------------------------------------------------------------------------------------------
 void PatternPieceTool::SetDialog()
 {
-    SCASSERT(not m_dialog.isNull());
+    SCASSERT(!m_dialog.isNull());
     QSharedPointer<PatternPieceDialog> dialogTool = m_dialog.objectCast<PatternPieceDialog>();
-    SCASSERT(not dialogTool.isNull())
+    SCASSERT(!dialogTool.isNull())
     dialogTool->SetPiece(VAbstractTool::data.GetPiece(m_id));
     dialogTool->enableApply(true);
 }
@@ -1493,7 +1493,7 @@ void PatternPieceTool::UpdateExcludeState()
             SCASSERT(tool != nullptr);
 
             tool->SetExluded(node.isExcluded());
-            tool->setVisible(not node.isExcluded());//Hide excluded point
+            tool->setVisible(!node.isExcluded());//Hide excluded point
         }
     }
 }
@@ -1561,7 +1561,7 @@ void PatternPieceTool::RefreshGeometry()
 //---------------------------------------------------------------------------------------------------------------------
 void PatternPieceTool::SaveDialogChange()
 {
-    SCASSERT(not m_dialog.isNull());
+    SCASSERT(!m_dialog.isNull());
     PatternPieceDialog *dialogTool = qobject_cast<PatternPieceDialog*>(m_dialog.data());
     SCASSERT(dialogTool != nullptr);
     const VPiece newPiece = dialogTool->GetPiece();
@@ -1581,7 +1581,7 @@ VPieceItem::MoveTypes PatternPieceTool::FindLabelGeometry(const VPatternLabelDat
     VPieceItem::MoveTypes restrictions = VPieceItem::AllModifications;
     try
     {
-        if (not qmu::QmuTokenParser::IsSingle(labelData.GetRotation()))
+        if (!qmu::QmuTokenParser::IsSingle(labelData.GetRotation()))
         {
             restrictions &= ~ VPieceItem::IsRotatable;
         }
@@ -1637,7 +1637,7 @@ VPieceItem::MoveTypes PatternPieceTool::FindLabelGeometry(const VPatternLabelDat
         labelHeight = cal2.EvalFormula(VAbstractTool::data.DataVariables(), labelData.GetLabelHeight());
         qDebug() << " Label height: " << labelHeight;
         qDebug() << " Label height is single: " << heightIsSingle;
-        if (not widthIsSingle || not heightIsSingle)
+        if (!widthIsSingle || not heightIsSingle)
         {
             restrictions &= ~ VPieceItem::IsResizable;
         }
@@ -1694,7 +1694,7 @@ VPieceItem::MoveTypes PatternPieceTool::FindGrainlineGeometry(const VGrainlineDa
             length = FromPixel(grainline.length(), *VDataTool::data.GetPatternUnit());
             rotationAngle = grainline.angle();
 
-            if (not VFuzzyComparePossibleNulls(rotationAngle, 0))
+            if (!VFuzzyComparePossibleNulls(rotationAngle, 0))
             {
                 grainline.setAngle(0);
             }
@@ -1712,21 +1712,21 @@ VPieceItem::MoveTypes PatternPieceTool::FindGrainlineGeometry(const VGrainlineDa
     VPieceItem::MoveTypes restrictions = VPieceItem::AllModifications;
     try
     {
-        if (not qmu::QmuTokenParser::IsSingle(data.GetRotation()))
+        if (!qmu::QmuTokenParser::IsSingle(data.getRotation()))
         {
             restrictions &= ~ VPieceItem::IsRotatable;
         }
 
         Calculator cal1;
-        rotationAngle = cal1.EvalFormula(VAbstractTool::data.DataVariables(), data.GetRotation());
+        rotationAngle = cal1.EvalFormula(VAbstractTool::data.DataVariables(), data.getRotation());
 
-        if (not qmu::QmuTokenParser::IsSingle(data.GetLength()))
+        if (!qmu::QmuTokenParser::IsSingle(data.getLength()))
         {
             restrictions &= ~ VPieceItem::IsResizable;
         }
 
         Calculator cal2;
-        length = cal2.EvalFormula(VAbstractTool::data.DataVariables(), data.GetLength());
+        length = cal2.EvalFormula(VAbstractTool::data.DataVariables(), data.getLength());
     }
     catch(qmu::QmuParserError &error)
     {
@@ -1794,7 +1794,7 @@ void PatternPieceTool::initializeNode(const VPieceNode &node, VMainGraphicsScene
             tool->setParentItem(parent);
             tool->SetParentType(ParentType::Item);
             tool->SetExluded(node.isExcluded());
-            tool->setVisible(not node.isExcluded());//Hide excluded point
+            tool->setVisible(!node.isExcluded());//Hide excluded point
             doc->IncrementReferens(node.GetId());
             break;
         }
@@ -1927,7 +1927,7 @@ bool PatternPieceTool::PrepareLabelData(const VPatternLabelData &labelData, VTex
         labelItem->hide();
         return false;
     }
-    labelItem->SetMoveType(type);
+    labelItem->setMoveType(type);
 
     QFont fnt = qApp->Settings()->getLabelFont();
     {
@@ -1968,7 +1968,7 @@ void PatternPieceTool::UpdateLabelItem(VTextGraphicsItem *labelItem, QPointF pos
 
     labelItem->setPos(pos);
     labelItem->setRotation(-labelAngle);// expects clockwise direction
-    labelItem->Update();
+    labelItem->updateItem();
     labelItem->getTextLines() > 0 ? labelItem->show() : labelItem->hide();
 }
 

--- a/src/libs/vtools/tools/union_tool.cpp
+++ b/src/libs/vtools/tools/union_tool.cpp
@@ -1355,8 +1355,8 @@ void createUnion(quint32 id, const UnionToolInitData &initData, qreal dx, qreal 
     newPiece.GetPatternPieceData().SetPos(QPointF(xPos, yPos));
 
     newPiece.GetGrainlineGeometry().SetVisible(qApp->Settings()->getDefaultGrainlineVisibilty());
-    newPiece.GetGrainlineGeometry().SetLength(QString::number(qApp->Settings()->getDefaultGrainlineLength()));
-    qreal length =  newPiece.GetGrainlineGeometry().GetLength().toDouble();
+    newPiece.GetGrainlineGeometry().setLength(QString::number(qApp->Settings()->getDefaultGrainlineLength()));
+    qreal length =  newPiece.GetGrainlineGeometry().getLength().toDouble();
     xPos = rect.center().x();
     yPos = rect.center().y();
     newPiece.GetGrainlineGeometry().SetPos(QPointF(xPos, yPos + length/2.0));

--- a/src/libs/vwidgets/vgrainlineitem.cpp
+++ b/src/libs/vwidgets/vgrainlineitem.cpp
@@ -1,30 +1,52 @@
-/************************************************************************
- **
- **  @file   vgrainlineitem.cpp
- **  @author Bojan Kverh
- **  @date   September 10, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vgrainlineitem.cpp
+//  @author Douglas S Caskey
+//  @date   11 Nov, 2024
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vgrainlineitem.cpp
+//  @author Bojan Kverh
+//  @date   September 10, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2015 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #include <math.h>
 
@@ -44,7 +66,7 @@
 #include "vgrainlineitem.h"
 
 #define ARROW_ANGLE                     M_PI/9
-#define ARROW_LENGTH                    15
+#define ARROW_LENGTH                    70.0
 #define RECT_WIDTH                      30
 #define RESIZE_RECT_SIZE                10
 #define ROTATE_CIRC_R                   7
@@ -52,56 +74,53 @@
 #define LINE_PEN_WIDTH                  3
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VGrainlineItem::VGrainlineItem constructor
- * @param painterarent pointer to the parent item
- */
-VGrainlineItem::VGrainlineItem(QGraphicsItem* painterarent)
-    : VPieceItem(painterarent),
-      m_dRotation(0),
-      m_dStartRotation(0),
-      m_dLength(0),
-      m_polyBound(),
-      m_ptStartPos(),
-      m_ptStartMove(),
-      m_dScale(1),
-      m_polyResize(),
-      m_dStartLength(0),
-      m_ptStart(),
-      m_ptFinish(),
-      m_ptCenter(),
-      m_dAngle(0),
-      m_eArrowType(ArrowType::atBoth),
+/// @brief VGrainlineItem::VGrainlineItem constructor
+/// @param parent pointer to the parent item
+//---------------------------------------------------------------------------------------------------------------------
+VGrainlineItem::VGrainlineItem(QGraphicsItem* parent)
+    : VPieceItem(parent),
+      m_rotation(0),
+      m_rotationStart(0),
+      m_length(0),
+      m_boundingPoly(),
+      m_startPos(),
+      m_movePos(),
+      m_resizePolygon(),
+      m_startLength(0),
+      m_startPoint(),
+      m_finishPoint(),
+      m_centerPoint(),
+      m_angle(0),
+      m_arrowType(ArrowType::Both),
       m_penWidth(LINE_PEN_WIDTH)
 {
     setAcceptHoverEvents(true);
     m_inactiveZ = 5;
-    Reset();
-    UpdateRectangle();
+    reset();
+    updateRectangle();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 QPainterPath VGrainlineItem::shape() const
 {
-    if (m_eMode == mNormal)
+    if (m_mode == Mode::Normal)
     {
-        return MainShape();
+        return mainShape();
     }
     else
     {
         QPainterPath path;
-        path.addPolygon(m_polyBound);
+        path.addPolygon(m_boundingPoly);
         return path;
     }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VGrainlineItem::paint paints the item content
- * @param painter pointer to the painter object
- * @param option not used
- * @param widget not used
- */
+/// @brief VGrainlineItem::paint paints the item content
+/// @param painter pointer to the painter object
+/// @param option not used
+/// @param widget not used
+//---------------------------------------------------------------------------------------------------------------------
 void VGrainlineItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
     Q_UNUSED(option)
@@ -114,59 +133,57 @@ void VGrainlineItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
 
     painter->setRenderHints(QPainter::Antialiasing);
     // line
-    const QLineF mainLine = MainLine();
-    painter->drawLine(mainLine.p1(), mainLine.p2());
+    const QLineF line = mainLine();
+    painter->drawLine(line.p1(), line.p2());
 
     painter->setBrush(color);
 
-    m_dScale = GetScale();
-    qreal dArrLen = ARROW_LENGTH*m_dScale;
-    if (m_eArrowType != ArrowType::atRear)
+    if (m_arrowType != ArrowType::Bottom)
     {
         // first arrow
-        painter->drawPolygon(FirstArrow(dArrLen));
+        painter->drawPolygon(firstArrow());
     }
-    if (m_eArrowType != ArrowType::atFront)
+    if (m_arrowType != ArrowType::Top)
     {
         // second arrow
-        painter->drawPolygon(SecondArrow(dArrLen));
+        painter->drawPolygon(secondArrow());
     }
 
-    if (m_eMode != mNormal)
+    if (m_mode != Mode::Normal)
     {
         painter->setPen(QPen(Qt::black, 2, Qt::DashLine));
         painter->setBrush(Qt::NoBrush);
         // bounding polygon
-        painter->drawPolygon(m_polyBound);
+        painter->drawPolygon(m_boundingPoly);
 
-        if (m_eMode != mRotate)
+        if (m_mode != Mode::Rotate)
         {
             painter->setPen(QPen(Qt::black, 3));
             painter->setBrush(Qt::black);
-            UpdatePolyResize();
-            painter->drawPolygon(m_polyResize);
+            updatePolyResize();
+            painter->drawPolygon(m_resizePolygon);
         }
 
         painter->setBrush(Qt::NoBrush);
-        if (m_eMode == mResize)
+        if (m_mode == Mode::Resize)
         {
             painter->setPen(Qt::black);
-            painter->drawLine(m_polyBound.at(0), m_polyBound.at(2));
-            painter->drawLine(m_polyBound.at(1), m_polyBound.at(3));
+            painter->drawLine(m_boundingPoly.at(0), m_boundingPoly.at(2));
+            painter->drawLine(m_boundingPoly.at(1), m_boundingPoly.at(3));
         }
 
-        if (m_eMode == mRotate)
+        if (m_mode == Mode::Rotate)
         {
-            QPointF ptC = (m_polyBound.at(0) + m_polyBound.at(2))/2;
-            qreal dRad = m_dScale * ROTATE_CIRC_R;
+            QPointF ptC = (m_boundingPoly.at(0) + m_boundingPoly.at(2))/2;
+            qreal dRad =  ROTATE_CIRC_R;
             painter->setBrush(Qt::black);
             painter->drawEllipse(ptC, dRad, dRad);
 
             painter->setBrush(Qt::NoBrush);
             painter->save();
             painter->translate(ptC);
-            painter->rotate(qRadiansToDegrees(-m_dRotation));
-            int iX = int(qRound(m_dLength/2 - 0.5*dRad));
+            painter->rotate(qRadiansToDegrees(-m_rotation));
+            int iX = int(qRound(m_length/2 - 0.5*dRad));
             int iY = int(qRound(RECT_WIDTH - 0.5*dRad));
             int iR = int(qRound(dRad*3));
             painter->drawArc(iX - iR, iY - iR, iR, iR, 0*16, -90*16);
@@ -180,51 +197,50 @@ void VGrainlineItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VGrainlineItem::UpdateGeometry updates the item with grainline parameters
- * @param ptPos position of one grainline's end
- * @param dRotation rotation of the grainline in [degrees]
- * @param dLength length of the grainline in user's units
- */
-void VGrainlineItem::UpdateGeometry(const QPointF& ptPos, qreal dRotation, qreal dLength, ArrowType eAT)
+/// @brief VGrainlineItem::updateGeometry updates the item with grainline parameters.
+/// @param position position of one grainline's end.
+/// @param rotation rotation of the grainline in [degrees].
+/// @param length length of the grainline in user's units.
+/// @param type type of arrowhead.
+//---------------------------------------------------------------------------------------------------------------------
+void VGrainlineItem::updateGeometry(const QPointF& position, qreal rotation, qreal length, ArrowType type)
 {
-    m_dRotation = qDegreesToRadians(dRotation);
-    m_dLength = dLength;
+    m_rotation = qDegreesToRadians(rotation);
+    m_length = length;
 
     qreal dX;
     qreal dY;
-    QPointF pt = ptPos;
-    if (isContained(pt, m_dRotation, dX, dY) == false)
+    QPointF point = position;
+    if (isContained(point, m_rotation, dX, dY) == false)
     {
-        pt.setX(pt.x() + dX);
-        pt.setY(pt.y() + dY);
+        point.setX(point.x() + dX);
+        point.setY(point.y() + dY);
     }
-    setPos(pt);
-    m_eArrowType = eAT;
+    setPos(point);
+    m_arrowType = type;
 
-    UpdateRectangle();
-    Update();
+    updateRectangle();
+    updateItem();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VGrainlineItem::isContained checks, if both ends of the grainline, starting at pt, are contained in
- * parent widget.
- * @param pt starting point of the grainline.
- * @param dRot rotation of the grainline in [rad]
- * @param dX horizontal translation needed to put the arrow inside parent item
- * @param dY vertical translation needed to put the arrow inside parent item
- * @return true, if both ends of the grainline, starting at pt, are contained in the parent widget and
- * false otherwise.
- */
-bool VGrainlineItem::isContained(const QPointF& pt, qreal dRot, qreal &dX, qreal &dY) const
+/// @brief VGrainlineItem::isContained checks, if both ends of the grainline, starting at point, are contained in
+/// parent widget.
+/// @param point starting point of the grainline.
+/// @param dRot rotation of the grainline in [rad]
+/// @param dX horizontal translation needed to put the arrow inside parent item
+/// @param dY vertical translation needed to put the arrow inside parent item
+/// @return true, if both ends of the grainline, starting at point, are contained in the parent widget and
+/// false otherwise.
+//---------------------------------------------------------------------------------------------------------------------
+bool VGrainlineItem::isContained(const QPointF& point, qreal dRot, qreal &dX, qreal &dY) const
 {
     dX = 0;
     dY = 0;
-    QPointF apt[2];
-    apt[0] = pt;
-    apt[1].setX(pt.x() + m_dLength * cos(dRot));
-    apt[1].setY(pt.y() - m_dLength * sin(dRot));
+    QPointF apoint[2];
+    apoint[0] = point;
+    apoint[1].setX(point.x() + m_length * cos(dRot));
+    apoint[1].setY(point.y() - m_length * sin(dRot));
     // single point differences
     qreal dPtX;
     qreal dPtY;
@@ -235,23 +251,23 @@ bool VGrainlineItem::isContained(const QPointF& pt, qreal dRot, qreal &dX, qreal
     {
         dPtX = 0;
         dPtY = 0;
-        if (rectParent.contains(apt[i]) == false)
+        if (rectParent.contains(apoint[i]) == false)
         {
-            if (apt[i].x() < rectParent.left())
+            if (apoint[i].x() < rectParent.left())
             {
-                dPtX = rectParent.left() - apt[i].x();
+                dPtX = rectParent.left() - apoint[i].x();
             }
-            else if (apt[i].x() > rectParent.right())
+            else if (apoint[i].x() > rectParent.right())
             {
-                dPtX = rectParent.right() - apt[i].x();
+                dPtX = rectParent.right() - apoint[i].x();
             }
-            if (apt[i].y() < rectParent.top())
+            if (apoint[i].y() < rectParent.top())
             {
-                dPtY = rectParent.top() - apt[i].y();
+                dPtY = rectParent.top() - apoint[i].y();
             }
-            else if (apt[i].y() > rectParent.bottom())
+            else if (apoint[i].y() > rectParent.bottom())
             {
-                dPtY = rectParent.bottom() - apt[i].y();
+                dPtY = rectParent.bottom() - apoint[i].y();
             }
 
             if (fabs(dPtX) > fabs(dX))
@@ -270,39 +286,38 @@ bool VGrainlineItem::isContained(const QPointF& pt, qreal dRot, qreal &dX, qreal
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VGrainlineItem::mousePressEvent handles left button mouse press events
- * @param pME pointer to QGraphicsSceneMouseEvent object
- */
-void VGrainlineItem::mousePressEvent(QGraphicsSceneMouseEvent* pME)
+/// @brief VGrainlineItem::mousePressEvent handles left button mouse press events
+/// @param event pointer to QGraphicsSceneMouseEvent object
+//---------------------------------------------------------------------------------------------------------------------
+void VGrainlineItem::mousePressEvent(QGraphicsSceneMouseEvent* event)
 {
-    if (pME->button() == Qt::LeftButton && pME->type() != QEvent::GraphicsSceneMouseDoubleClick
+    if (event->button() == Qt::LeftButton && event->type() != QEvent::GraphicsSceneMouseDoubleClick
         && (flags() & QGraphicsItem::ItemIsMovable))
     {
         if (m_moveType == NotMovable)
         {
-            pME->ignore();
+            event->ignore();
             return;
         }
 
-        m_ptStartPos = pos();
-        m_ptStartMove = pME->scenePos();
-        m_dStartLength = m_dLength;
-        m_dStartRotation = m_dRotation;
-        m_dAngle = GetAngle(mapToParent(pME->pos()));
-        m_ptRotCenter = m_ptCenter;
+        m_startPos = pos();
+        m_movePos = event->scenePos();
+        m_startLength = m_length;
+        m_rotationStart = m_rotation;
+        m_angle = GetAngle(mapToParent(event->pos()));
+        m_rotationCenter = m_centerPoint;
 
         if ((m_moveType & AllModifications ) == AllModifications)
         {
-            allUserModifications(pME->pos());
+            allUserModifications(event->pos());
             setZValue(ACTIVE_Z);
-            Update();
+            updateItem();
         }
         else if (m_moveType & IsRotatable)
         {
             if (m_moveType & IsResizable)
             {
-                allUserModifications(pME->pos());
+                allUserModifications(event->pos());
             }
             else if (m_moveType & IsMovable)
             {
@@ -310,24 +325,24 @@ void VGrainlineItem::mousePressEvent(QGraphicsSceneMouseEvent* pME)
             }
             else
             {
-                m_eMode = mRotate;
+                m_mode = Mode::Rotate;
                 SetItemOverrideCursor(this, cursorArrowCloseHand, 1, 1);
             }
             setZValue(ACTIVE_Z);
-            Update();
+            updateItem();
         }
         else if (m_moveType & IsResizable)
         {
             if (m_moveType & IsRotatable)
             {
-                allUserModifications(pME->pos());
+                allUserModifications(event->pos());
             }
             else if (m_moveType & IsMovable)
             {
-                userMoveAndResize(pME->pos());
+                userMoveAndResize(event->pos());
             }
             setZValue(ACTIVE_Z);
-            Update();
+            updateItem();
         }
         else if (m_moveType & IsMovable)
         {
@@ -337,58 +352,57 @@ void VGrainlineItem::mousePressEvent(QGraphicsSceneMouseEvent* pME)
             }
             else if (m_moveType & IsResizable)
             {
-                userMoveAndResize(pME->pos());
+                userMoveAndResize(event->pos());
             }
             else
             {
-                m_eMode = mMove;
+                m_mode = Mode::Move;
                 SetItemOverrideCursor(this, cursorArrowCloseHand, 1, 1);
             }
 
             setZValue(ACTIVE_Z);
-            Update();
+            updateItem();
         }
         else
         {
-            pME->ignore();
+            event->ignore();
             return;
         }
     }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VGrainlineItem::mouseMoveEvent handles mouse move events, making sure that the item is moved properly
- * @param pME pointer to QGraphicsSceneMouseEvent object
- */
-void VGrainlineItem::mouseMoveEvent(QGraphicsSceneMouseEvent* pME)
+/// @brief VGrainlineItem::mouseMoveEvent handles mouse move events, making sure that the item is moved properly
+/// @param event pointer to QGraphicsSceneMouseEvent object
+//---------------------------------------------------------------------------------------------------------------------
+void VGrainlineItem::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
 {
-    QPointF ptDiff = pME->scenePos() - m_ptStartMove;
+    QPointF delta = event->scenePos() - m_movePos;
     qreal dX;
     qreal dY;
-    if (m_eMode == mMove && m_moveType & IsMovable)
+    if (m_mode == Mode::Move && m_moveType & IsMovable)
     {
-        QPointF pt = m_ptStartPos + ptDiff;
-        if (isContained(pt, m_dRotation, dX, dY) == false)
+        QPointF point = m_startPos + delta;
+        if (isContained(point, m_rotation, dX, dY) == false)
         {
-            pt.setX(pt.x() + dX);
-            pt.setY(pt.y() + dY);
+            point.setX(point.x() + dX);
+            point.setY(point.y() + dY);
         }
-        setPos(pt);
-        Update();
+        setPos(point);
+        updateItem();
     }
-    else if (m_eMode == mResize && m_moveType & IsResizable)
+    else if (m_mode == Mode::Resize && m_moveType & IsResizable)
     {
-        qreal dLen = qSqrt(ptDiff.x()*ptDiff.x() + ptDiff.y()*ptDiff.y());
-        qreal dAng = qAtan2(-ptDiff.y(), ptDiff.x());
-        dLen = -dLen*qCos(dAng - m_dRotation);
-        qreal dPrevLen = m_dLength;
+        qreal dLen = qSqrt(delta.x()*delta.x() + delta.y()*delta.y());
+        qreal dAng = qAtan2(-delta.y(), delta.x());
+        dLen = -dLen*qCos(dAng - m_rotation);
+        qreal dPrevLen = m_length;
         // try with new length
-        if (not (m_moveType & IsMovable))
+        if (!(m_moveType & IsMovable))
         {
             dLen *= 2;
         }
-        m_dLength = m_dStartLength + dLen;
+        m_length = m_startLength + dLen;
 
         QPointF pos;
 
@@ -396,193 +410,189 @@ void VGrainlineItem::mouseMoveEvent(QGraphicsSceneMouseEvent* pME)
         {
             QLineF grainline(this->pos().x(), this->pos().y(),
                              this->pos().x() + dPrevLen, this->pos().y());
-            grainline.setAngle(qRadiansToDegrees(m_dRotation));
+            grainline.setAngle(qRadiansToDegrees(m_rotation));
             grainline = QLineF(grainline.p2(), grainline.p1());
-            grainline.setLength(m_dLength);
+            grainline.setLength(m_length);
             pos = grainline.p2();
         }
         else
         {
-            QLineF grainline(m_ptCenter.x(), m_ptCenter.y(),
-                             m_ptCenter.x() + m_dLength / 2.0, m_ptCenter.y());
+            QLineF grainline(m_centerPoint.x(), m_centerPoint.y(),
+                             m_centerPoint.x() + m_length / 2.0, m_centerPoint.y());
 
-            grainline.setAngle(qRadiansToDegrees(m_dRotation));
+            grainline.setAngle(qRadiansToDegrees(m_rotation));
             grainline = QLineF(grainline.p2(), grainline.p1());
-            grainline.setLength(m_dLength);
+            grainline.setLength(m_length);
 
             pos = grainline.p2();
         }
 
         qreal dX;
         qreal dY;
-        if (isContained(pos, m_dRotation, dX, dY) == false)
+        if (isContained(pos, m_rotation, dX, dY) == false)
         {
-            m_dLength = dPrevLen;
+            m_length = dPrevLen;
         }
         else
         {
             setPos(pos);
         }
 
-        UpdateRectangle();
-        Update();
+        updateRectangle();
+        updateItem();
     }
-    else if (m_eMode == mRotate && m_moveType & IsRotatable)
+    else if (m_mode == Mode::Rotate && m_moveType & IsRotatable)
     {
         // prevent strange angle changes due to singularities
-        qreal dLen = qSqrt(ptDiff.x()*ptDiff.x() + ptDiff.y()*ptDiff.y());
+        qreal dLen = qSqrt(delta.x()*delta.x() + delta.y()*delta.y());
         if (dLen < 2)
         {
             return;
         }
 
-        if (fabs(m_dAngle) < 0.01)
+        if (fabs(m_angle) < 0.01)
         {
-            m_dAngle = GetAngle(mapToParent(pME->pos()));
+            m_angle = GetAngle(mapToParent(event->pos()));
             return;
         }
 
-        qreal dAng = GetAngle(mapToParent(pME->pos())) - m_dAngle;
-        QPointF ptNewPos = Rotate(m_ptStartPos, m_ptRotCenter, dAng);
-        if (isContained(ptNewPos, m_dStartRotation + dAng, dX, dY) == true)
+        qreal dAng = GetAngle(mapToParent(event->pos())) - m_angle;
+        QPointF ptNewPos = rotate(m_startPos, m_rotationCenter, dAng);
+        if (isContained(ptNewPos, m_rotationStart + dAng, dX, dY) == true)
         {
             setPos(ptNewPos);
-            m_dRotation = m_dStartRotation + dAng;
-            UpdateRectangle();
-            Update();
+            m_rotation = m_rotationStart + dAng;
+            updateRectangle();
+            updateItem();
         }
     }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VGrainlineItem::mouseReleaseEvent handles mouse release events and emits the proper signal if the item was
- * moved
- * @param pME pointer to QGraphicsSceneMouseEvent object
- */
-void VGrainlineItem::mouseReleaseEvent(QGraphicsSceneMouseEvent* pME)
+/// @brief VGrainlineItem::mouseReleaseEvent handles mouse release events and emits the proper signal if the item was
+/// moved
+/// @param event pointer to QGraphicsSceneMouseEvent object
+//---------------------------------------------------------------------------------------------------------------------
+void VGrainlineItem::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
 {
-    if (pME->button() == Qt::LeftButton)
+    if (event->button() == Qt::LeftButton)
     {
-        if ((m_eMode == mMove || m_eMode == mRotate || m_eMode == mResize) && (flags() & QGraphicsItem::ItemIsMovable))
+        if ((m_mode == Mode::Move || m_mode == Mode::Rotate || m_mode == Mode::Resize) && (flags() & QGraphicsItem::ItemIsMovable))
         {
             SetItemOverrideCursor(this, cursorArrowOpenHand, 1, 1);
         }
 
-        QPointF ptDiff = pME->scenePos() - m_ptStartMove;
-        qreal dLen = qSqrt(ptDiff.x()*ptDiff.x() + ptDiff.y()*ptDiff.y());
+        QPointF delta = event->scenePos() - m_movePos;
+        qreal dLen = qSqrt(delta.x()*delta.x() + delta.y()*delta.y());
         bool bShort = (dLen < 2);
 
-        if (m_eMode == mMove || m_eMode == mResize)
+        if (m_mode == Mode::Move || m_mode == Mode::Resize)
         {
             if (bShort == true)
             {
-                if (m_bReleased == true && m_moveType & IsRotatable)
+                if (m_isReleased == true && m_moveType & IsRotatable)
                 {
-                    m_eMode = mRotate;
-                    Update();
+                    m_mode = Mode::Rotate;
+                    updateItem();
                 }
             }
             else
             {
-                if (m_eMode == mMove && m_moveType & IsMovable)
+                if (m_mode == Mode::Move && m_moveType & IsMovable)
                 {
                     emit itemMoved(pos());
                 }
                 else if (m_moveType & IsResizable)
                 {
-                    emit itemResized(m_dLength);
+                    emit itemResized(m_length);
                 }
-                Update();
+                updateItem();
             }
         }
         else
         {
             if (bShort == true)
             {
-                m_eMode = mMove;
+                m_mode = Mode::Move;
             }
             else if (m_moveType & IsRotatable)
             {
-                emit itemRotated(m_dRotation, m_ptStart);
+                emit itemRotated(m_rotation, m_startPoint);
             }
-            Update();
+            updateItem();
         }
-        m_bReleased = true;
+        m_isReleased = true;
     }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VGrainlineItem::hoverEnterEvent(QGraphicsSceneHoverEvent *pME)
+void VGrainlineItem::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 {
     m_penWidth = m_penWidth + 1;
-    VPieceItem::hoverEnterEvent(pME);
+    VPieceItem::hoverEnterEvent(event);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VGrainlineItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *pME)
+void VGrainlineItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 {
     m_penWidth = m_penWidth - 1;
-    VPieceItem::hoverLeaveEvent(pME);
+    VPieceItem::hoverLeaveEvent(event);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VGrainlineItem::Update updates the item
- */
-void VGrainlineItem::Update()
+/// @brief VGrainlineItem::updateItem updates the item
+//---------------------------------------------------------------------------------------------------------------------
+void VGrainlineItem::updateItem()
 {
-    update(m_rectBoundingBox);
+    update(m_boundingRect);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VGrainlineItem::UpdateRectangle updates the polygon for the box around active item
- * and the bounding rectangle
- */
-void VGrainlineItem::UpdateRectangle()
+/// @brief VGrainlineItem::updateRectangle updates the polygon for the box around active item
+/// and the bounding rectangle
+//---------------------------------------------------------------------------------------------------------------------
+void VGrainlineItem::updateRectangle()
 {
-    QPointF pt1(0, 0);
-    QPointF pt2(pt1.x() + m_dLength * cos(m_dRotation), pt1.y() - m_dLength * sin(m_dRotation));
+    QPointF point1(0, 0);
+    QPointF point2(point1.x() + m_length * cos(m_rotation), point1.y() - m_length * sin(m_rotation));
 
-    m_ptStart = mapToParent(pt1);
-    m_ptFinish = mapToParent(pt2);
-    m_ptCenter = (m_ptStart + m_ptFinish)/2;
+    m_startPoint  = mapToParent(point1);
+    m_finishPoint = mapToParent(point2);
+    m_centerPoint = (m_startPoint + m_finishPoint)/2;
 
-    m_polyBound.clear();
-    m_polyBound << QPointF(pt1.x() + RECT_WIDTH*cos(m_dRotation + M_PI/2),
-                           pt1.y() - RECT_WIDTH*sin(m_dRotation + M_PI/2));
-    m_polyBound << QPointF(pt1.x() + RECT_WIDTH*cos(m_dRotation - M_PI/2),
-                           pt1.y() - RECT_WIDTH*sin(m_dRotation - M_PI/2));
-    m_polyBound << QPointF(pt2.x() + RECT_WIDTH*cos(m_dRotation - M_PI/2),
-                           pt2.y() - RECT_WIDTH*sin(m_dRotation - M_PI/2));
-    m_polyBound << QPointF(pt2.x() + RECT_WIDTH*cos(m_dRotation + M_PI/2),
-                           pt2.y() - RECT_WIDTH*sin(m_dRotation + M_PI/2));
-    m_rectBoundingBox = m_polyBound.boundingRect().adjusted(-2, -2, 2, 2);
-    setTransformOriginPoint(m_rectBoundingBox.center());
+    m_boundingPoly.clear();
+    m_boundingPoly << QPointF(point1.x() + RECT_WIDTH*cos(m_rotation + M_PI/2),
+                              point1.y() - RECT_WIDTH*sin(m_rotation + M_PI/2));
+    m_boundingPoly << QPointF(point1.x() + RECT_WIDTH*cos(m_rotation - M_PI/2),
+                              point1.y() - RECT_WIDTH*sin(m_rotation - M_PI/2));
+    m_boundingPoly << QPointF(point2.x() + RECT_WIDTH*cos(m_rotation - M_PI/2),
+                              point2.y() - RECT_WIDTH*sin(m_rotation - M_PI/2));
+    m_boundingPoly << QPointF(point2.x() + RECT_WIDTH*cos(m_rotation + M_PI/2),
+                              point2.y() - RECT_WIDTH*sin(m_rotation + M_PI/2));
+    m_boundingRect = m_boundingPoly.boundingRect().adjusted(-2, -2, 2, 2);
+    setTransformOriginPoint(m_boundingRect.center());
 
-    UpdatePolyResize();
+    updatePolyResize();
     prepareGeometryChange();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-double VGrainlineItem::GetAngle(const QPointF &pt) const
+double VGrainlineItem::GetAngle(const QPointF &point) const
 {
-    return -VPieceItem::GetAngle(pt);
+    return -VPieceItem::GetAngle(point);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VGrainlineItem::Rotate rotates point pt around ptCenter by angle dAng [rad]
- * and returns the resulting point
- * @param pt point to rotate
- * @param ptCenter center of rotation
- * @param dAng angle of rotation
- * @return point, which is a result of rotating pt around ptCenter by angle dAng
- */
-QPointF VGrainlineItem::Rotate(const QPointF& pt, const QPointF& ptCenter, qreal dAng) const
+/// @brief VGrainlineItem::rotate rotates point point around ptCenter by angle dAng [rad]
+/// and returns the resulting point
+/// @param point point to rotate
+/// @param ptCenter center of rotation
+/// @param dAng angle of rotation
+/// @return point, which is a result of rotating point around ptCenter by angle dAng
+//---------------------------------------------------------------------------------------------------------------------
+QPointF VGrainlineItem::rotate(const QPointF& point, const QPointF& ptCenter, qreal dAng) const
 {
-    QPointF ptRel = pt - ptCenter;
+    QPointF ptRel = point - ptCenter;
     QPointF ptFinal;
     ptFinal.setX(ptRel.x()*qCos(dAng) + ptRel.y()*qSin(dAng));
     ptFinal.setY(-ptRel.x()*qSin(dAng) + ptRel.y()*qCos(dAng));
@@ -591,89 +601,68 @@ QPointF VGrainlineItem::Rotate(const QPointF& pt, const QPointF& ptCenter, qreal
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VGrainlineItem::GetInsideCorner calculates a point inside the bounding polygon,
- * dDist away of i-th point in each direction
- * @param i index of corner
- * @param dDist distance
- * @return resulting point
- */
-QPointF VGrainlineItem::GetInsideCorner(int i, qreal dDist) const
+/// @brief VGrainlineItem::getInsideCorner calculates a point inside the bounding polygon,
+/// distance away of i-th point in each direction
+/// @param i index of corner
+/// @param distance distance
+/// @return resulting point
+//---------------------------------------------------------------------------------------------------------------------
+QPointF VGrainlineItem::getInsideCorner(int i, qreal distance) const
 {
-    QPointF pt1 = m_polyBound.at((i + 1) % m_polyBound.count()) - m_polyBound.at(i);
-    QPointF pt2 = m_polyBound.at((i + m_polyBound.count() - 1) % m_polyBound.count()) - m_polyBound.at(i);
+    QPointF point1 = m_boundingPoly.at((i + 1) % m_boundingPoly.count()) - m_boundingPoly.at(i);
 
-    pt1 = dDist*pt1/qSqrt(pt1.x()*pt1.x() + pt1.y()*pt1.y());
-    pt2 = dDist*pt2/qSqrt(pt2.x()*pt2.x() + pt2.y()*pt2.y());
+    QPointF point2 = m_boundingPoly.at((i + m_boundingPoly.count() - 1) %
+                     m_boundingPoly.count()) - m_boundingPoly.at(i);
 
-    return m_polyBound.at(i) + pt1 + pt2;
+    point1 = distance * point1/qSqrt(point1.x()*point1.x() + point1.y()*point1.y());
+    point2 = distance * point2/qSqrt(point2.x()*point2.x() + point2.y()*point2.y());
+
+    return m_boundingPoly.at(i) + point1 + point2;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief GetScale gets the scale for keeping the arrows of constant size
- */
-qreal VGrainlineItem::GetScale() const
+QLineF VGrainlineItem::mainLine() const
 {
-    if (scene()->views().count() > 0)
-    {
-        const QPoint pt0 = scene()->views().at(0)->mapFromScene(0, 0);
-        const QPoint pt = scene()->views().at(0)->mapFromScene(0, 100);
-        const QPoint p = pt - pt0;
-        qreal dScale = qSqrt(QPoint::dotProduct(p, p));
-        dScale = 100.0/dScale;
-        if (dScale < 1.0)
-        {
-            dScale = 1.0;
-        }
-        return dScale;
-    }
-
-    return 1.0;
+    QPointF point1;
+    QPointF point2(point1.x() + m_length * cos(m_rotation), point1.y() - m_length * sin(m_rotation));
+    return QLineF(point1, point2);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QLineF VGrainlineItem::MainLine() const
+QPolygonF VGrainlineItem::firstArrow() const
 {
-    QPointF pt1;
-    QPointF pt2(pt1.x() + m_dLength * cos(m_dRotation), pt1.y() - m_dLength * sin(m_dRotation));
-    return QLineF(pt1, pt2);
+    QPointF point2 = mainLine().p2();
+    QPolygonF polygon;
+    polygon << point2;
+    polygon << QPointF(point2.x() + ARROW_LENGTH * cos(M_PI + m_rotation + ARROW_ANGLE),
+                       point2.y() - ARROW_LENGTH * sin(M_PI + m_rotation + ARROW_ANGLE));
+    polygon << QPointF(point2.x() + ARROW_LENGTH * cos(M_PI + m_rotation - ARROW_ANGLE),
+                       point2.y() - ARROW_LENGTH * sin(M_PI + m_rotation - ARROW_ANGLE));
+    return polygon;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QPolygonF VGrainlineItem::FirstArrow(qreal dArrLen) const
+QPolygonF VGrainlineItem::secondArrow() const
 {
-    QPointF pt2 = MainLine().p2();
-    QPolygonF poly;
-    poly << pt2;
-    poly << QPointF(pt2.x() + dArrLen*cos(M_PI + m_dRotation + ARROW_ANGLE),
-                    pt2.y() - dArrLen*sin(M_PI + m_dRotation + ARROW_ANGLE));
-    poly << QPointF(pt2.x() + dArrLen*cos(M_PI + m_dRotation - ARROW_ANGLE),
-                    pt2.y() - dArrLen*sin(M_PI + m_dRotation - ARROW_ANGLE));
-    return poly;
+    QPointF point1 = mainLine().p1();
+    QPolygonF polygon;
+    polygon << point1;
+    polygon << QPointF(point1.x() + ARROW_LENGTH * cos(m_rotation + ARROW_ANGLE),
+                       point1.y() - ARROW_LENGTH * sin(m_rotation + ARROW_ANGLE));
+    polygon << QPointF(point1.x() + ARROW_LENGTH * cos(m_rotation - ARROW_ANGLE),
+                       point1.y() - ARROW_LENGTH * sin(m_rotation - ARROW_ANGLE));
+    return polygon;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QPolygonF VGrainlineItem::SecondArrow(qreal dArrLen) const
-{
-    QPointF pt1 = MainLine().p1();
-    QPolygonF poly;
-    poly << pt1;
-    poly << QPointF(pt1.x() + dArrLen*cos(m_dRotation + ARROW_ANGLE),
-                    pt1.y() - dArrLen*sin(m_dRotation + ARROW_ANGLE));
-    poly << QPointF(pt1.x() + dArrLen*cos(m_dRotation - ARROW_ANGLE),
-                    pt1.y() - dArrLen*sin(m_dRotation - ARROW_ANGLE));
-    return poly;
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-QPainterPath VGrainlineItem::MainShape() const
+QPainterPath VGrainlineItem::mainShape() const
 {
     QPainterPath path;
-    const QLineF mainLine = MainLine();
+    const QLineF line = mainLine();
+
     QPainterPath linePath;
-    linePath.moveTo(mainLine.p1());
-    linePath.lineTo(mainLine.p2());
+    linePath.moveTo(line.p1());
+    linePath.lineTo(line.p2());
     linePath.closeSubpath();
 
     QPainterPathStroker stroker;
@@ -681,21 +670,20 @@ QPainterPath VGrainlineItem::MainShape() const
     path.addPath((stroker.createStroke(linePath) + linePath).simplified());
     path.closeSubpath();
 
-    const qreal dArrLen = ARROW_LENGTH*GetScale();
-    if (m_eArrowType != ArrowType::atRear)
+    if (m_arrowType != ArrowType::Bottom)
     {
         // first arrow
         QPainterPath polyPath;
-        polyPath.addPolygon(FirstArrow(dArrLen));
+        polyPath.addPolygon(firstArrow());
         path.addPath((stroker.createStroke(polyPath) + polyPath).simplified());
         path.closeSubpath();
     }
 
-    if (m_eArrowType != ArrowType::atFront)
+    if (m_arrowType != ArrowType::Top)
     {
         // second arrow
         QPainterPath polyPath;
-        polyPath.addPolygon(SecondArrow(dArrLen));
+        polyPath.addPolygon(secondArrow());
         path.addPath((stroker.createStroke(polyPath) + polyPath).simplified());
         path.closeSubpath();
     }
@@ -705,7 +693,7 @@ QPainterPath VGrainlineItem::MainShape() const
 //---------------------------------------------------------------------------------------------------------------------
 void VGrainlineItem::allUserModifications(const QPointF &pos)
 {
-    if (m_eMode != mRotate)
+    if (m_mode != Mode::Rotate)
     {
         userMoveAndResize(pos);
     }
@@ -718,9 +706,9 @@ void VGrainlineItem::allUserModifications(const QPointF &pos)
 //---------------------------------------------------------------------------------------------------------------------
 void VGrainlineItem::userRotateAndMove()
 {
-    if (m_eMode != mRotate)
+    if (m_mode != Mode::Rotate)
     {
-        m_eMode = mMove;
+        m_mode = Mode::Move;
     }
     SetItemOverrideCursor(this, cursorArrowCloseHand, 1, 1);
 }
@@ -728,35 +716,34 @@ void VGrainlineItem::userRotateAndMove()
 //---------------------------------------------------------------------------------------------------------------------
 void VGrainlineItem::userMoveAndResize(const QPointF &pos)
 {
-    if (m_polyResize.containsPoint(pos, Qt::OddEvenFill) == true)
+    if (m_resizePolygon.containsPoint(pos, Qt::OddEvenFill) == true)
     {
-        m_eMode = mResize;
+        m_mode = Mode::Resize;
         setCursor(Qt::SizeFDiagCursor);
     }
     else
     {
-        m_eMode = mMove; // block later if need
+        m_mode = Mode::Move; // block later if need
         SetItemOverrideCursor(this, cursorArrowCloseHand, 1, 1);
     }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VGrainlineItem::UpdatePolyResize()
+void VGrainlineItem::updatePolyResize()
 {
-    m_polyResize.clear();
-    QPointF ptA = m_polyBound.at(1);
-    m_polyResize << ptA;
-    const double dSize = m_dScale * RESIZE_RECT_SIZE;
+    m_resizePolygon.clear();
+    QPointF point = m_boundingPoly.at(1);
+    m_resizePolygon << point;
 
-    ptA.setX(ptA.x() - dSize*cos(m_dRotation - M_PI/2));
-    ptA.setY(ptA.y() + dSize*sin(m_dRotation - M_PI/2));
-    m_polyResize << ptA;
+    point.setX(point.x() - RESIZE_RECT_SIZE * cos(m_rotation - M_PI/2));
+    point.setY(point.y() + RESIZE_RECT_SIZE * sin(m_rotation - M_PI/2));
+    m_resizePolygon << point;
 
-    ptA.setX(ptA.x() + dSize*cos(m_dRotation));
-    ptA.setY(ptA.y() - dSize*sin(m_dRotation));
-    m_polyResize << ptA;
+    point.setX(point.x() + RESIZE_RECT_SIZE * cos(m_rotation));
+    point.setY(point.y() - RESIZE_RECT_SIZE * sin(m_rotation));
+    m_resizePolygon << point;
 
-    ptA.setX(ptA.x() - dSize*cos(m_dRotation + M_PI/2));
-    ptA.setY(ptA.y() + dSize*sin(m_dRotation + M_PI/2));
-    m_polyResize << ptA;
+    point.setX(point.x() - RESIZE_RECT_SIZE * cos(m_rotation + M_PI/2));
+    point.setY(point.y() + RESIZE_RECT_SIZE * sin(m_rotation + M_PI/2));
+    m_resizePolygon << point;
 }

--- a/src/libs/vwidgets/vgrainlineitem.cpp
+++ b/src/libs/vwidgets/vgrainlineitem.cpp
@@ -66,7 +66,6 @@
 #include "vgrainlineitem.h"
 
 #define ARROW_ANGLE                     M_PI/9
-#define ARROW_LENGTH                    70.0
 #define RECT_WIDTH                      30
 #define RESIZE_RECT_SIZE                10
 #define ROTATE_CIRC_R                   7
@@ -78,21 +77,21 @@
 /// @param parent pointer to the parent item
 //---------------------------------------------------------------------------------------------------------------------
 VGrainlineItem::VGrainlineItem(QGraphicsItem* parent)
-    : VPieceItem(parent),
-      m_rotation(0),
-      m_rotationStart(0),
-      m_length(0),
-      m_boundingPoly(),
-      m_startPos(),
-      m_movePos(),
-      m_resizePolygon(),
-      m_startLength(0),
-      m_startPoint(),
-      m_finishPoint(),
-      m_centerPoint(),
-      m_angle(0),
-      m_arrowType(ArrowType::Both),
-      m_penWidth(LINE_PEN_WIDTH)
+    : VPieceItem(parent)
+    , m_rotation(0)
+    , m_rotationStart(0)
+    , m_length(0)
+    , m_boundingPoly()
+    , m_startPos()
+    , m_movePos()
+    , m_resizePolygon()
+    , m_startLength(0)
+    , m_startPoint()
+    , m_finishPoint()
+    , m_centerPoint()
+    , m_angle(0)
+    , m_arrowType(ArrowType::Both)
+    , m_penWidth(LINE_PEN_WIDTH)
 {
     setAcceptHoverEvents(true);
     m_inactiveZ = 5;
@@ -631,26 +630,28 @@ QLineF VGrainlineItem::mainLine() const
 //---------------------------------------------------------------------------------------------------------------------
 QPolygonF VGrainlineItem::firstArrow() const
 {
+    qreal arrowLength = qApp->Settings()->getDefaultArrowLength();
     QPointF point2 = mainLine().p2();
     QPolygonF polygon;
     polygon << point2;
-    polygon << QPointF(point2.x() + ARROW_LENGTH * cos(M_PI + m_rotation + ARROW_ANGLE),
-                       point2.y() - ARROW_LENGTH * sin(M_PI + m_rotation + ARROW_ANGLE));
-    polygon << QPointF(point2.x() + ARROW_LENGTH * cos(M_PI + m_rotation - ARROW_ANGLE),
-                       point2.y() - ARROW_LENGTH * sin(M_PI + m_rotation - ARROW_ANGLE));
+    polygon << QPointF(point2.x() + arrowLength * cos(M_PI + m_rotation + ARROW_ANGLE),
+                       point2.y() - arrowLength * sin(M_PI + m_rotation + ARROW_ANGLE));
+    polygon << QPointF(point2.x() + arrowLength * cos(M_PI + m_rotation - ARROW_ANGLE),
+                       point2.y() - arrowLength * sin(M_PI + m_rotation - ARROW_ANGLE));
     return polygon;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 QPolygonF VGrainlineItem::secondArrow() const
 {
+    qreal arrowLength = qApp->Settings()->getDefaultArrowLength();
     QPointF point1 = mainLine().p1();
     QPolygonF polygon;
     polygon << point1;
-    polygon << QPointF(point1.x() + ARROW_LENGTH * cos(m_rotation + ARROW_ANGLE),
-                       point1.y() - ARROW_LENGTH * sin(m_rotation + ARROW_ANGLE));
-    polygon << QPointF(point1.x() + ARROW_LENGTH * cos(m_rotation - ARROW_ANGLE),
-                       point1.y() - ARROW_LENGTH * sin(m_rotation - ARROW_ANGLE));
+    polygon << QPointF(point1.x() + arrowLength * cos(m_rotation + ARROW_ANGLE),
+                       point1.y() - arrowLength * sin(m_rotation + ARROW_ANGLE));
+    polygon << QPointF(point1.x() + arrowLength * cos(m_rotation - ARROW_ANGLE),
+                       point1.y() - arrowLength * sin(m_rotation - ARROW_ANGLE));
     return polygon;
 }
 

--- a/src/libs/vwidgets/vgrainlineitem.cpp
+++ b/src/libs/vwidgets/vgrainlineitem.cpp
@@ -401,6 +401,12 @@ void VGrainlineItem::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
         {
             dLen *= 2;
         }
+        // limit length of grainline to twice the length of the arrowheads.
+        qreal minLength = qApp->Settings()->getDefaultArrowLength() * 2.0;
+        if (m_startLength + dLen < minLength)
+        {
+            return;
+        }
         m_length = m_startLength + dLen;
 
         QPointF pos;

--- a/src/libs/vwidgets/vgrainlineitem.h
+++ b/src/libs/vwidgets/vgrainlineitem.h
@@ -1,30 +1,52 @@
-/************************************************************************
- **
- **  @file   vgrainlineitem.h
- **  @author Bojan Kverh
- **  @date   September 10, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vgrainlineitem.h
+//  @author Douglas S Caskey
+//  @date   11 Nov, 2024
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vgrainlineitem.h
+//  @author Bojan Kverh
+//  @date   September 10, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2015 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #ifndef VGRAINLINEITEM_H
 #define VGRAINLINEITEM_H
@@ -37,68 +59,65 @@ class VGrainlineItem : public VPieceItem
 {
     Q_OBJECT
 public:
-    explicit VGrainlineItem(QGraphicsItem* pParent = nullptr);
-    virtual ~VGrainlineItem() Q_DECL_EQ_DEFAULT;
+    explicit             VGrainlineItem(QGraphicsItem* parent = nullptr);
+    virtual             ~VGrainlineItem() Q_DECL_EQ_DEFAULT;
 
     virtual QPainterPath shape() const Q_DECL_OVERRIDE;
 
-    virtual void paint(QPainter* pP, const QStyleOptionGraphicsItem* pOption, QWidget* pWidget) Q_DECL_OVERRIDE;
-    void         UpdateGeometry(const QPointF& ptPos, qreal dRotation, qreal dLength, ArrowType eAT);
+    virtual void         paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) Q_DECL_OVERRIDE;
+    void                 updateGeometry(const QPointF& pos, qreal rotation, qreal length, ArrowType type);
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
-    enum { Type = UserType + static_cast<int>(Vis::GrainlineItem)};
+    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    enum                 {Type = UserType + static_cast<int>(Vis::GrainlineItem)};
 
-    bool isContained(const QPointF &pt, qreal dRot, qreal &dX, qreal &dY) const;
+    bool                 isContained(const QPointF &pt, qreal dRot, qreal &dX, qreal &dY) const;
 
 signals:
-    void itemResized(qreal dLength);
-    void itemRotated(qreal dRot, const QPointF& ptNewPos);
+    void                 itemResized(qreal dLength);
+    void                 itemRotated(qreal dRot, const QPointF& ptNewPos);
 
 protected:
-    virtual void mousePressEvent(QGraphicsSceneMouseEvent* pME) Q_DECL_OVERRIDE;
-    virtual void mouseMoveEvent(QGraphicsSceneMouseEvent* pME) Q_DECL_OVERRIDE;
-    virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent* pME) Q_DECL_OVERRIDE;
-    virtual void hoverEnterEvent(QGraphicsSceneHoverEvent* pME) Q_DECL_OVERRIDE;
-    virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent* pME) Q_DECL_OVERRIDE;
-    virtual void Update() Q_DECL_OVERRIDE;
-    void         UpdateRectangle();
+    virtual void         mousePressEvent(QGraphicsSceneMouseEvent* pME) Q_DECL_OVERRIDE;
+    virtual void         mouseMoveEvent(QGraphicsSceneMouseEvent* pME) Q_DECL_OVERRIDE;
+    virtual void         mouseReleaseEvent(QGraphicsSceneMouseEvent* pME) Q_DECL_OVERRIDE;
+    virtual void         hoverEnterEvent(QGraphicsSceneHoverEvent* pME) Q_DECL_OVERRIDE;
+    virtual void         hoverLeaveEvent(QGraphicsSceneHoverEvent* pME) Q_DECL_OVERRIDE;
+    virtual void         updateItem() Q_DECL_OVERRIDE;
+    void                 updateRectangle();
 
-    virtual double GetAngle(const QPointF &pt) const Q_DECL_OVERRIDE;
+    virtual double       GetAngle(const QPointF &pt) const Q_DECL_OVERRIDE;
 
-    QPointF Rotate(const QPointF& pt, const QPointF& ptCenter, qreal dAng) const;
-    QPointF GetInsideCorner(int i, qreal dDist) const;
+    QPointF              rotate(const QPointF& pt, const QPointF& ptCenter, qreal dAng) const;
+    QPointF              getInsideCorner(int i, qreal dDist) const;
 
 private:
     Q_DISABLE_COPY(VGrainlineItem)
-    qreal                         m_dRotation;
-    qreal                         m_dStartRotation;
-    qreal                         m_dLength;
-    QPolygonF                     m_polyBound;
-    QPointF                       m_ptStartPos;
-    QPointF                       m_ptStartMove;
-    qreal                         m_dScale;
-    QPolygonF                     m_polyResize;
-    qreal                         m_dStartLength;
-    QPointF                       m_ptStart;
-    QPointF                       m_ptFinish;
-    QPointF                       m_ptCenter;
-    qreal                         m_dAngle;
-    ArrowType                     m_eArrowType;
-    qreal                         m_penWidth;
+    qreal                m_rotation;
+    qreal                m_rotationStart;
+    qreal                m_length;
+    QPolygonF            m_boundingPoly;
+    QPointF              m_startPos;
+    QPointF              m_movePos;
+    QPolygonF            m_resizePolygon;
+    qreal                m_startLength;
+    QPointF              m_startPoint;
+    QPointF              m_finishPoint;
+    QPointF              m_centerPoint;
+    qreal                m_angle;
+    ArrowType            m_arrowType;
+    qreal                m_penWidth;
 
-    qreal GetScale() const;
+    QLineF               mainLine() const;
+    QPolygonF            firstArrow() const;
+    QPolygonF            secondArrow() const;
 
-    QLineF    MainLine() const;
-    QPolygonF FirstArrow(qreal dArrLen) const;
-    QPolygonF SecondArrow(qreal dArrLen) const;
+    QPainterPath         mainShape() const;
 
-    QPainterPath MainShape() const;
+    void                 allUserModifications(const QPointF &pos);
+    void                 userRotateAndMove();
+    void                 userMoveAndResize(const QPointF &pos);
 
-    void allUserModifications(const QPointF &pos);
-    void userRotateAndMove();
-    void userMoveAndResize(const QPointF &pos);
-
-    void UpdatePolyResize();
+    void                 updatePolyResize();
 };
 
 #endif // VGRAINLINEITEM_H

--- a/src/libs/vwidgets/vgrainlineitem.h
+++ b/src/libs/vwidgets/vgrainlineitem.h
@@ -98,7 +98,7 @@ private:
     QPolygonF            m_boundingPoly;
     QPointF              m_startPos;
     QPointF              m_movePos;
-    QPolygonF            m_resizePolygon;
+    QPolygonF            m_resizeHandle;
     qreal                m_startLength;
     QPointF              m_startPoint;
     QPointF              m_finishPoint;
@@ -117,7 +117,7 @@ private:
     void                 userRotateAndMove();
     void                 userMoveAndResize(const QPointF &pos);
 
-    void                 updatePolyResize();
+    void                 updateResizeHandle();
 };
 
 #endif // VGRAINLINEITEM_H

--- a/src/libs/vwidgets/vmaingraphicsview.cpp
+++ b/src/libs/vwidgets/vmaingraphicsview.cpp
@@ -480,7 +480,7 @@ VMainGraphicsView::VMainGraphicsView(QWidget *parent)
     , rubberBandRect(nullptr)
     , startPoint(QPoint())
     , endPoint(QPoint())
-    , m_ptStartPos(QPoint())
+    , m_startPos(QPoint())
     , cursorPos(QPoint())
 {
     initScrollBars();
@@ -655,7 +655,7 @@ void VMainGraphicsView::mousePressEvent(QMouseEvent *event)
                 const QList<QGraphicsItem *> list = items(event->pos());
                 if (list.size() == 0)
                 {// Only when the user clicks on the scene background
-                    m_ptStartPos = event->pos();
+                    m_startPos = event->pos();
                     QGraphicsView::setDragMode(QGraphicsView::ScrollHandDrag);
                     event->accept();
                     viewport()->setCursor(Qt::ClosedHandCursor);
@@ -697,7 +697,7 @@ void VMainGraphicsView::mousePressEvent(QMouseEvent *event)
         }
         case Qt::MiddleButton:
         {
-            m_ptStartPos = event->pos();
+            m_startPos = event->pos();
             QGraphicsView::setDragMode(QGraphicsView::ScrollHandDrag);
             event->accept();
             viewport()->setCursor(Qt::ClosedHandCursor);
@@ -716,10 +716,10 @@ void VMainGraphicsView::mouseMoveEvent(QMouseEvent *event)
     {
         QScrollBar *hBar = horizontalScrollBar();
         QScrollBar *vBar = verticalScrollBar();
-        const QPoint delta = event->pos() - m_ptStartPos;
+        const QPoint delta = event->pos() - m_startPos;
         hBar->setValue(hBar->value() + (isRightToLeft() ? delta.x() : -delta.x()));
         vBar->setValue(vBar->value() - delta.y());
-        m_ptStartPos = event->pos();
+        m_startPos = event->pos();
     }
     else if ( isRubberBandActive )
     {

--- a/src/libs/vwidgets/vmaingraphicsview.h
+++ b/src/libs/vwidgets/vmaingraphicsview.h
@@ -221,7 +221,7 @@ private:
     QRect                *rubberBandRect;
     QPoint                startPoint;
     QPoint                endPoint;
-    QPoint                m_ptStartPos;
+    QPoint                m_startPos;
     QPoint                cursorPos;
 };
 

--- a/src/libs/vwidgets/vpieceitem.cpp
+++ b/src/libs/vwidgets/vpieceitem.cpp
@@ -1,53 +1,52 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vpieceitem.cpp
+//  @author Douglas S Caskey
+//  @date   11 Nov, 2024
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
- ************************************************************************
- **
- **  @file
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   18 1, 2017
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2017 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vpieceitem.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   18 1, 2017
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2015 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #include "vpieceitem.h"
 #include "../vmisc/vmath.h"
@@ -56,15 +55,15 @@
 
 //---------------------------------------------------------------------------------------------------------------------
 VPieceItem::VPieceItem(QGraphicsItem *pParent)
-    : QGraphicsObject(pParent),
-      m_rectBoundingBox(),
-      m_eMode(VPieceItem::mNormal),
-      m_bReleased(false),
-      m_ptRotCenter(),
-      m_moveType(AllModifications),
-      m_inactiveZ(1)
+    : QGraphicsObject(pParent)
+    , m_boundingRect()
+    , m_mode(Mode::Normal)
+    , m_isReleased(false)
+    , m_rotationCenter()
+    , m_moveType(AllModifications)
+    , m_inactiveZ(1)
 {
-    m_rectBoundingBox.setTopLeft(QPointF(0, 0));
+    m_boundingRect.setTopLeft(QPointF(0, 0));
     setAcceptHoverEvents(true);
 }
 
@@ -74,51 +73,47 @@ VPieceItem::~VPieceItem()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief boundingRect returns the item bounding box
- * @return item bounding box
- */
+/// @brief boundingRect returns the item bounding box
+/// @return item bounding box
+//---------------------------------------------------------------------------------------------------------------------
 QRectF VPieceItem::boundingRect() const
 {
-    return m_rectBoundingBox;
+    return m_boundingRect;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Reset resets the item, putting the mode and z coordinate to normal and redraws it
- */
-void VPieceItem::Reset()
+/// @brief reset resets the item, putting the mode and z coordinate to normal and redraws it
+//---------------------------------------------------------------------------------------------------------------------
+void VPieceItem::reset()
 {
     if (QGraphicsScene *toolScene = scene())
     {
         toolScene->clearSelection();
     }
-    m_eMode = mNormal;
-    m_bReleased = false;
-    Update();
+    m_mode = Mode::Normal;
+    m_isReleased = false;
+    updateItem();
     setZValue(m_inactiveZ);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief IsIdle returns the idle flag.
- * @return true, if item mode is normal and false otherwise.
- */
-bool VPieceItem::IsIdle() const
+/// @brief isIdle returns the idle flag.
+/// @return true, if item mode is normal and false otherwise.
+//---------------------------------------------------------------------------------------------------------------------
+bool VPieceItem::isIdle() const
 {
-    return m_eMode == mNormal;
+    return m_mode == Mode::Normal;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief GetAngle calculates the angle between the line, which goes from rotation center to pt and x axis
- * @param pt point of interest
- * @return the angle between line from rotation center and point of interest and x axis
- */
-double VPieceItem::GetAngle(const QPointF &pt) const
+/// @brief GetAngle calculates the angle between the line, which goes from rotation center to point and x axis
+/// @param point point of interest
+/// @return the angle between line from rotation center and point of interest and x axis
+//---------------------------------------------------------------------------------------------------------------------
+double VPieceItem::GetAngle(const QPointF &point) const
 {
-    const double dX = pt.x() - m_ptRotCenter.x();
-    const double dY = pt.y() - m_ptRotCenter.y();
+    const double dX = point.x() - m_rotationCenter.x();
+    const double dY = point.y() - m_rotationCenter.y();
 
     if (fabs(dX) < 1 && fabs(dY) < 1)
     {
@@ -131,13 +126,13 @@ double VPieceItem::GetAngle(const QPointF &pt) const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-VPieceItem::MoveTypes VPieceItem::GetMoveType() const
+VPieceItem::MoveTypes VPieceItem::getMoveType() const
 {
     return m_moveType;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VPieceItem::SetMoveType(const VPieceItem::MoveTypes &moveType)
+void VPieceItem::setMoveType(const VPieceItem::MoveTypes &moveType)
 {
     m_moveType = moveType;
     setAcceptHoverEvents(m_moveType != NotMovable);

--- a/src/libs/vwidgets/vpieceitem.h
+++ b/src/libs/vwidgets/vpieceitem.h
@@ -1,53 +1,52 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vpieceitem.h
+//  @author Douglas S Caskey
+//  @date   11 Nov, 2024
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
- ************************************************************************
- **
- **  @file
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   18 1, 2017
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2017 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vpieceitem.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   18 1, 2017
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2015 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #ifndef VPIECEITEM_H
 #define VPIECEITEM_H
@@ -63,54 +62,47 @@ class VPieceItem : public QGraphicsObject
 public:
     enum MoveType
     {
-        NotMovable = 0x0,
+        NotMovable  = 0x0, // 0000
         IsRotatable = 0x1, // 0001
         IsResizable = 0x2, // 0010
-        IsMovable = 0x4,   // 0100
-        AllModifications = IsRotatable | IsResizable | IsMovable,
-        Error = 0x8        // 1000
+        IsMovable   = 0x4, // 0100
+        Error       = 0x8,  // 1000
+        AllModifications = IsRotatable | IsResizable | IsMovable // 0111
     };
     Q_DECLARE_FLAGS(MoveTypes, MoveType)
 
-    explicit VPieceItem(QGraphicsItem* pParent = nullptr);
-    virtual ~VPieceItem();
+    explicit              VPieceItem(QGraphicsItem* pParent = nullptr);
+    virtual              ~VPieceItem();
 
-    virtual QRectF boundingRect() const Q_DECL_OVERRIDE;
+    virtual QRectF        boundingRect() const Q_DECL_OVERRIDE;
 
-    virtual void Update() =0;
+    virtual void          updateItem() =0;
 
-    void Reset();
-    bool IsIdle() const;
+    void                  reset();
+    bool                  isIdle() const;
 
-    VPieceItem::MoveTypes GetMoveType() const;
-    void                  SetMoveType(const VPieceItem::MoveTypes &moveType);
+    VPieceItem::MoveTypes getMoveType() const;
+    void                  setMoveType(const VPieceItem::MoveTypes &moveType);
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
-    enum { Type = UserType + static_cast<int>(Vis::PieceItem)};
+    virtual int           type() const Q_DECL_OVERRIDE {return Type;}
+    enum                  {Type = UserType + static_cast<int>(Vis::PieceItem)};
 
 signals:
-    void itemMoved(const QPointF &ptPos);
+    void                  itemMoved(const QPointF &ptPos);
 
 protected:
-    enum Mode
-    {
-        mNormal,
-        mMove,
-        mResize,
-        mRotate
-    };
-    QRectF                m_rectBoundingBox;
-    Mode                  m_eMode;
-    bool                  m_bReleased;
-    QPointF               m_ptRotCenter;
+    enum class Mode       {Normal, Move, Resize, Rotate};
+    QRectF                m_boundingRect;
+    Mode                  m_mode;
+    bool                  m_isReleased;
+    QPointF               m_rotationCenter;
     VPieceItem::MoveTypes m_moveType;
+    qreal                 m_inactiveZ;
 
-    qreal m_inactiveZ;
-
-    virtual double GetAngle(const QPointF &pt) const;
+    virtual double        GetAngle(const QPointF &pt) const;
 
 private:
-    Q_DISABLE_COPY(VPieceItem)
+                          Q_DISABLE_COPY(VPieceItem)
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(VPieceItem::MoveTypes)

--- a/src/libs/vwidgets/vtextgraphicsitem.cpp
+++ b/src/libs/vwidgets/vtextgraphicsitem.cpp
@@ -192,24 +192,24 @@ void VTextGraphicsItem::paint(QPainter *painter, const QStyleOptionGraphicsItem 
     }
 
     // now draw the features specific to non-normal modes
-    if (m_eMode != mNormal)
+    if (m_mode != Mode::Normal)
     {
         // outextLineine the rectangle
         painter->setPen(QPen(Qt::black, 2, Qt::DashLine));
         painter->drawRect(boundingRect().adjusted(1, 1, -1, -1));
 
-        if (m_eMode != mRotate)
+        if (m_mode != Mode::Rotate)
         {
             // draw the resize square
             painter->setPen(Qt::black);
             painter->setBrush(Qt::black);
             painter->drawRect(m_rectResize.adjusted(-1, -1, -1, -1));
 
-            if (m_eMode == mResize)
+            if (m_mode == Mode::Resize)
             {
                 // draw the resize diagonal lines
-                painter->drawLine(1, 1, qFloor(m_rectBoundingBox.width())-1, qFloor(m_rectBoundingBox.height())-1);
-                painter->drawLine(1, qFloor(m_rectBoundingBox.height())-1, qFloor(m_rectBoundingBox.width())-1, 1);
+                painter->drawLine(1, 1, qFloor(m_boundingRect.width())-1, qFloor(m_boundingRect.height())-1);
+                painter->drawLine(1, qFloor(m_boundingRect.height())-1, qFloor(m_boundingRect.width())-1, 1);
             }
         }
         else
@@ -218,19 +218,19 @@ void VTextGraphicsItem::paint(QPainter *painter, const QStyleOptionGraphicsItem 
             painter->setPen(Qt::black);
             painter->setBrush(Qt::black);
             painter->drawEllipse(
-                        QPointF(m_rectBoundingBox.width()/2, m_rectBoundingBox.height()/2),
+                        QPointF(m_boundingRect.width()/2, m_boundingRect.height()/2),
                         rotateCircle,
                         rotateCircle
                         );
-            if (m_rectBoundingBox.width() > minW*3 && m_rectBoundingBox.height() > minH*3)
+            if (m_boundingRect.width() > minW*3 && m_boundingRect.height() > minH*3)
             {
                 painter->setPen(QPen(Qt::black, 3));
                 painter->setBrush(Qt::NoBrush);
                 // and then draw the arc in each of the corners
                 int top = ROTATE_RECT - ROTATE_ARC;
                 int left = ROTATE_RECT - ROTATE_ARC;
-                int right = qRound(m_rectBoundingBox.width()) - ROTATE_RECT;
-                int bottom = qRound(m_rectBoundingBox.height()) - ROTATE_RECT;
+                int right = qRound(m_boundingRect.width()) - ROTATE_RECT;
+                int bottom = qRound(m_boundingRect.height()) - ROTATE_RECT;
                 painter->drawArc(left, top, ROTATE_ARC, ROTATE_ARC, 180*16, -90*16);
                 painter->drawArc(right, top, ROTATE_ARC, ROTATE_ARC, 90*16, -90*16);
                 painter->drawArc(left, bottom, ROTATE_ARC, ROTATE_ARC, 270*16, -90*16);
@@ -276,20 +276,20 @@ void VTextGraphicsItem::setSize(qreal width, qreal height)
     }
 
     prepareGeometryChange();
-    m_rectBoundingBox.setTopLeft(QPointF(0, 0));
-    m_rectBoundingBox.setWidth(width);
-    m_rectBoundingBox.setHeight(height);
+    m_boundingRect.setTopLeft(QPointF(0, 0));
+    m_boundingRect.setWidth(width);
+    m_boundingRect.setHeight(height);
     m_rectResize.setTopLeft(QPointF(width - resizeSquare, height - resizeSquare));
     m_rectResize.setWidth(resizeSquare);
     m_rectResize.setHeight(resizeSquare);
-    setTransformOriginPoint(m_rectBoundingBox.center());
+    setTransformOriginPoint(m_boundingRect.center());
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief VTextGraphicsItem::Update sets the correct size and font size and redraws the label
+ * @brief VTextGraphicsItem::updateItem sets the correct size and font size and redraws the label
  */
-void VTextGraphicsItem::Update()
+void VTextGraphicsItem::updateItem()
 {
     correctLabel();
     //UpdateBox();
@@ -401,9 +401,9 @@ void VTextGraphicsItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
         m_startPos = pos();
        qDebug() << " start position" << m_startPos;
         m_start = event->scenePos();
-        m_startSize = m_rectBoundingBox.size();
-        m_ptRotCenter = mapToScene(m_rectBoundingBox.center());
-        qDebug() << " center position" << m_ptRotCenter;
+        m_startSize = m_boundingRect.size();
+        m_rotationCenter = mapToScene(m_boundingRect.center());
+        qDebug() << " center position" << m_rotationCenter;
         m_angle = GetAngle(event->scenePos());
         m_rotation = rotation();
         // in rotation mode, do not do any changes here, because user might want to
@@ -413,7 +413,7 @@ void VTextGraphicsItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
         {
             allUserModifications(event->pos());
             setZValue(ACTIVE_Z);
-            Update();
+            updateItem();
         }
         else if (m_moveType & IsRotatable)
         {
@@ -427,11 +427,11 @@ void VTextGraphicsItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
             }
             else
             {
-                m_eMode = mRotate;
+                m_mode = Mode::Rotate;
                 SetItemOverrideCursor(this, cursorArrowCloseHand, 1, 1);
             }
             setZValue(ACTIVE_Z);
-            Update();
+            updateItem();
         }
         else if (m_moveType & IsResizable)
         {
@@ -445,7 +445,7 @@ void VTextGraphicsItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
                 userMoveAndResize(event->pos());
             }
             setZValue(ACTIVE_Z);
-            Update();
+            updateItem();
         }
         else if (m_moveType & IsMovable)
         {
@@ -459,12 +459,12 @@ void VTextGraphicsItem::mousePressEvent(QGraphicsSceneMouseEvent *event)
             }
             else
             {
-                m_eMode = mMove;
+                m_mode = Mode::Move;
                 SetItemOverrideCursor(this, cursorArrowCloseHand, 1, 1);
             }
 
             setZValue(ACTIVE_Z);
-            Update();
+            updateItem();
         }
         else
         {
@@ -486,14 +486,14 @@ void VTextGraphicsItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event )
     qreal yPos;
     QRectF rectBB;
     const QPointF ptDiff = event ->scenePos() - m_start;
-    if (m_eMode == mMove && m_moveType & IsMovable)
+    if (m_mode == Mode::Move && m_moveType & IsMovable)
     {
         qDebug() << " Item is Movable\n";
         // in move mode move the label along the mouse move from the origin
         QPointF pt = m_startPos + ptDiff;
         rectBB.setTopLeft(pt);
-        rectBB.setWidth(m_rectBoundingBox.width());
-        rectBB.setHeight(m_rectBoundingBox.height());
+        rectBB.setWidth(m_boundingRect.width());
+        rectBB.setHeight(m_boundingRect.height());
         // before moving label to a new position, check if it will still be inside the parent item
         if (isContained(rectBB, rotation(), xPos, yPos) == false)
         {
@@ -505,7 +505,7 @@ void VTextGraphicsItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event )
         qDebug() << " Item position" << pt;
         UpdateBox();
     }
-    else if (m_eMode == mResize && m_moveType & IsResizable)
+    else if (m_mode == Mode::Resize && m_moveType & IsResizable)
     {
         qDebug() << " Item is Resizable\n";
         // in resize mode, resize the label along the mouse move from the origin
@@ -517,7 +517,7 @@ void VTextGraphicsItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event )
         }
         else
         {
-            pt = m_ptRotCenter - QRectF(0, 0, m_startSize.width() + ptDiff.x(),
+            pt = m_rotationCenter - QRectF(0, 0, m_startSize.width() + ptDiff.x(),
                                         m_startSize.height() + ptDiff.y()).center();
         }
 
@@ -536,7 +536,7 @@ void VTextGraphicsItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event )
         }
         else
         {
-            if (not (m_moveType & IsMovable))
+            if (!(m_moveType & IsMovable))
             {
                 setPos(pt);
             }
@@ -544,10 +544,10 @@ void VTextGraphicsItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event )
 
         setSize(size.width(), size.height());
         qDebug() << " Item size" << size.width() << size.height();
-        Update();
+        updateItem();
         emit textShrink();
     }
-    else if (m_eMode == mRotate && m_moveType & IsRotatable)
+    else if (m_mode == Mode::Rotate && m_moveType & IsRotatable)
     {
         qDebug() << " Item is Rotatable\n";
         // if the angle from the original position is small (0.5 degrees), just remeber the new angle
@@ -560,13 +560,13 @@ void VTextGraphicsItem::mouseMoveEvent(QGraphicsSceneMouseEvent *event )
         // calculate the angle difference from the starting angle
         double angle =  qRadiansToDegrees(GetAngle(event ->scenePos()) - m_angle);
         rectBB.setTopLeft(m_startPos);
-        rectBB.setWidth(m_rectBoundingBox.width());
-        rectBB.setHeight(m_rectBoundingBox.height());
+        rectBB.setWidth(m_boundingRect.width());
+        rectBB.setHeight(m_boundingRect.height());
         // check if the rotated label will be inside the parent item and then rotate it
         if (isContained(rectBB, m_rotation + angle, xPos, yPos) == true)
         {
             setRotation(m_rotation + angle);
-            Update();
+            updateItem();
         }
     }
 }
@@ -581,7 +581,7 @@ void VTextGraphicsItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event )
     if (event ->button() == Qt::LeftButton)
     {
         // restore the cursor
-        if ((m_eMode == mMove || m_eMode == mRotate || m_eMode == mResize) && (flags() & QGraphicsItem::ItemIsMovable))
+        if ((m_mode == Mode::Move || m_mode == Mode::Rotate || m_mode == Mode::Resize) && (flags() & QGraphicsItem::ItemIsMovable))
         {
             SetItemOverrideCursor(this, cursorArrowOpenHand, 1, 1);
         }
@@ -589,33 +589,33 @@ void VTextGraphicsItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event )
         // determine if this was just press/release (isShort) or user did some operation between press and release
         bool isShort = (distance < 2);
 
-        if (m_eMode == mMove || m_eMode == mResize)
+        if (m_mode == Mode::Move || m_mode == Mode::Resize)
         {   // if user just pressed and released the button, we must switch the mode to rotate
             // but if user did some operation (move/resize), emit the proper signal and update the label
             if (isShort)
             {
-                if (m_bReleased  && m_moveType & IsRotatable)
+                if (m_isReleased  && m_moveType & IsRotatable)
                 {
-                    m_eMode = mRotate;
+                    m_mode = Mode::Rotate;
                     UpdateBox();
                 }
             }
-            else if (m_eMode == mMove && m_moveType & IsMovable)
+            else if (m_mode == Mode::Move && m_moveType & IsMovable)
             {
                 emit itemMoved(pos());
                 UpdateBox();
             }
             else if (m_moveType & IsResizable)
             {
-                emit itemResized(m_rectBoundingBox.width(), m_textMananger.GetFont().pixelSize());
-                Update();
+                emit itemResized(m_boundingRect.width(), m_textMananger.GetFont().pixelSize());
+                updateItem();
             }
         }
         else
         {   // in rotate mode, if user did just press/release, switch to move mode
             if (isShort && (m_moveType & IsMovable || m_moveType & IsResizable))
             {
-                m_eMode = mMove;
+                m_mode = Mode::Move;
             }
             else if (m_moveType & IsRotatable)
             {
@@ -624,7 +624,7 @@ void VTextGraphicsItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event )
             }
             UpdateBox();
         }
-        m_bReleased = true;
+        m_isReleased = true;
     }
 }
 
@@ -635,7 +635,7 @@ void VTextGraphicsItem::mouseReleaseEvent(QGraphicsSceneMouseEvent *event )
  */
 void VTextGraphicsItem::hoverMoveEvent(QGraphicsSceneHoverEvent *event)
 {
-    if (m_eMode == mResize && m_moveType & IsResizable)
+    if (m_mode == Mode::Resize && m_moveType & IsResizable)
     {
         if (m_rectResize.contains(event->pos()))
         {
@@ -666,7 +666,7 @@ void VTextGraphicsItem::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
  */
 void VTextGraphicsItem::UpdateBox()
 {
-    update(m_rectBoundingBox);
+    update(m_boundingRect);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -680,20 +680,20 @@ void VTextGraphicsItem::correctLabel()
     qreal yPos;
     QRectF rectBB;
     rectBB.setTopLeft(pos());
-    rectBB.setSize(m_rectBoundingBox.size());
+    rectBB.setSize(m_boundingRect.size());
     if (isContained(rectBB, rotation(), xPos, yPos) == false)
     {
         // put the label inside the pattern
         setPos(pos().x() + xPos, pos().y() + yPos);
     }
-    m_textMananger.FitFontSize(m_rectBoundingBox.width(), m_rectBoundingBox.height());
+    m_textMananger.FitFontSize(m_boundingRect.width(), m_boundingRect.height());
     UpdateBox();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VTextGraphicsItem::allUserModifications(const QPointF &pos)
 {
-    if (m_eMode != mRotate)
+    if (m_mode != Mode::Rotate)
     {
         userMoveAndResize(pos);
     }
@@ -706,9 +706,9 @@ void VTextGraphicsItem::allUserModifications(const QPointF &pos)
 //---------------------------------------------------------------------------------------------------------------------
 void VTextGraphicsItem::userRotateAndMove()
 {
-    if (m_eMode != mRotate)
+    if (m_mode != Mode::Rotate)
     {
-        m_eMode = mMove;
+        m_mode = Mode::Move;
     }
     SetItemOverrideCursor(this, cursorArrowCloseHand, 1, 1);
 }
@@ -718,12 +718,12 @@ void VTextGraphicsItem::userMoveAndResize(const QPointF &pos)
 {
     if (m_rectResize.contains(pos) == true)
     {
-        m_eMode = mResize;
+        m_mode = Mode::Resize;
         setCursor(Qt::SizeAllCursor);
     }
     else
     {
-        m_eMode = mMove; // block later if need
+        m_mode = Mode::Move; // block later if need
         SetItemOverrideCursor(this, cursorArrowCloseHand, 1, 1);
     }
 }

--- a/src/libs/vwidgets/vtextgraphicsitem.h
+++ b/src/libs/vwidgets/vtextgraphicsitem.h
@@ -56,7 +56,7 @@ public:
     virtual ~VTextGraphicsItem() Q_DECL_EQ_DEFAULT;
 
     virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) Q_DECL_OVERRIDE;
-    virtual void Update() Q_DECL_OVERRIDE;
+    virtual void updateItem() Q_DECL_OVERRIDE;
 
     virtual int  type() const Q_DECL_OVERRIDE {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::TextGraphicsItem)};


### PR DESCRIPTION
This PR:

-  Fixes the grainline arrow heads so they scale with the zoom, and are not fixed at a constant size.
-  Adds a preference for the arrow head length. It's range is from 25 to 200 pixels. 
![image](https://github.com/user-attachments/assets/e7477937-9e27-4d33-bdd6-ca85b5400f1d)

-  Refactors the grainlineitem class and related code to clean it up. 

This issue closes #1201 