### PR TITLE
feature: add color attribute to point on curve tools

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1307,6 +1323,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Backward (from end point)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -1176,6 +1176,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation>Rückwärts (vom Endpunkt)</translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation>Eigenschaften</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation>Farbe:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1243,6 +1251,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation>Rückwärts (vom Endpunkt)</translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation>Eigenschaften</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation>Farbe:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1309,6 +1325,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Backward (from end point)</source>
         <translation>Rückwärts (vom Endpunkt)</translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation>Eigenschaften</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation>Farbe:</translation>
     </message>
 </context>
 <context>
@@ -4186,7 +4210,7 @@ for writing</source>
         <translation>Date %1 kann nicht zum schreiben geöffnet werden</translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file 
+        <source>Unable to get exclusive access to file
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
@@ -5307,7 +5331,7 @@ Das Programm wird WIE ES IST, OHNE GEWÄHRLEISTUNG JEGLICHER ART, EINSCHLIESSLIC
         <translation>Millimeter</translation>
     </message>
     <message>
-        <source>Margins go beyond printing. 
+        <source>Margins go beyond printing.
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
@@ -9911,7 +9935,7 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     </message>
     <message>
         <source>Pattern</source>
-        <translation type="unfinished">Schnittmuster</translation>
+        <translation>Schnittmuster</translation>
     </message>
 </context>
 <context>
@@ -10341,13 +10365,13 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <translation>Zoll</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10415,13 +10439,13 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Legt den Klickton für die Knotenauswahl fest.</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Χρώμα:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Χρώμα:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1308,6 +1324,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Χρώμα:</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Color:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Color:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1308,6 +1324,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Color:</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Color:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Color:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1308,6 +1324,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Color:</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Color:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Color:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1308,6 +1324,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Color:</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Color:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Color:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1308,6 +1324,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Color:</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -1210,6 +1210,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation>Hacia atrás (desde el punto final)</translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation>Propiedades</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation>Color:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1277,6 +1285,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation>Hacia atrás (desde el punto final)</translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation>Propiedades</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation>Color:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1343,6 +1359,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Backward (from end point)</source>
         <translation>Hacia atrás (desde el punto final)</translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation>Propiedades</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation>Color:</translation>
     </message>
 </context>
 <context>
@@ -4227,7 +4251,7 @@ Do you want to download it?</source>
 ¿Quiere descargarla?</translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file 
+        <source>Unable to get exclusive access to file
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
@@ -5348,7 +5372,7 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
         <translation>Ninguno</translation>
     </message>
     <message>
-        <source>Margins go beyond printing. 
+        <source>Margins go beyond printing.
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
@@ -9961,15 +9985,15 @@ actualización:</translation>
     </message>
     <message>
         <source>Images</source>
-        <translation type="unfinished">Imágenes</translation>
+        <translation>Imágenes</translation>
     </message>
     <message>
         <source>Open Image File</source>
-        <translation type="unfinished">Abrir archivo de imagen</translation>
+        <translation>Abrir archivo de imagen</translation>
     </message>
     <message>
         <source>Pattern</source>
-        <translation type="unfinished">Patrón</translation>
+        <translation>Patrón</translation>
     </message>
 </context>
 <context>
@@ -10399,13 +10423,13 @@ actualización:</translation>
         <translation>Pulgadas</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10473,13 +10497,13 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Establece el sonido del clic de selección del nodo.</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15196,182 +15220,182 @@ Example: atan(1) = 0.78538</comment>
         <comment>Hyperbolic sine function
 Usage: sinh(θ)
 Example: sinh(1) = 1.1752</comment>
-        <translation type="unfinished">sinh</translation>
+        <translation>sinh</translation>
     </message>
     <message>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(θ) → returns a number greater than or equal to 1
 Example: cosh(0) = 1</comment>
-        <translation type="unfinished">cosh</translation>
+        <translation>cosh</translation>
     </message>
     <message>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(θ) → returns a number between -1 and 1 (excluded)
 Example: tanh(1) = 0.761594</comment>
-        <translation type="unfinished">tanh</translation>
+        <translation>tanh</translation>
     </message>
     <message>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)
 Example: asinh(90) = 5.19299</comment>
-        <translation type="unfinished">asinh</translation>
+        <translation>asinh</translation>
     </message>
     <message>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x greater than or equal to 1)
 Example: acosh(2) = 1.31696</comment>
-        <translation type="unfinished">acosh</translation>
+        <translation>acosh</translation>
     </message>
     <message>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x between -1 and 1 (excluded))
 Example: atanh(0,99) = 2.64665</comment>
-        <translation type="unfinished">atanh</translation>
+        <translation>atanh</translation>
     </message>
     <message>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees) → returns a number between -1 and 1
 Example: sinD(90) = 1</comment>
-        <translation type="unfinished">sinD</translation>
+        <translation>sinD</translation>
     </message>
     <message>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees) → returns a number between -1 and 1
 Example: cosD(180) = -1</comment>
-        <translation type="unfinished">cosD</translation>
+        <translation>cosD</translation>
     </message>
     <message>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)
 Example: tanD(45) = 1</comment>
-        <translation type="unfinished">tanD</translation>
+        <translation>tanD</translation>
     </message>
     <message>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x between -1 and 1) → returns an angle in degrees
 Example: asinD(1) = 90</comment>
-        <translation type="unfinished">asinD</translation>
+        <translation>asinD</translation>
     </message>
     <message>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x between -1 and 1) → returns an angle in degrees
 Example: acosD(-1) = 180</comment>
-        <translation type="unfinished">acosD</translation>
+        <translation>acosD</translation>
     </message>
     <message>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x) → returns an angle in degrees
 Example: atanD(1) = 45</comment>
-        <translation type="unfinished">atanD</translation>
+        <translation>atanD</translation>
     </message>
     <message>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x greater than 0)
 Example: log2(10) = 3.32193</comment>
-        <translation type="unfinished">log2</translation>
+        <translation>log2</translation>
     </message>
     <message>
         <source>log10</source>
         <comment>Logarithm to the base 10 (same as log(x))
 Usage: log10(x greater than 0)
 Example: log10(10) = 1</comment>
-        <translation type="unfinished">log10</translation>
+        <translation>log10</translation>
     </message>
     <message>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x greater than 0)
 Example: log(10) = 1</comment>
-        <translation type="unfinished">log</translation>
+        <translation>log</translation>
     </message>
     <message>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x greater than 0)
 Example: ln(10) = 2.30259</comment>
-        <translation type="unfinished">in</translation>
+        <translation>ln</translation>
     </message>
     <message>
         <source>exp</source>
         <comment>e raised to the power of x where e = 2.718
 Usage: exp(x) → returns a positive number
 Example: exp(2) = 7.38906</comment>
-        <translation type="unfinished">exp</translation>
+        <translation>exp</translation>
     </message>
     <message>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x greater than or equal to 0) → returns a positive number
 Example: sqrt(4) = 2</comment>
-        <translation type="unfinished">sqrt</translation>
+        <translation>sqrt</translation>
     </message>
     <message>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x) → returns -1, 0 or 1
 Example: sign(-3) = -1</comment>
-        <translation type="unfinished">sign</translation>
+        <translation>sign</translation>
     </message>
     <message>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(x) → returns an integer number
 Example: rint(2.3) = 2</comment>
-        <translation type="unfinished">rint</translation>
+        <translation>rint</translation>
     </message>
     <message>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x) → returns a positive number
 Example: abs(-5) = 5</comment>
-        <translation type="unfinished">abs</translation>
+        <translation>abs</translation>
     </message>
     <message>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)
 Example: min(2;3;4) = 2</comment>
-        <translation type="unfinished">min</translation>
+        <translation>min</translation>
     </message>
     <message>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)
 Example: max(2;3;4) = 4</comment>
-        <translation type="unfinished">max</translation>
+        <translation>max</translation>
     </message>
     <message>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)
 Example: sum(2;3;4) = 9</comment>
-        <translation type="unfinished">sum</translation>
+        <translation>sum</translation>
     </message>
     <message>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)
 Example: avg(2;3;4) = 3</comment>
-        <translation type="unfinished">avg</translation>
+        <translation>avg</translation>
     </message>
     <message>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)
 Example: fmod(3.3;2) = 1.3</comment>
-        <translation type="unfinished">fmod</translation>
+        <translation>fmod</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1307,6 +1323,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Backward (from end point)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -57,7 +57,7 @@
     </message>
     <message>
         <source>CPU:</source>
-        <translation type="unfinished"></translation>
+        <translation>CPU:</translation>
     </message>
     <message>
         <source>Compiler:</source>
@@ -81,7 +81,7 @@
     </message>
     <message>
         <source>OS:</source>
-        <translation type="unfinished"></translation>
+        <translation>OS:</translation>
     </message>
     <message>
         <source>OS Version:</source>
@@ -149,7 +149,7 @@
     </message>
     <message>
         <source>unknown</source>
-        <translation type="unfinished">inconnu</translation>
+        <translation>inconnu</translation>
     </message>
 </context>
 <context>
@@ -217,7 +217,7 @@
     </message>
     <message>
         <source>Point:</source>
-        <translation type="unfinished">Point :</translation>
+        <translation>Point :</translation>
     </message>
     <message>
         <source>Piece:</source>
@@ -389,19 +389,19 @@
     </message>
     <message>
         <source>MC</source>
-        <translation type="unfinished"></translation>
+        <translation>MC</translation>
     </message>
     <message>
         <source>MR</source>
-        <translation type="unfinished"></translation>
+        <translation>MR</translation>
     </message>
     <message>
         <source>MS</source>
-        <translation type="unfinished"></translation>
+        <translation>MS</translation>
     </message>
     <message>
         <source>M+</source>
-        <translation type="unfinished"></translation>
+        <translation>M+</translation>
     </message>
     <message>
         <source>÷</source>
@@ -506,19 +506,19 @@ p, li { white-space: pre-wrap; }
     <name>DialogAboutSeamlyMe</name>
     <message>
         <source>About SeamlyMe</source>
-        <translation type="unfinished">A propos de SeamlyMe</translation>
+        <translation>A propos de SeamlyMe</translation>
     </message>
     <message>
         <source>SeamlyMe version</source>
-        <translation type="unfinished">Version de SeamlyMe</translation>
+        <translation>Version de SeamlyMe</translation>
     </message>
     <message>
         <source>Build revision: %1</source>
-        <translation type="unfinished">Version compilée: %1</translation>
+        <translation>Version compilée: %1</translation>
     </message>
     <message>
         <source>This program is part of Seamly2D project.</source>
-        <translation type="unfinished">Ce programme fait partie du projet Seamly2D.</translation>
+        <translation>Ce programme fait partie du projet Seamly2D.</translation>
     </message>
     <message>
         <source>Downloading installer %p% complete</source>
@@ -526,23 +526,23 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Check For Updates</source>
-        <translation type="unfinished">Vérifier les Mises à Jour</translation>
+        <translation>Vérifier les Mises à Jour</translation>
     </message>
     <message>
         <source>Cannot open your default browser</source>
-        <translation type="unfinished">Impossible d&apos;ouvrir votre navigateur par défaut</translation>
+        <translation>Impossible d&apos;ouvrir votre navigateur par défaut</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation type="unfinished">Compilé le %1 à %2</translation>
+        <translation>Compilé le %1 à %2</translation>
     </message>
     <message>
         <source>Web site : %1</source>
-        <translation type="unfinished">Site web : %1</translation>
+        <translation>Site web : %1</translation>
     </message>
     <message>
         <source>unknown</source>
-        <translation type="unfinished">inconnu</translation>
+        <translation>inconnu</translation>
     </message>
 </context>
 <context>
@@ -1018,7 +1018,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Path:</source>
-        <translation type="unfinished">Chemin:</translation>
+        <translation>Chemin:</translation>
     </message>
     <message>
         <source>Attributes</source>
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1307,6 +1323,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Backward (from end point)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1642,7 +1666,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Path</source>
-        <translation type="unfinished">Chemin</translation>
+        <translation>Chemin</translation>
     </message>
     <message>
         <source>Name:</source>
@@ -1650,15 +1674,15 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Unnamed path</source>
-        <translation type="unfinished">Chemin sans nom</translation>
+        <translation>Chemin sans nom</translation>
     </message>
     <message>
         <source>Create name for your path</source>
-        <translation type="unfinished">Créer un nom pour votre chemin</translation>
+        <translation>Créer un nom pour votre chemin</translation>
     </message>
     <message>
         <source>Type:</source>
-        <translation type="unfinished">Type:</translation>
+        <translation>Type:</translation>
     </message>
     <message>
         <source>Linetype:</source>
@@ -1698,27 +1722,27 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Ready!</source>
-        <translation type="unfinished">Prêt!</translation>
+        <translation>Prêt!</translation>
     </message>
     <message>
         <source>Seam allowance</source>
-        <translation type="unfinished">Marge de couture</translation>
+        <translation>Marge de couture</translation>
     </message>
     <message>
         <source>Width:</source>
-        <translation type="unfinished">Largeur :</translation>
+        <translation>Largeur :</translation>
     </message>
     <message>
         <source>Formula wizard</source>
-        <translation type="unfinished">Assistant Formule</translation>
+        <translation>Assistant Formule</translation>
     </message>
     <message>
         <source>Value</source>
-        <translation type="unfinished">Valeur</translation>
+        <translation>Valeur</translation>
     </message>
     <message>
         <source>Calculation</source>
-        <translation type="unfinished">Calcul</translation>
+        <translation>Calcul</translation>
     </message>
     <message>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show full calculation in message box&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
@@ -1726,19 +1750,19 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Nodes</source>
-        <translation type="unfinished">Nœuds</translation>
+        <translation>Nœuds</translation>
     </message>
     <message>
         <source>Node:</source>
-        <translation type="unfinished">Nœud:</translation>
+        <translation>Nœud:</translation>
     </message>
     <message>
         <source>Before:</source>
-        <translation type="unfinished">Avant:</translation>
+        <translation>Avant:</translation>
     </message>
     <message>
         <source>Return to default width</source>
-        <translation type="unfinished">Retourner à la largeur par défaut</translation>
+        <translation>Retourner à la largeur par défaut</translation>
     </message>
     <message>
         <source>Default</source>
@@ -1746,23 +1770,23 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>After:</source>
-        <translation type="unfinished">Après:</translation>
+        <translation>Après:</translation>
     </message>
     <message>
         <source>Angle:</source>
-        <translation type="unfinished">Angle:</translation>
+        <translation>Angle:</translation>
     </message>
     <message>
         <source>Notches</source>
-        <translation type="unfinished">Repères de montage</translation>
+        <translation>Repères de montage</translation>
     </message>
     <message>
         <source>Notch:</source>
-        <translation type="unfinished">Repère de montage :</translation>
+        <translation>Repère de montage :</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished">Type</translation>
+        <translation>Type</translation>
     </message>
     <message>
         <source>Slit</source>
@@ -1846,7 +1870,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Length:</source>
-        <translation type="unfinished">Longueur:</translation>
+        <translation>Longueur:</translation>
     </message>
     <message>
         <source>Select main path objects, Use &lt;b&gt;SHIFT&lt;/b&gt; to reverse curve direction, Press &lt;b&gt;ENTER&lt;/b&gt; to finish path creation </source>
@@ -1854,47 +1878,47 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Reverse</source>
-        <translation type="unfinished">Inverser</translation>
+        <translation>Inverser</translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="unfinished">Supprimer</translation>
+        <translation>Supprimer</translation>
     </message>
     <message>
         <source>Current seam allowance</source>
-        <translation type="unfinished">Marge de couture actuelle</translation>
+        <translation>Marge de couture actuelle</translation>
     </message>
     <message>
         <source>Edit seam allowance width</source>
-        <translation type="unfinished">Editer la largeur de la marge de couture</translation>
+        <translation>Editer la largeur de la marge de couture</translation>
     </message>
     <message>
         <source>Edit seam allowance width before</source>
-        <translation type="unfinished">Editer la largeur de la marge de couture avant</translation>
+        <translation>Editer la largeur de la marge de couture avant</translation>
     </message>
     <message>
         <source>Edit seam allowance width after</source>
-        <translation type="unfinished">Editer la largeur de la marge de couture après</translation>
+        <translation>Editer la largeur de la marge de couture après</translation>
     </message>
     <message>
         <source>Internal path</source>
-        <translation type="unfinished">Chemin interne</translation>
+        <translation>Chemin interne</translation>
     </message>
     <message>
         <source>Custom seam allowance</source>
-        <translation type="unfinished">Personnaliser la marge de couture</translation>
+        <translation>Personnaliser la marge de couture</translation>
     </message>
     <message>
         <source>You need more points!</source>
-        <translation type="unfinished">Vous avez besoin de plus de points!</translation>
+        <translation>Vous avez besoin de plus de points!</translation>
     </message>
     <message>
         <source>First point of &lt;b&gt;custom seam allowance&lt;/b&gt; cannot be equal to the last point!</source>
-        <translation type="unfinished">Le premier point de la &lt;b&gt;marge de couture personnalisée&lt;/b&gt; ne peut être identique au dernier!</translation>
+        <translation>Le premier point de la &lt;b&gt;marge de couture personnalisée&lt;/b&gt; ne peut être identique au dernier!</translation>
     </message>
     <message>
         <source>You have double points!</source>
-        <translation type="unfinished">Vous avez des points en double!</translation>
+        <translation>Vous avez des points en double!</translation>
     </message>
     <message>
         <source>Each point in the &lt;b&gt;custom seam allowance&lt;/b&gt; path must be unique!</source>
@@ -1976,7 +2000,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Line_</source>
-        <translation type="unfinished">Ligne_</translation>
+        <translation>Ligne_</translation>
     </message>
 </context>
 <context>
@@ -2142,11 +2166,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Find:</source>
-        <translation type="unfinished">Rechercher:</translation>
+        <translation>Rechercher:</translation>
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished">Rechercher</translation>
+        <translation>Rechercher</translation>
     </message>
 </context>
 <context>
@@ -2157,7 +2181,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Axis point:</source>
-        <translation type="unfinished">Point d&apos;axe :</translation>
+        <translation>Point d&apos;axe :</translation>
     </message>
     <message>
         <source>Suffix:</source>
@@ -2165,7 +2189,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Axis type:</source>
-        <translation type="unfinished">Type d&apos;axe :</translation>
+        <translation>Type d&apos;axe :</translation>
     </message>
     <message>
         <source>Select axis rotation point</source>
@@ -2177,11 +2201,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Vertical axis</source>
-        <translation type="unfinished">Axes verticaux</translation>
+        <translation>Axes verticaux</translation>
     </message>
     <message>
         <source>Horizontal axis</source>
-        <translation type="unfinished">Axes horizontaux</translation>
+        <translation>Axes horizontaux</translation>
     </message>
     <message>
         <source>Selection</source>
@@ -2200,7 +2224,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>First line point:</source>
-        <translation type="unfinished">Point de la première ligne:</translation>
+        <translation>Point de la première ligne:</translation>
     </message>
     <message>
         <source>Second line point:</source>
@@ -2271,7 +2295,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Origin Point:</source>
-        <translation type="unfinished">Point d&apos;origine:</translation>
+        <translation>Point d&apos;origine:</translation>
     </message>
     <message>
         <source>Geometry</source>
@@ -2279,7 +2303,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Rotation:</source>
-        <translation type="unfinished">Rotation:</translation>
+        <translation>Rotation:</translation>
     </message>
     <message>
         <source>Center point</source>
@@ -2327,7 +2351,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Millimeters</source>
-        <translation type="unfinished">Millimètres</translation>
+        <translation>Millimètres</translation>
     </message>
     <message>
         <source>Draft block name:</source>
@@ -2402,7 +2426,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Rotation:</source>
-        <translation type="unfinished">Rotation:</translation>
+        <translation>Rotation:</translation>
     </message>
     <message>
         <source>Attributes</source>
@@ -4166,7 +4190,7 @@ for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file 
+        <source>Unable to get exclusive access to file
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
@@ -5167,7 +5191,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Surface décroissante</translation>
     </message>
     <message>
-        <source>Margins go beyond printing. 
+        <source>Margins go beyond printing.
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
@@ -10298,13 +10322,13 @@ Press enter to temporarily add it to the list.</source>
         <translation>Séparateur décimal :</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10364,7 +10388,7 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Langue de l&apos;interface:</translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10397,8 +10421,8 @@ You can change this setting in the Seamly2D preferences.</source>
         <translation>Veuillez choisir les unités, le séparateur décimal, la langue et le son de sélection que vous préférez. (Vous pourrez les modifier ultérieurement.)</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1307,6 +1323,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Backward (from end point)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1307,6 +1323,14 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Backward (from end point)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Colore:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Colore:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1308,6 +1324,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Colore:</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -1178,6 +1178,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation>Kenmerken</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation>Kleur:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1245,6 +1253,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation>Kenmerken</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation>Kleur:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1311,6 +1327,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation>Kenmerken</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation>Kleur:</translation>
     </message>
 </context>
 <context>
@@ -4188,7 +4212,7 @@ Do you want to download it?</source>
         <translation>Een nieuwe versie %1 is beschikbaar. Wil je het downloaden?</translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file 
+        <source>Unable to get exclusive access to file
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
@@ -4676,7 +4700,7 @@ Possibly the file is already being downloaded.</source>
     </message>
     <message>
         <source>Selection</source>
-        <translation type="unfinished">Selectie</translation>
+        <translation>Selectie</translation>
     </message>
     <message>
         <source>Id:</source>
@@ -4684,11 +4708,11 @@ Possibly the file is already being downloaded.</source>
     </message>
     <message>
         <source>Id</source>
-        <translation type="unfinished">Id</translation>
+        <translation>Id</translation>
     </message>
     <message>
         <source>Name:</source>
-        <translation type="unfinished">Naam:</translation>
+        <translation>Naam:</translation>
     </message>
     <message>
         <source>Lock Image:</source>
@@ -4696,7 +4720,7 @@ Possibly the file is already being downloaded.</source>
     </message>
     <message>
         <source>Geometry</source>
-        <translation type="unfinished">Geometrie</translation>
+        <translation>Geometrie</translation>
     </message>
     <message>
         <source>Switch between px and pattern units</source>
@@ -4708,7 +4732,7 @@ Possibly the file is already being downloaded.</source>
     </message>
     <message>
         <source>Unit:</source>
-        <translation type="unfinished">Eenheid:</translation>
+        <translation>Eenheid:</translation>
     </message>
     <message>
         <source>X Position:</source>
@@ -4732,11 +4756,11 @@ Possibly the file is already being downloaded.</source>
     </message>
     <message>
         <source>Width:</source>
-        <translation type="unfinished">Breedte:</translation>
+        <translation>Breedte:</translation>
     </message>
     <message>
         <source>Height:</source>
-        <translation type="unfinished">Hoogte:</translation>
+        <translation>Hoogte:</translation>
     </message>
     <message>
         <source>X Scale:</source>
@@ -4752,7 +4776,7 @@ Possibly the file is already being downloaded.</source>
     </message>
     <message>
         <source>Rotation:</source>
-        <translation type="unfinished">Draaiing:</translation>
+        <translation>Draaiing:</translation>
     </message>
     <message>
         <source>°</source>
@@ -4760,7 +4784,7 @@ Possibly the file is already being downloaded.</source>
     </message>
     <message>
         <source>Attributes</source>
-        <translation type="unfinished">Kenmerken</translation>
+        <translation>Kenmerken</translation>
     </message>
     <message>
         <source>Opacity:</source>
@@ -4771,7 +4795,7 @@ Possibly the file is already being downloaded.</source>
     <name>ImageItem</name>
     <message>
         <source>Properties</source>
-        <translation type="unfinished">Eigenschappen</translation>
+        <translation>Eigenschappen</translation>
     </message>
     <message>
         <source>Lock</source>
@@ -4834,11 +4858,11 @@ Possibly the file is already being downloaded.</source>
     </message>
     <message>
         <source>Confirm deletion</source>
-        <translation type="unfinished">Bevestig verwijdering</translation>
+        <translation>Bevestig verwijdering</translation>
     </message>
     <message>
         <source>Do you really want to delete?</source>
-        <translation type="unfinished">Wil je dit echt verwijderen?</translation>
+        <translation>Wil je dit echt verwijderen?</translation>
     </message>
     <message>
         <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
@@ -5299,7 +5323,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Millimeters</translation>
     </message>
     <message>
-        <source>Margins go beyond printing. 
+        <source>Margins go beyond printing.
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
@@ -9893,7 +9917,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Images</source>
-        <translation type="unfinished">Afbeeldingen</translation>
+        <translation>Afbeeldingen</translation>
     </message>
     <message>
         <source>Open Image File</source>
@@ -9901,7 +9925,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Pattern</source>
-        <translation type="unfinished">Patroon</translation>
+        <translation>Patroon</translation>
     </message>
 </context>
 <context>
@@ -10331,13 +10355,13 @@ Press enter to temporarily add it to the list.</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10405,13 +10429,13 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Stelt het klikgeluid van de knooppuntselectie in.</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14878,238 +14902,238 @@ load in SeamlyME as usual.
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees) → returns an angle in radians
 Example: degTorad(180) = 3.14159</comment>
-        <translation type="unfinished">degTorad</translation>
+        <translation>degTorad</translation>
     </message>
     <message>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)  → returns an angle in degrees
 Example: radTodeg(3.14159) = 180</comment>
-        <translation type="unfinished">radTodeg</translation>
+        <translation>radTodeg</translation>
     </message>
     <message>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians) → returns a number between -1 and 1
 Example: sin(90) = 0.893997</comment>
-        <translation type="unfinished">sin</translation>
+        <translation>sin</translation>
     </message>
     <message>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians) → returns a number between -1 and 1
 Example: cos(1) = 0.540302</comment>
-        <translation type="unfinished">cos</translation>
+        <translation>cos</translation>
     </message>
     <message>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)
 Example: tan(1) = 1.55741</comment>
-        <translation type="unfinished">tan</translation>
+        <translation>tan</translation>
     </message>
     <message>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x between -1 and 1) → returns an angle in radians
 Example: asin(-1) = -1.5708</comment>
-        <translation type="unfinished">asin</translation>
+        <translation>asin</translation>
     </message>
     <message>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x between -1 and 1) → returns an angle in radians
 Example: acos(0.1) = 1.47063</comment>
-        <translation type="unfinished">acos</translation>
+        <translation>acos</translation>
     </message>
     <message>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x) → returns an angle in radians
 Example: atan(1) = 0.78538</comment>
-        <translation type="unfinished">atan</translation>
+        <translation>atan</translation>
     </message>
     <message>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(θ)
 Example: sinh(1) = 1.1752</comment>
-        <translation type="unfinished">sinh</translation>
+        <translation>sinh</translation>
     </message>
     <message>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(θ) → returns a number greater than or equal to 1
 Example: cosh(0) = 1</comment>
-        <translation type="unfinished">cosh</translation>
+        <translation>cosh</translation>
     </message>
     <message>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(θ) → returns a number between -1 and 1 (excluded)
 Example: tanh(1) = 0.761594</comment>
-        <translation type="unfinished">tanh</translation>
+        <translation>tanh</translation>
     </message>
     <message>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)
 Example: asinh(90) = 5.19299</comment>
-        <translation type="unfinished">asinh</translation>
+        <translation>asinh</translation>
     </message>
     <message>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x greater than or equal to 1)
 Example: acosh(2) = 1.31696</comment>
-        <translation type="unfinished">acosh</translation>
+        <translation>acosh</translation>
     </message>
     <message>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x between -1 and 1 (excluded))
 Example: atanh(0,99) = 2.64665</comment>
-        <translation type="unfinished">atanh</translation>
+        <translation>atanh</translation>
     </message>
     <message>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees) → returns a number between -1 and 1
 Example: sinD(90) = 1</comment>
-        <translation type="unfinished">sinD</translation>
+        <translation>sinD</translation>
     </message>
     <message>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees) → returns a number between -1 and 1
 Example: cosD(180) = -1</comment>
-        <translation type="unfinished">cosD</translation>
+        <translation>cosD</translation>
     </message>
     <message>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)
 Example: tanD(45) = 1</comment>
-        <translation type="unfinished">tanD</translation>
+        <translation>tanD</translation>
     </message>
     <message>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x between -1 and 1) → returns an angle in degrees
 Example: asinD(1) = 90</comment>
-        <translation type="unfinished">asinD</translation>
+        <translation>asinD</translation>
     </message>
     <message>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x between -1 and 1) → returns an angle in degrees
 Example: acosD(-1) = 180</comment>
-        <translation type="unfinished">acosD</translation>
+        <translation>acosD</translation>
     </message>
     <message>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x) → returns an angle in degrees
 Example: atanD(1) = 45</comment>
-        <translation type="unfinished">atanD</translation>
+        <translation>atanD</translation>
     </message>
     <message>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x greater than 0)
 Example: log2(10) = 3.32193</comment>
-        <translation type="unfinished">log2</translation>
+        <translation>log2</translation>
     </message>
     <message>
         <source>log10</source>
         <comment>Logarithm to the base 10 (same as log(x))
 Usage: log10(x greater than 0)
 Example: log10(10) = 1</comment>
-        <translation type="unfinished">log10</translation>
+        <translation>log10</translation>
     </message>
     <message>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x greater than 0)
 Example: log(10) = 1</comment>
-        <translation type="unfinished">log</translation>
+        <translation>log</translation>
     </message>
     <message>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x greater than 0)
 Example: ln(10) = 2.30259</comment>
-        <translation type="unfinished">ln</translation>
+        <translation>ln</translation>
     </message>
     <message>
         <source>exp</source>
         <comment>e raised to the power of x where e = 2.718
 Usage: exp(x) → returns a positive number
 Example: exp(2) = 7.38906</comment>
-        <translation type="unfinished">exp</translation>
+        <translation>exp</translation>
     </message>
     <message>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x greater than or equal to 0) → returns a positive number
 Example: sqrt(4) = 2</comment>
-        <translation type="unfinished">sqrt</translation>
+        <translation>sqrt</translation>
     </message>
     <message>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x) → returns -1, 0 or 1
 Example: sign(-3) = -1</comment>
-        <translation type="unfinished">sign</translation>
+        <translation>sign</translation>
     </message>
     <message>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(x) → returns an integer number
 Example: rint(2.3) = 2</comment>
-        <translation type="unfinished">rint</translation>
+        <translation>rint</translation>
     </message>
     <message>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x) → returns a positive number
 Example: abs(-5) = 5</comment>
-        <translation type="unfinished">abs</translation>
+        <translation>abs</translation>
     </message>
     <message>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)
 Example: min(2;3;4) = 2</comment>
-        <translation type="unfinished">min</translation>
+        <translation>min</translation>
     </message>
     <message>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)
 Example: max(2;3;4) = 4</comment>
-        <translation type="unfinished">max</translation>
+        <translation>max</translation>
     </message>
     <message>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)
 Example: sum(2;3;4) = 9</comment>
-        <translation type="unfinished">sum</translation>
+        <translation>sum</translation>
     </message>
     <message>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)
 Example: avg(2;3;4) = 3</comment>
-        <translation type="unfinished">avg</translation>
+        <translation>avg</translation>
     </message>
     <message>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)
 Example: fmod(3.3;2) = 1.3</comment>
-        <translation type="unfinished">fmod</translation>
+        <translation>fmod</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Cor:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Cor:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1308,6 +1324,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Cor:</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Culoare:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Culoare:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1308,6 +1324,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Culoare:</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -1193,6 +1193,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation>Свойства</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation>Цвет:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1260,6 +1268,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation>Свойства</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation>Цвет:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1326,6 +1342,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation>Свойства</translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation>Цвет:</translation>
     </message>
 </context>
 <context>
@@ -4194,7 +4218,7 @@ for writing</source>
 для записи</translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file 
+        <source>Unable to get exclusive access to file
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
@@ -4700,7 +4724,7 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>Selection</source>
-        <translation type="unfinished">Выбрать</translation>
+        <translation>Выбрать</translation>
     </message>
     <message>
         <source>Id:</source>
@@ -4708,7 +4732,7 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>Id</source>
-        <translation type="unfinished">Идентификатор</translation>
+        <translation>Идентификатор</translation>
     </message>
     <message>
         <source>Name:</source>
@@ -4720,7 +4744,7 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>Geometry</source>
-        <translation type="unfinished">Геометрия</translation>
+        <translation>Геометрия</translation>
     </message>
     <message>
         <source>Switch between px and pattern units</source>
@@ -4732,7 +4756,7 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>Unit:</source>
-        <translation type="unfinished">Единицы:</translation>
+        <translation>Единицы:</translation>
     </message>
     <message>
         <source>X Position:</source>
@@ -4740,7 +4764,7 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>px</source>
-        <translation type="unfinished">px</translation>
+        <translation>px</translation>
     </message>
     <message>
         <source>Y Position:</source>
@@ -4752,11 +4776,11 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>Lock Aspect:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <source>Width:</source>
-        <translation type="unfinished">Ширина:</translation>
+        <translation>Ширина:</translation>
     </message>
     <message>
         <source>Height:</source>
@@ -4776,7 +4800,7 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>Rotation:</source>
-        <translation type="unfinished">Вращение:</translation>
+        <translation>Вращение:</translation>
     </message>
     <message>
         <source>°</source>
@@ -4784,7 +4808,7 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>Attributes</source>
-        <translation type="unfinished">Свойства</translation>
+        <translation>Свойства</translation>
     </message>
     <message>
         <source>Opacity:</source>
@@ -4795,7 +4819,7 @@ Do you want to download it?</source>
     <name>ImageItem</name>
     <message>
         <source>Properties</source>
-        <translation type="unfinished">Свойства</translation>
+        <translation>Свойства</translation>
     </message>
     <message>
         <source>Lock</source>
@@ -4823,7 +4847,7 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="unfinished">Удалить</translation>
+        <translation>Удалить</translation>
     </message>
     <message>
         <source>&lt;b&gt;Image (%7)&lt;/b&gt;: Size(%2%1, %3%1); Pos(%4%1, %5%1); Rot(%6°)%8</source>
@@ -4858,11 +4882,11 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>Confirm deletion</source>
-        <translation type="unfinished">Подтвердите удаление</translation>
+        <translation>Подтвердите удаление</translation>
     </message>
     <message>
         <source>Do you really want to delete?</source>
-        <translation type="unfinished">Вы точно хотите удалить?</translation>
+        <translation>Вы точно хотите удалить?</translation>
     </message>
     <message>
         <source>The image &lt;br/&gt;&lt;br/&gt; &lt;b&gt;%1&lt;/b&gt; &lt;br/&gt;&lt;br/&gt; could not be found. Do you want to update the file location?</source>
@@ -5196,7 +5220,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>По убыванию площади</translation>
     </message>
     <message>
-        <source>Margins go beyond printing. 
+        <source>Margins go beyond printing.
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
@@ -7327,11 +7351,11 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Zoom 100%</source>
-        <translation type="unfinished">Зум 100%</translation>
+        <translation>Зум 100%</translation>
     </message>
     <message>
         <source>100%</source>
-        <translation type="unfinished">100%</translation>
+        <translation>100%</translation>
     </message>
 </context>
 <context>
@@ -9920,7 +9944,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Images</source>
-        <translation type="unfinished">Изображения</translation>
+        <translation>Изображения</translation>
     </message>
     <message>
         <source>Open Image File</source>
@@ -9928,7 +9952,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Pattern</source>
-        <translation type="unfinished">Выкройка</translation>
+        <translation>Выкройка</translation>
     </message>
 </context>
 <context>
@@ -10330,13 +10354,13 @@ Press enter to temporarily add it to the list.</source>
         <translation>Десятичный Разделитель:</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10392,8 +10416,8 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Десятичный Разделитель:</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10402,7 +10426,7 @@ When unchecked the period is used.</source>
         <translation>Язык интерфейса:</translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11110,11 +11134,11 @@ You can change this setting in the Seamly2D preferences.</source>
     </message>
     <message>
         <source>Zoom 100%</source>
-        <translation type="unfinished">Зум 100%</translation>
+        <translation>Зум 100%</translation>
     </message>
     <message>
         <source>Ctrl+9</source>
-        <translation type="unfinished">Ctrl+9</translation>
+        <translation>Ctrl+9</translation>
     </message>
 </context>
 <context>
@@ -14911,238 +14935,238 @@ load in SeamlyME as usual.
         <comment>Converts degrees to radians
 Usage: degTorad(angle θ in degrees) → returns an angle in radians
 Example: degTorad(180) = 3.14159</comment>
-        <translation type="unfinished">degTorad</translation>
+        <translation>degTorad</translation>
     </message>
     <message>
         <source>radTodeg</source>
         <comment>Converts radians to degrees
 Usage: radTodeg(angle θ in radians)  → returns an angle in degrees
 Example: radTodeg(3.14159) = 180</comment>
-        <translation type="unfinished">radTodeg</translation>
+        <translation>radTodeg</translation>
     </message>
     <message>
         <source>sin</source>
         <comment>Sine function working with radians
 Usage: sin(angle θ in radians) → returns a number between -1 and 1
 Example: sin(90) = 0.893997</comment>
-        <translation type="unfinished">sin</translation>
+        <translation>sin</translation>
     </message>
     <message>
         <source>cos</source>
         <comment>Cosine function working with radians
 Usage: cos(angle θ in radians) → returns a number between -1 and 1
 Example: cos(1) = 0.540302</comment>
-        <translation type="unfinished">cos</translation>
+        <translation>cos</translation>
     </message>
     <message>
         <source>tan</source>
         <comment>Tangent function working with radians
 Usage: tan(angle θ in radians)
 Example: tan(1) = 1.55741</comment>
-        <translation type="unfinished">tan</translation>
+        <translation>tan</translation>
     </message>
     <message>
         <source>asin</source>
         <comment>Inverse sine function working with radians
 Usage: asin(x between -1 and 1) → returns an angle in radians
 Example: asin(-1) = -1.5708</comment>
-        <translation type="unfinished">asin</translation>
+        <translation>asin</translation>
     </message>
     <message>
         <source>acos</source>
         <comment>Inverse cosine function working with radians
 Usage: acos(x between -1 and 1) → returns an angle in radians
 Example: acos(0.1) = 1.47063</comment>
-        <translation type="unfinished">acos</translation>
+        <translation>acos</translation>
     </message>
     <message>
         <source>atan</source>
         <comment>Inverse tangent function working with radians
 Usage: atan(x) → returns an angle in radians
 Example: atan(1) = 0.78538</comment>
-        <translation type="unfinished">atan</translation>
+        <translation>atan</translation>
     </message>
     <message>
         <source>sinh</source>
         <comment>Hyperbolic sine function
 Usage: sinh(θ)
 Example: sinh(1) = 1.1752</comment>
-        <translation type="unfinished">sinh</translation>
+        <translation>sinh</translation>
     </message>
     <message>
         <source>cosh</source>
         <comment>Hyperbolic cosine
 Usage: cosh(θ) → returns a number greater than or equal to 1
 Example: cosh(0) = 1</comment>
-        <translation type="unfinished">cosh</translation>
+        <translation>cosh</translation>
     </message>
     <message>
         <source>tanh</source>
         <comment>Hyperbolic tangent function
 Usage: tanh(θ) → returns a number between -1 and 1 (excluded)
 Example: tanh(1) = 0.761594</comment>
-        <translation type="unfinished">tanh</translation>
+        <translation>tanh</translation>
     </message>
     <message>
         <source>asinh</source>
         <comment>Inverse Hyperbolic sine function
 Usage: asinh(x)
 Example: asinh(90) = 5.19299</comment>
-        <translation type="unfinished">asinh</translation>
+        <translation>asinh</translation>
     </message>
     <message>
         <source>acosh</source>
         <comment>Inverse Hyperbolic cosine function
 Usage: acosh(x greater than or equal to 1)
 Example: acosh(2) = 1.31696</comment>
-        <translation type="unfinished">acosh</translation>
+        <translation>acosh</translation>
     </message>
     <message>
         <source>atanh</source>
         <comment>Inverse Hyperbolic tangent function
 Usage: atanh(x between -1 and 1 (excluded))
 Example: atanh(0,99) = 2.64665</comment>
-        <translation type="unfinished">atanh</translation>
+        <translation>atanh</translation>
     </message>
     <message>
         <source>sinD</source>
         <comment>Sine function working with degrees
 Usage: sinD(angle θ in degrees) → returns a number between -1 and 1
 Example: sinD(90) = 1</comment>
-        <translation type="unfinished">sinD</translation>
+        <translation>sinD</translation>
     </message>
     <message>
         <source>cosD</source>
         <comment>Cosine function working with degrees
 Usage: cosD(angle θ in degrees) → returns a number between -1 and 1
 Example: cosD(180) = -1</comment>
-        <translation type="unfinished">cosD</translation>
+        <translation>cosD</translation>
     </message>
     <message>
         <source>tanD</source>
         <comment>Tangent function working with degrees
 Usage: tanD(angle θ in degrees)
 Example: tanD(45) = 1</comment>
-        <translation type="unfinished">tanD</translation>
+        <translation>tanD</translation>
     </message>
     <message>
         <source>asinD</source>
         <comment>Inverse sine function working with degrees
 Usage: asinD(x between -1 and 1) → returns an angle in degrees
 Example: asinD(1) = 90</comment>
-        <translation type="unfinished">asinD</translation>
+        <translation>asinD</translation>
     </message>
     <message>
         <source>acosD</source>
         <comment>Inverse cosine function working with degrees
 Usage: acosD(x between -1 and 1) → returns an angle in degrees
 Example: acosD(-1) = 180</comment>
-        <translation type="unfinished">acosD</translation>
+        <translation>acosD</translation>
     </message>
     <message>
         <source>atanD</source>
         <comment>Inverse tangent function working with degrees
 Usage: atanD(x) → returns an angle in degrees
 Example: atanD(1) = 45</comment>
-        <translation type="unfinished">atanD</translation>
+        <translation>atanD</translation>
     </message>
     <message>
         <source>log2</source>
         <comment>Logarithm to the base 2
 Usage: log2(x greater than 0)
 Example: log2(10) = 3.32193</comment>
-        <translation type="unfinished">log2</translation>
+        <translation>log2</translation>
     </message>
     <message>
         <source>log10</source>
         <comment>Logarithm to the base 10 (same as log(x))
 Usage: log10(x greater than 0)
 Example: log10(10) = 1</comment>
-        <translation type="unfinished">log10</translation>
+        <translation>log10</translation>
     </message>
     <message>
         <source>log</source>
         <comment>Logarithm to the base 10
 Usage: log(x greater than 0)
 Example: log(10) = 1</comment>
-        <translation type="unfinished">log</translation>
+        <translation>log</translation>
     </message>
     <message>
         <source>ln</source>
         <comment>Logarithm to base e (2.71828...)
 Usage: ln(x greater than 0)
 Example: ln(10) = 2.30259</comment>
-        <translation type="unfinished">ln</translation>
+        <translation>ln</translation>
     </message>
     <message>
         <source>exp</source>
         <comment>e raised to the power of x where e = 2.718
 Usage: exp(x) → returns a positive number
 Example: exp(2) = 7.38906</comment>
-        <translation type="unfinished">exp</translation>
+        <translation>exp</translation>
     </message>
     <message>
         <source>sqrt</source>
         <comment>Square root of a value
 Usage: sqrt(x greater than or equal to 0) → returns a positive number
 Example: sqrt(4) = 2</comment>
-        <translation type="unfinished">sqrt</translation>
+        <translation>sqrt</translation>
     </message>
     <message>
         <source>sign</source>
         <comment>Sign function -1 if x&lt;0; 1 if x&gt;0
 Usage: sign(x) → returns -1, 0 or 1
 Example: sign(-3) = -1</comment>
-        <translation type="unfinished">sign</translation>
+        <translation>sign</translation>
     </message>
     <message>
         <source>rint</source>
         <comment>Round to nearest integer
 Usage: rint(x) → returns an integer number
 Example: rint(2.3) = 2</comment>
-        <translation type="unfinished">rint</translation>
+        <translation>rint</translation>
     </message>
     <message>
         <source>abs</source>
         <comment>Absolute value
 Usage: abs(x) → returns a positive number
 Example: abs(-5) = 5</comment>
-        <translation type="unfinished">abs</translation>
+        <translation>abs</translation>
     </message>
     <message>
         <source>min</source>
         <comment>Min of all arguments
 Usage: min(arg 1; arg 2; ... arg n)
 Example: min(2;3;4) = 2</comment>
-        <translation type="unfinished">min</translation>
+        <translation>min</translation>
     </message>
     <message>
         <source>max</source>
         <comment>Max of all arguments
 Usage: max(arg 1; arg 2; ... arg n)
 Example: max(2;3;4) = 4</comment>
-        <translation type="unfinished">max</translation>
+        <translation>max</translation>
     </message>
     <message>
         <source>sum</source>
         <comment>Sum of all arguments
 Usage: sum(arg 1; arg 2; ... arg n)
 Example: sum(2;3;4) = 9</comment>
-        <translation type="unfinished">sum</translation>
+        <translation>sum</translation>
     </message>
     <message>
         <source>avg</source>
         <comment>Mean value of all arguments
 Usage: avg(arg 1; arg 2; ... arg n)
 Example: avg(2;3;4) = 3</comment>
-        <translation type="unfinished">avg</translation>
+        <translation>avg</translation>
     </message>
     <message>
         <source>fmod</source>
         <comment>Returns the floating-point remainder of x/y (rounded towards zero)
 Usage: fmod(x; y)
 Example: fmod(3.3;2) = 1.3</comment>
-        <translation type="unfinished">fmod</translation>
+        <translation>fmod</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Колір:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Колір:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1308,6 +1324,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">Колір:</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -1175,6 +1175,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">颜色:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSpline</name>
@@ -1242,6 +1250,14 @@ p, li { white-space: pre-wrap; }
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">颜色:</translation>
+    </message>
 </context>
 <context>
     <name>DialogCutSplinePath</name>
@@ -1308,6 +1324,14 @@ p, li { white-space: pre-wrap; }
     <message>
         <source>Backward (from end point)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Attributes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Color:</source>
+        <translation type="unfinished">颜色:</translation>
     </message>
 </context>
 <context>

--- a/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
+++ b/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
@@ -1420,6 +1420,9 @@ void VToolOptionsPropertyBrowser::changeDataToolCutArc(VPE::VProperty *property)
         case 62: // AttrDiretion
             tool->setDirection(value.toString());
             break;
+        case 26: // AttrLineColor
+            tool->setLineColor(value.toString());
+            break;
         default:
             qWarning() << "Unknown property type. id = "<<id;
             break;
@@ -1450,6 +1453,9 @@ void VToolOptionsPropertyBrowser::changeDataToolCutSpline(VPE::VProperty *proper
         case 62: // AttrDiretion
             tool->setDirection(value.toString());
             break;
+        case 26: // AttrLineColor
+            tool->setLineColor(value.toString());
+            break;
         default:
             qWarning() << "Unknown property type. id = "<<id;
             break;
@@ -1479,6 +1485,9 @@ void VToolOptionsPropertyBrowser::changeDataToolCutSplinePath(VPE::VProperty *pr
             break;
         case 62: // AttrDiretion
             tool->setDirection(value.toString());
+            break;
+        case 26: // AttrLineColor
+            tool->setLineColor(value.toString());
             break;
         default:
             qWarning() << "Unknown property type. id = "<<id;
@@ -2545,6 +2554,9 @@ void VToolOptionsPropertyBrowser::showOptionsToolCutArc(QGraphicsItem *item)
 
     addPropertyLabel(tr("Geometry"), AttrName);
     addPropertyFormula(tr("Length:"), tool->GetFormula(), AttrLength);
+
+    addPropertyLabel(tr("Attributes"), AttrName);
+    addPropertyLineColor(tool, tr("Color:"), AttrLineColor);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -2561,6 +2573,9 @@ void VToolOptionsPropertyBrowser::showOptionsToolCutSpline(QGraphicsItem *item)
 
     addPropertyLabel(tr("Geometry"), AttrName);
     addPropertyFormula(tr("Length:"), tool->GetFormula(), AttrLength);
+
+    addPropertyLabel(tr("Attributes"), AttrName);
+    addPropertyLineColor(tool, tr("Color:"), AttrLineColor);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -2577,6 +2592,9 @@ void VToolOptionsPropertyBrowser::showOptionsToolCutSplinePath(QGraphicsItem *it
 
     addPropertyLabel(tr("Geometry"), AttrName);
     addPropertyFormula(tr("Length:"), tool->GetFormula(), AttrLength);
+
+    addPropertyLabel(tr("Attributes"), AttrName);
+    addPropertyLineColor(tool, tr("Color:"), AttrLineColor);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -3307,6 +3325,11 @@ void VToolOptionsPropertyBrowser::updateOptionsToolCutArc()
     QVariant valueFormula;
     valueFormula.setValue(tool->GetFormula());
     idToProperty[AttrLength]->setValue(valueFormula);
+
+    {
+        const qint32 index = VPE::VLineColorProperty::indexOfColor(VAbstractTool::ColorsList(), tool->getLineColor());
+        idToProperty[AttrLineColor]->setValue(index);
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -3330,6 +3353,11 @@ void VToolOptionsPropertyBrowser::updateOptionsToolCutSpline()
     QVariant valueFormula;
     valueFormula.setValue(tool->GetFormula());
     idToProperty[AttrLength]->setValue(valueFormula);
+
+    {
+        const qint32 index = VPE::VLineColorProperty::indexOfColor(VAbstractTool::ColorsList(), tool->getLineColor());
+        idToProperty[AttrLineColor]->setValue(index);
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -3353,6 +3381,11 @@ void VToolOptionsPropertyBrowser::updateOptionsToolCutSplinePath()
     QVariant valueFormula;
     valueFormula.setValue(tool->GetFormula());
     idToProperty[AttrLength]->setValue(valueFormula);
+
+    {
+        const qint32 index = VPE::VLineColorProperty::indexOfColor(VAbstractTool::ColorsList(), tool->getLineColor());
+        idToProperty[AttrLineColor]->setValue(index);
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/app/seamly2d/xml/vpattern.cpp
+++ b/src/app/seamly2d/xml/vpattern.cpp
@@ -1100,6 +1100,14 @@ void VPattern::PointsCommonAttributes(const QDomElement &domElement, quint32 &id
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+void VPattern::PointsCommonAttributes(const QDomElement &domElement, quint32 &id, QString &name, qreal &mx, qreal &my,
+                                      bool &isVisible, QString &lineColor)
+{
+    PointsCommonAttributes(domElement, id, name, mx, my, isVisible);
+    lineColor  = GetParametrString(domElement, AttrLineColor,  qApp->Settings()->getPointNameColor());
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 void VPattern::PointsCommonAttributes(const QDomElement &domElement, quint32 &id, QString &name,
                                       qreal &mx, qreal &my, bool &isVisible)
 {
@@ -1884,16 +1892,17 @@ void VPattern::ParseToolCutSpline(VMainGraphicsScene *scene, QDomElement &domEle
         QString name;
         qreal mx = 0;
         qreal my = 0;
+        QString lineColor;
         bool showPointName = true;
 
-        PointsCommonAttributes(domElement, id, name, mx, my, showPointName);
+        PointsCommonAttributes(domElement, id, name, mx, my, showPointName, lineColor);
         QString direction       = GetParametrString(domElement, AttrDirection, "forward");
         const QString formula   = GetParametrString(domElement, AttrLength, "0");
         QString f               = formula;//need for saving fixed formula;
         const quint32 splineId  = GetParametrUInt(domElement, VToolCutSpline::AttrSpline, NULL_ID_STR);
 
-        VToolCutSpline::Create(id, name, direction, f, splineId, mx, my, showPointName, scene, this,
-                               data, parse, Source::FromFile);
+        VToolCutSpline::Create(id, name, direction, f, lineColor, splineId, mx, my, showPointName, scene,
+                               this, data, parse, Source::FromFile);
 
         //Rewrite attribute formula. Need for situation when we have wrong formula.
         if (f != formula)
@@ -1929,16 +1938,18 @@ void VPattern::ParseToolCutSplinePath(VMainGraphicsScene *scene, QDomElement &do
         QString name;
         qreal mx = 0;
         qreal my = 0;
+        QString lineColor;
         bool showPointName = true;
 
-        PointsCommonAttributes(domElement, id, name, mx, my, showPointName);
+        PointsCommonAttributes(domElement, id, name, mx, my, showPointName, lineColor);
         QString direction          = GetParametrString(domElement, AttrDirection, "forward");
         const QString formula      = GetParametrString(domElement, AttrLength, "0");
         QString f = formula; //need for saving fixed formula;
         const quint32 splinePathId = GetParametrUInt(domElement, VToolCutSplinePath::AttrSplinePath,
                                                      NULL_ID_STR);
 
-        VToolCutSplinePath::Create(id, name, direction, f, splinePathId, mx, my, showPointName, scene, this, data, parse, Source::FromFile);
+        VToolCutSplinePath::Create(id, name, direction, f, lineColor, splinePathId, mx, my, showPointName, scene,
+                                   this, data, parse, Source::FromFile);
         //Rewrite attribute formula. Need for situation when we have wrong formula.
         if (f != formula)
         {
@@ -1973,15 +1984,17 @@ void VPattern::ParseToolCutArc(VMainGraphicsScene *scene, QDomElement &domElemen
         QString name;
         qreal mx = 0;
         qreal my = 0;
+        QString lineColor;
         bool showPointName = true;
 
-        PointsCommonAttributes(domElement, id, name, mx, my, showPointName);
+        PointsCommonAttributes(domElement, id, name, mx, my, showPointName, lineColor);
         QString direction     = GetParametrString(domElement, AttrDirection, "forward");
         const QString formula = GetParametrString(domElement, AttrLength, "0");
         QString f = formula;//need for saving fixed formula;
         const quint32 arcId   = GetParametrUInt(domElement, AttrArc, NULL_ID_STR);
 
-        VToolCutArc::Create(id, name, direction, f, arcId, mx, my, showPointName, scene, this, data, parse, Source::FromFile);
+        VToolCutArc::Create(id, name, direction, f, lineColor, arcId, mx, my, showPointName, scene,
+                            this, data, parse, Source::FromFile);
         //Rewrite attribute formula. Need for situation when we have wrong formula.
         if (f != formula)
         {

--- a/src/app/seamly2d/xml/vpattern.h
+++ b/src/app/seamly2d/xml/vpattern.h
@@ -176,6 +176,10 @@ private:
     void           PointsCommonAttributes(const QDomElement &domElement, quint32 &id, QString &name, qreal &mx,
                                           qreal &my, bool &labelVisible, QString &lineType,
                                           QString &lineWeight, QString &lineColor);
+
+    void           PointsCommonAttributes(const QDomElement &domElement, quint32 &id, QString &name, qreal &mx,
+                                          qreal &my, bool &labelVisible, QString &lineColor);
+
     void           PointsCommonAttributes(const QDomElement &domElement, quint32 &id, QString &name, qreal &mx,
                                           qreal &my, bool &labelVisible);
     void           PointsCommonAttributes(const QDomElement &domElement, quint32 &id, qreal &mx, qreal &my);

--- a/src/libs/vtools/dialogs/tools/dialogcutarc.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcutarc.cpp
@@ -67,11 +67,10 @@
 #include "ui_dialogcutarc.h"
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief DialogCutArc create dialog.
- * @param data container with data
- * @param parent parent widget
- */
+/// @brief DialogCutArc create dialog.
+/// @param data container with data
+/// @param parent parent widget
+//---------------------------------------------------------------------------------------------------------------------
 DialogCutArc::DialogCutArc(const VContainer *data, const quint32 &toolId, QWidget *parent)
     : DialogTool(data, toolId, parent)
     , ui(new Ui::DialogCutArc)
@@ -98,6 +97,12 @@ DialogCutArc::DialogCutArc(const VContainer *data, const quint32 &toolId, QWidge
     DialogTool::CheckState();
 
     FillComboBoxArcs(ui->comboBoxArc);
+
+    int index = ui->lineColor_ComboBox->findData(qApp->getCurrentDocument()->getDefaultLineColor());
+    if (index != -1)
+    {
+        ui->lineColor_ComboBox->setCurrentIndex(index);
+    }
 
     ui->direction_ComboBox->addItem(tr("Forward (from start point)"), "forward");
     ui->direction_ComboBox->addItem(tr("Backward (from end point)"), "backward");
@@ -149,11 +154,10 @@ DialogCutArc::~DialogCutArc()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
- * @param id id of point or detail
- * @param type type of object
- */
+/// @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
+/// @param id id of point or detail
+/// @param type type of object
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCutArc::ChosenObject(quint32 id, const SceneObject &type)
 {
     if (prepare == false)// After first choose we ignore all objects
@@ -195,10 +199,9 @@ void DialogCutArc::closeEvent(QCloseEvent *event)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief setArcId set id of arc
- * @param value id
- */
+/// @brief setArcId set id of arc
+/// @param value id
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCutArc::setArcId(const quint32 &value)
 {
     setCurrentArcId(ui->comboBoxArc, value);
@@ -209,10 +212,9 @@ void DialogCutArc::setArcId(const quint32 &value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief SetFormula set string with formula length
- * @param value string with formula
- */
+/// @brief SetFormula set string with formula length
+/// @param value string with formula
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCutArc::SetFormula(const QString &value)
 {
     formula = qApp->translateVariables()->FormulaToUser(value, qApp->Settings()->getOsSeparator());
@@ -231,10 +233,9 @@ void DialogCutArc::SetFormula(const QString &value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief SetPointName set name point on arc
- * @param value name
- */
+/// @brief SetPointName set name point on arc
+/// @param value name
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCutArc::SetPointName(const QString &value)
 {
     pointName = value;
@@ -254,21 +255,37 @@ QString DialogCutArc::getDirection() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief GetFormula return string with formula length
- * @return formula
- */
+/// @brief GetFormula return string with formula length
+/// @return formula
+//---------------------------------------------------------------------------------------------------------------------
 QString DialogCutArc::GetFormula() const
 {
     return qApp->translateVariables()->TryFormulaFromUser(formula, qApp->Settings()->getOsSeparator());
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief getArcId return id of arc
- * @return id
- */
+/// @brief getArcId return id of arc
+/// @return id
+//---------------------------------------------------------------------------------------------------------------------
 quint32 DialogCutArc::getArcId() const
 {
     return getCurrentObjectId(ui->comboBoxArc);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief getLineColor get the color of line
+/// @return QString name of color
+//---------------------------------------------------------------------------------------------------------------------
+QString DialogCutArc::getLineColor() const
+{
+    return GetComboBoxCurrentData(ui->lineColor_ComboBox, ColorBlack);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief setLineColor set color of the line
+/// @param value type
+//---------------------------------------------------------------------------------------------------------------------
+void DialogCutArc::setLineColor(const QString &value)
+{
+    ChangeCurrentData(ui->lineColor_ComboBox, value);
 }

--- a/src/libs/vtools/dialogs/tools/dialogcutarc.h
+++ b/src/libs/vtools/dialogs/tools/dialogcutarc.h
@@ -1,53 +1,51 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//-----------------------------------------------------------------------------
+//  @file   dialogcutarc.cpp
+//  @author Douglas S Caskey
+//  @date   14 Aug, 2023
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
- ************************************************************************
- **
- **  @file   dialogcutarc.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   7 1, 2014
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   dialogcutarc.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   7 1, 2014
+//
+//  @copyright
+//  Copyright (C) 2013 Valentina project.
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published
+//  by the Free Software Foundation, either version 3 of the License,
+//  or (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #ifndef DIALOGCUTARC_H
 #define DIALOGCUTARC_H
@@ -66,55 +64,57 @@ namespace Ui
     class DialogCutArc;
 }
 
-/**
- * @brief The DialogCutArc class dialog for ToolCutArc.
- */
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief The DialogCutArc class dialog for ToolCutArc.
+//---------------------------------------------------------------------------------------------------------------------
 class DialogCutArc : public DialogTool
 {
     Q_OBJECT
 public:
+                       DialogCutArc(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
+    virtual           ~DialogCutArc() Q_DECL_OVERRIDE;
 
-    DialogCutArc(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogCutArc() Q_DECL_OVERRIDE;
+    void               SetPointName(const QString &value);
 
-    void              SetPointName(const QString &value);
+    QString            getDirection() const;
+    void               setDirection(const QString &value);
 
-    QString           getDirection() const;
-    void              setDirection(const QString &value);
+    QString            GetFormula() const;
+    void               SetFormula(const QString &value);
 
-    QString           GetFormula() const;
-    void              SetFormula(const QString &value);
+    quint32            getArcId() const;
+    void               setArcId(const quint32 &value);
 
-    quint32           getArcId() const;
-    void              setArcId(const quint32 &value);
+    QString            getLineColor() const;
+    void               setLineColor(const QString &value);
+
 public slots:
-    virtual void      ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    /**
-     * @brief DeployFormulaTextEdit grow or shrink formula input
-     */
-    void              DeployFormulaTextEdit();
-    /**
-     * @brief FormulaTextChanged when formula text changes for validation and calc
-     */
-    void              FormulaTextChanged();
-    void              FXLength();
+    virtual void       ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+
+    /// @brief DeployFormulaTextEdit grow or shrink formula input.
+    void               DeployFormulaTextEdit();
+
+    /// @brief FormulaTextChanged when formula text changes for validation and calc.
+    void               FormulaTextChanged();
+    void               FXLength();
+
 protected:
-    virtual void      ShowVisualization() Q_DECL_OVERRIDE;
-    /**
-     * @brief SaveData Put dialog data in local variables
-     */
-    virtual void      SaveData() Q_DECL_OVERRIDE;
-    virtual void      closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void       ShowVisualization() Q_DECL_OVERRIDE;
+
+    /// @brief SaveData Put dialog data in local variables
+    virtual void       SaveData() Q_DECL_OVERRIDE;
+    virtual void       closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+
 private:
     Q_DISABLE_COPY(DialogCutArc)
-    /** @brief ui keeps information about user interface */
+    /// @brief ui keeps information about user interface.
     Ui::DialogCutArc  *ui;
 
-    /** @brief formula string with formula */
-    QString           formula;
+    /// @brief formula string with formula.
+    QString            formula;
 
-    /** @brief formulaBaseHeight base height defined by dialogui */
-    int               formulaBaseHeight;
+    /// @brief formulaBaseHeight base height defined by dialogui.
+    int                formulaBaseHeight;
 };
 
 #endif // DIALOGCUTARC_H

--- a/src/libs/vtools/dialogs/tools/dialogcutarc.ui
+++ b/src/libs/vtools/dialogs/tools/dialogcutarc.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>350</width>
-    <height>338</height>
+    <height>360</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -406,6 +406,90 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="attributes_GroupBox_2">
+     <property name="minimumSize">
+      <size>
+       <width>240</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>9</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="title">
+      <string>Attributes</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <layout class="QFormLayout" name="formLayout_2">
+        <property name="labelAlignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="lineColor_Label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Color:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="ColorComboBox" name="lineColor_ComboBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+            <bold>false</bold>
+           </font>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -430,6 +514,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ColorComboBox</class>
+   <extends>QComboBox</extends>
+   <header location="global">color_combobox.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>comboBoxArc</tabstop>
   <tabstop>buttonBox</tabstop>
@@ -471,7 +562,4 @@
    </hints>
   </connection>
  </connections>
- <buttongroups>
-  <buttongroup name="direction_ButtonGroup"/>
- </buttongroups>
 </ui>

--- a/src/libs/vtools/dialogs/tools/dialogcutspline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcutspline.cpp
@@ -67,11 +67,10 @@
 #include "ui_dialogcutspline.h"
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief DialogCutSpline create dialog.
- * @param data container with data
- * @param parent parent widget
- */
+/// @brief DialogCutSpline create dialog.
+/// @param data container with data
+/// @param parent parent widget
+//---------------------------------------------------------------------------------------------------------------------
 DialogCutSpline::DialogCutSpline(const VContainer *data, const quint32 &toolId, QWidget *parent)
     : DialogTool(data, toolId, parent)
     , ui(new Ui::DialogCutSpline)
@@ -99,6 +98,12 @@ DialogCutSpline::DialogCutSpline(const VContainer *data, const quint32 &toolId, 
 
     FillComboBoxSplines(ui->comboBoxSpline);
 
+    int index = ui->lineColor_ComboBox->findData(qApp->getCurrentDocument()->getDefaultLineColor());
+    if (index != -1)
+    {
+        ui->lineColor_ComboBox->setCurrentIndex(index);
+    }
+
     ui->direction_ComboBox->addItem(tr("Forward (from start point)"), "forward");
     ui->direction_ComboBox->addItem(tr("Backward (from end point)"), "backward");
 
@@ -117,19 +122,19 @@ DialogCutSpline::~DialogCutSpline()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief SetPointName set name of point
- * @param value name
- */
-void DialogCutSpline::SetPointName(const QString &value)
+/// @brief setPointName set name of point
+/// @param value name
+//---------------------------------------------------------------------------------------------------------------------
+void DialogCutSpline::setPointName(const QString &value)
 {
     pointName = value;
     ui->lineEditNamePoint->setText(pointName);
 }
 
-
-// @brief setDirection set the direction
-// @param value name
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief setDirection set the direction
+/// @param value name
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCutSpline::setDirection(const QString &value)
 {
     ChangeCurrentData(ui->direction_ComboBox, value);
@@ -138,17 +143,21 @@ void DialogCutSpline::setDirection(const QString &value)
     path->setDirection(value);
 }
 
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief getDirection get the direction of the spline
+/// @return QString direction
+//---------------------------------------------------------------------------------------------------------------------
+
 QString DialogCutSpline::getDirection() const
 {
     return GetComboBoxCurrentData(ui->direction_ComboBox, "forward");
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief SetFormula set string of formula
- * @param value formula
- */
-void DialogCutSpline::SetFormula(const QString &value)
+/// @brief setFormula set string of formula
+/// @param value formula
+//---------------------------------------------------------------------------------------------------------------------
+void DialogCutSpline::setFormula(const QString &value)
 {
     formula = qApp->translateVariables()->FormulaToUser(value, qApp->Settings()->getOsSeparator());
     // increase height if needed. TODO : see if I can get the max number of caracters in one line
@@ -167,10 +176,9 @@ void DialogCutSpline::SetFormula(const QString &value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief setSplineId set id spline
- * @param value id
- */
+/// @brief setSplineId set id spline
+/// @param value id
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCutSpline::setSplineId(const quint32 &value)
 {
     setCurrentSplineId(ui->comboBoxSpline, value);
@@ -181,11 +189,28 @@ void DialogCutSpline::setSplineId(const quint32 &value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
- * @param id id of point or detail
- * @param type type of object
- */
+/// @brief getLineColor get the color of line
+/// @return QString name of color
+//---------------------------------------------------------------------------------------------------------------------
+QString DialogCutSpline::getLineColor() const
+{
+    return GetComboBoxCurrentData(ui->lineColor_ComboBox, ColorBlack);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief setLineColor set color of the line
+/// @param value type
+//---------------------------------------------------------------------------------------------------------------------
+void DialogCutSpline::setLineColor(const QString &value)
+{
+    ChangeCurrentData(ui->lineColor_ComboBox, value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
+/// @param id id of point or detail
+/// @param type type of object
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCutSpline::ChosenObject(quint32 id, const SceneObject &type)
 {
     if (prepare == false)// After first choose we ignore all objects
@@ -237,11 +262,11 @@ void DialogCutSpline::FXLength()
 {
     EditFormulaDialog *dialog = new EditFormulaDialog(data, toolId, ToolDialog, this);
     dialog->setWindowTitle(tr("Edit length"));
-    dialog->SetFormula(GetFormula());
+    dialog->SetFormula(getFormula());
     dialog->setPostfix(UnitsToStr(qApp->patternUnit(), true));
     if (dialog->exec() == QDialog::Accepted)
     {
-        SetFormula(dialog->GetFormula());
+        setFormula(dialog->GetFormula());
     }
     delete dialog;
 }
@@ -253,20 +278,18 @@ void DialogCutSpline::ShowVisualization()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief GetFormula return string of formula
- * @return formula
- */
-QString DialogCutSpline::GetFormula() const
+/// @brief getFormula return string of formula
+/// @return formula
+//---------------------------------------------------------------------------------------------------------------------
+QString DialogCutSpline::getFormula() const
 {
     return qApp->translateVariables()->TryFormulaFromUser(formula, qApp->Settings()->getOsSeparator());
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief getSplineId return id base point of line
- * @return id
- */
+/// @brief getSplineId return id base point of line
+/// @return id
+//---------------------------------------------------------------------------------------------------------------------
 quint32 DialogCutSpline::getSplineId() const
 {
     return getCurrentObjectId(ui->comboBoxSpline);

--- a/src/libs/vtools/dialogs/tools/dialogcutspline.h
+++ b/src/libs/vtools/dialogs/tools/dialogcutspline.h
@@ -1,53 +1,51 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//-----------------------------------------------------------------------------
+//  @file   dialogcutspline.h
+//  @author Douglas S Caskey
+//  @date   14 Aug, 2024
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
- ************************************************************************
- **
- **  @file   dialogcutspline.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   15 12, 2013
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   dialogcutspline.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   15 Dec 2013
+//
+//  @copyright
+//  Copyright (C) 2013 Valentina project.
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published
+//  by the Free Software Foundation, either version 3 of the License,
+//  or (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #ifndef DIALOGCUTSPLINE_H
 #define DIALOGCUTSPLINE_H
@@ -66,9 +64,9 @@ namespace Ui
     class DialogCutSpline;
 }
 
-/**
- * @brief The DialogCutSpline class dialog for ToolCutSpline.
- */
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief The DialogCutSpline class dialog for ToolCutSpline.
+//---------------------------------------------------------------------------------------------------------------------
 class DialogCutSpline : public DialogTool
 {
     Q_OBJECT
@@ -76,40 +74,42 @@ public:
     DialogCutSpline(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
     virtual ~DialogCutSpline() Q_DECL_OVERRIDE;
 
-    void                SetPointName(const QString &value);
+    void                setPointName(const QString &value);
 
     QString             getDirection() const;
     void                setDirection(const QString &value);
 
-    QString             GetFormula() const;
-    void                SetFormula(const QString &value);
+    QString             getFormula() const;
+    void                setFormula(const QString &value);
 
     quint32             getSplineId() const;
     void                setSplineId(const quint32 &value);
+
+    QString             getLineColor() const;
+    void                setLineColor(const QString &value);
+
 public slots:
     virtual void        ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    /**
-     * @brief DeployFormulaTextEdit grow or shrink formula input
-     */
+
+    /// @brief DeployFormulaTextEdit grow or shrink formula input
     void                DeployFormulaTextEdit();
     void                FXLength();
 protected:
     virtual void        ShowVisualization() Q_DECL_OVERRIDE;
-    /**
-     * @brief SaveData Put dialog data in local variables
-     */
+
+    /// @brief SaveData Put dialog data in local variables
     virtual void        SaveData() Q_DECL_OVERRIDE;
     virtual void        closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
 private:
     Q_DISABLE_COPY(DialogCutSpline)
 
-    /** @brief ui keeps information about user interface */
+    ///  @brief ui keeps information about user interface */
     Ui::DialogCutSpline *ui;
 
-    /** @brief formula string with formula */
+    ///  @brief formula string with formula */
     QString             formula;
 
-    /** @brief formulaBaseHeight base height defined by dialogui */
+    ///  @brief formulaBaseHeight base height defined by dialogui */
     int                 formulaBaseHeight;
 };
 

--- a/src/libs/vtools/dialogs/tools/dialogcutspline.ui
+++ b/src/libs/vtools/dialogs/tools/dialogcutspline.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>350</width>
-    <height>353</height>
+    <height>360</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -415,6 +415,90 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="attributes_GroupBox_2">
+     <property name="minimumSize">
+      <size>
+       <width>240</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>9</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="title">
+      <string>Attributes</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <layout class="QFormLayout" name="formLayout_2">
+        <property name="labelAlignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="lineColor_Label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Color:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="ColorComboBox" name="lineColor_ComboBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+            <bold>false</bold>
+           </font>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -439,6 +523,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ColorComboBox</class>
+   <extends>QComboBox</extends>
+   <header location="global">color_combobox.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>plainTextEditFormula</tabstop>
   <tabstop>comboBoxSpline</tabstop>
@@ -481,7 +572,4 @@
    </hints>
   </connection>
  </connections>
- <buttongroups>
-  <buttongroup name="direction_ButtonGroup"/>
- </buttongroups>
 </ui>

--- a/src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcutsplinepath.cpp
@@ -67,11 +67,10 @@
 #include "ui_dialogcutsplinepath.h"
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief DialogCutSplinePath create dialog.
- * @param data container with data
- * @param parent parent widget
- */
+/// @brief DialogCutSplinePath create dialog.
+/// @param data container with data
+/// @param parent parent widget
+//---------------------------------------------------------------------------------------------------------------------
 DialogCutSplinePath::DialogCutSplinePath(const VContainer *data, const quint32 &toolId, QWidget *parent)
     : DialogTool(data, toolId, parent)
     , ui(new Ui::DialogCutSplinePath)
@@ -99,6 +98,12 @@ DialogCutSplinePath::DialogCutSplinePath(const VContainer *data, const quint32 &
 
     FillComboBoxSplinesPath(ui->comboBoxSplinePath);
 
+    int index = ui->lineColor_ComboBox->findData(qApp->getCurrentDocument()->getDefaultLineColor());
+    if (index != -1)
+    {
+        ui->lineColor_ComboBox->setCurrentIndex(index);
+    }
+
     ui->direction_ComboBox->addItem(tr("Forward (from start point)"), "forward");
     ui->direction_ComboBox->addItem(tr("Backward (from end point)"), "backward");
 
@@ -117,10 +122,9 @@ DialogCutSplinePath::~DialogCutSplinePath()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief SetPointName set name of point
- * @param value name
- */
+/// @brief SetPointName set name of point
+/// @param value name
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCutSplinePath::SetPointName(const QString &value)
 {
     pointName = value;
@@ -140,10 +144,9 @@ QString DialogCutSplinePath::getDirection() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief SetFormula set string of formula
- * @param value formula
- */
+/// @brief SetFormula set string of formula
+/// @param value formula
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCutSplinePath::SetFormula(const QString &value)
 {
     formula = qApp->translateVariables()->FormulaToUser(value, qApp->Settings()->getOsSeparator());
@@ -163,10 +166,9 @@ void DialogCutSplinePath::SetFormula(const QString &value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief setSplineId set id spline
- * @param value id
- */
+/// @brief setSplineId set id spline
+/// @param value id
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCutSplinePath::setSplinePathId(const quint32 &value)
 {
     setCurrentSplinePathId(ui->comboBoxSplinePath, value);
@@ -177,11 +179,10 @@ void DialogCutSplinePath::setSplinePathId(const quint32 &value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
- * @param id id of point or detail
- * @param type type of object
- */
+/// @brief ChosenObject gets id and type of selected object. Save right data and ignore wrong.
+/// @param id id of point or detail
+/// @param type type of object
+//---------------------------------------------------------------------------------------------------------------------
 void DialogCutSplinePath::ChosenObject(quint32 id, const SceneObject &type)
 {
     if (prepare == false)// After first choose we ignore all objects
@@ -249,21 +250,37 @@ void DialogCutSplinePath::ShowVisualization()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief GetFormula return string of formula
- * @return formula
- */
+/// @brief GetFormula return string of formula
+/// @return formula
+//---------------------------------------------------------------------------------------------------------------------
 QString DialogCutSplinePath::GetFormula() const
 {
     return qApp->translateVariables()->TryFormulaFromUser(formula, qApp->Settings()->getOsSeparator());
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief getSplineId return id base point of line
- * @return id
- */
+/// @brief getSplineId return id base point of line
+/// @return id
+//---------------------------------------------------------------------------------------------------------------------
 quint32 DialogCutSplinePath::getSplinePathId() const
 {
     return getCurrentObjectId(ui->comboBoxSplinePath);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief getLineColor get the color of line
+/// @return QString name of color
+//---------------------------------------------------------------------------------------------------------------------
+QString DialogCutSplinePath::getLineColor() const
+{
+    return GetComboBoxCurrentData(ui->lineColor_ComboBox, ColorBlack);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief setLineColor set color of the line
+/// @param value type
+//---------------------------------------------------------------------------------------------------------------------
+void DialogCutSplinePath::setLineColor(const QString &value)
+{
+    ChangeCurrentData(ui->lineColor_ComboBox, value);
 }

--- a/src/libs/vtools/dialogs/tools/dialogcutsplinepath.h
+++ b/src/libs/vtools/dialogs/tools/dialogcutsplinepath.h
@@ -1,53 +1,52 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//-----------------------------------------------------------------------------
+//  @file   dialogcutsplinrpath.h
+//  @author Douglas S Caskey
+//  @date   14 Aug, 2024
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
- ************************************************************************
- **
- **  @file   dialogcutsplinrpath.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   15 12, 2013
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   dialogcutsplinrpath.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   15 Dec, 2013
+//
+//  @copyright
+//  Copyright (C) 2013 Valentina project.
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published
+//  by the Free Software Foundation, either version 3 of the License,
+//  or (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
+
 
 #ifndef DIALOGCUTSPLINEPATH_H
 #define DIALOGCUTSPLINEPATH_H
@@ -66,15 +65,15 @@ namespace Ui
     class DialogCutSplinePath;
 }
 
-/**
- * @brief The DialogCutSplinePath class dialog for ToolCutSplinePath.
- */
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief The DialogCutSplinePath class dialog for ToolCutSplinePath.
+//---------------------------------------------------------------------------------------------------------------------
 class DialogCutSplinePath : public DialogTool
 {
     Q_OBJECT
 public:
-    DialogCutSplinePath(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogCutSplinePath() Q_DECL_OVERRIDE;
+                 DialogCutSplinePath(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
+    virtual     ~DialogCutSplinePath() Q_DECL_OVERRIDE;
 
     void         SetPointName(const QString &value);
 
@@ -86,31 +85,34 @@ public:
 
     quint32      getSplinePathId() const;
     void         setSplinePathId(const quint32 &value);
+
+    QString      getLineColor() const;
+    void         setLineColor(const QString &value);
+
 public slots:
     virtual void ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    /**
-     * @brief DeployFormulaTextEdit grow or shrink formula input
-     */
+
+    /// @brief DeployFormulaTextEdit grow or shrink formula input.
     void         DeployFormulaTextEdit();
     void         FXLength();
+
 protected:
     virtual void ShowVisualization() Q_DECL_OVERRIDE;
-    /**
-     * @brief SaveData Put dialog data in local variables
-     */
+    /// @brief SaveData Put dialog data in local variables
     virtual void SaveData() Q_DECL_OVERRIDE;
     virtual void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+
 private:
     Q_DISABLE_COPY(DialogCutSplinePath)
 
-    /** @brief ui keeps information about user interface */
+    /// @brief ui keeps information about user interface.
     Ui::DialogCutSplinePath *ui;
 
-    /** @brief formula string with formula */
+    /// @brief formula string with formula.
     QString      formula;
 
-    /** @brief formulaBaseHeight base height defined by dialogui */
-    int formulaBaseHeight;
+    /// @brief formulaBaseHeight base height defined by dialogui.
+    int          formulaBaseHeight;
 };
 
 #endif // DIALOGCUTSPLINEPATH_H

--- a/src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui
+++ b/src/libs/vtools/dialogs/tools/dialogcutsplinepath.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>350</width>
-    <height>328</height>
+    <height>360</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -409,6 +409,90 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="attributes_GroupBox_2">
+     <property name="minimumSize">
+      <size>
+       <width>240</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>9</pointsize>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="title">
+      <string>Attributes</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <layout class="QFormLayout" name="formLayout_2">
+        <property name="labelAlignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="lineColor_Label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>100</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+            <bold>false</bold>
+           </font>
+          </property>
+          <property name="text">
+           <string>Color:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="ColorComboBox" name="lineColor_ComboBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>80</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="font">
+           <font>
+            <pointsize>9</pointsize>
+            <bold>false</bold>
+           </font>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -433,6 +517,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ColorComboBox</class>
+   <extends>QComboBox</extends>
+   <header location="global">color_combobox.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>plainTextEditFormula</tabstop>
   <tabstop>comboBoxSplinePath</tabstop>
@@ -475,7 +566,4 @@
    </hints>
   </connection>
  </connections>
- <buttongroups>
-  <buttongroup name="direction_ButtonGroup"/>
- </buttongroups>
 </ui>

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcut.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcut.cpp
@@ -1,53 +1,49 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//  @file   vtoolcut.cpp
+//  @author Douglas S Caskey
+//  @date   8 Jun, 2024
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
 
- ************************************************************************
- **
- **  @file   vtoolcut.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   25 6, 2014
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vtoolcut.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   25 6, 2014
+//
+//  @copyright
+//  Copyright (C) 2013 Valentina project.
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published
+//  by the Free Software Foundation, either version 3 of the License,
+//  or (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #include "vtoolcut.h"
 
@@ -68,13 +64,16 @@
 
 //---------------------------------------------------------------------------------------------------------------------
 VToolCut::VToolCut(VAbstractPattern *doc, VContainer *data, const quint32 &id, QString &direction,
-                   const QString &formula, const quint32 &curveCutId, QGraphicsItem *parent)
-    : VToolSinglePoint(doc, data, id, QColor(qApp->Settings()->getPointNameColor()), parent)
+                   const QString &formula, const QString &lineColor, const quint32 &curveCutId, QGraphicsItem *parent)
+    : VToolSinglePoint(doc, data, id, QColor(lineColor), parent)
     , m_direction(direction)
     , formula(formula)
+    , lineColor(lineColor)
     , curveCutId(curveCutId)
     , m_piecesMode(false)
 {
+    setPointColor(lineColor);
+
     Q_ASSERT_X(curveCutId != 0, Q_FUNC_INFO, "curveCutId == 0"); //-V654 //-V712
 }
 
@@ -156,6 +155,21 @@ void VToolCut::SetFormula(const VFormula &value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+QString VToolCut::getLineColor() const
+{
+    return lineColor;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VToolCut::setLineColor(const QString &value)
+{
+    lineColor = value;
+
+    QSharedPointer<VGObject> obj = VAbstractTool::data.GetGObject(m_id);
+    SaveOption(obj);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 QString VToolCut::CurveName() const
 {
     return VAbstractTool::data.GetGObject(curveCutId)->name();
@@ -167,6 +181,7 @@ QString VToolCut::CurveName() const
  */
 void VToolCut::RefreshGeometry()
 {
+    setPointColor(lineColor);
     VToolSinglePoint::refreshPointGeometry(*VDrawTool::data.GeometricObject<VPointF>(m_id));
 }
 

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcut.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcut.h
@@ -20,33 +20,30 @@
 //  You should have received a copy of the GNU General Public License
 //  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
 
-/************************************************************************
- **
- **  @file   vtoolcut.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   25 6, 2014
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vtoolcut.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   25 6, 2014
+//
+//  @copyright
+//  Copyright (C) 2013 Valentina project.
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published
+//  by the Free Software Foundation, either version 3 of the License,
+//  or (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #ifndef VTOOLCUT_H
 #define VTOOLCUT_H
@@ -72,13 +69,17 @@ class VToolCut : public VToolSinglePoint
     Q_OBJECT
 public:
                   VToolCut(VAbstractPattern *doc, VContainer *data, const quint32 &id, QString &direction,
-                           const QString &formula, const quint32 &curveCutId, QGraphicsItem * parent = nullptr);
+                           const QString &formula, const QString &lineColor, const quint32 &curveCutId,
+                           QGraphicsItem * parent = nullptr);
 
     virtual int   type() const Q_DECL_OVERRIDE {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::Cut)};
 
     VFormula      GetFormula() const;
     void          SetFormula(const VFormula &value);
+
+    QString       getLineColor() const;
+    void          setLineColor(const QString &value);
 
     QString       CurveName() const;
 
@@ -96,6 +97,7 @@ public slots:
 protected:
     QString       m_direction;
     QString       formula;      /*!< @brief formula keep formula of length */
+    QString       lineColor;
     quint32       curveCutId;
     bool          m_piecesMode;
 

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.h
@@ -77,10 +77,10 @@ public:
 
     static VToolCutArc *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene, VAbstractPattern *doc,
                                 VContainer *data);
-    static VToolCutArc *Create(const quint32 _id, const QString &pointName, QString &direction, QString &formula, quint32 arcId,
-                                qreal mx, qreal my, bool showPointName, VMainGraphicsScene *scene,
-                                VAbstractPattern *doc, VContainer *data, const Document &parse,
-                                const Source &typeCreation);
+    static VToolCutArc *Create(const quint32 _id, const QString &pointName, QString &direction, QString &formula,
+                               const QString &lineColor, quint32 arcId, qreal mx, qreal my, bool showPointName,
+                               VMainGraphicsScene *scene, VAbstractPattern *doc, VContainer *data,
+                               const Document &parse, const Source &typeCreation);
 
     static const QString ToolType;
     virtual int          type() const Q_DECL_OVERRIDE {return Type;}
@@ -100,8 +100,8 @@ protected:
 private:
     Q_DISABLE_COPY(VToolCutArc)
 
-                         VToolCutArc(VAbstractPattern *doc, VContainer *data, const quint32 &id,
-                                     QString &direction, const QString &formula, const quint32 &arcId,
+                         VToolCutArc(VAbstractPattern *doc, VContainer *data, const quint32 &id, QString &direction,
+                                     const QString &formula, const QString &lineColor, const quint32 &arcId,
                                      const Source &typeCreation, QGraphicsItem * parent = nullptr);
 };
 #endif // VTOOLCUTARC_H

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.cpp
@@ -1,53 +1,50 @@
-/***************************************************************************
- **  @file   vtoolcutspline.cpp
- **  @author Douglas S Caskey
- **  @date   17 Sep, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//  @file   vtoolcutspline.cpp
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
-/************************************************************************
- **  @file   vtoolcutspline.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   15 12, 2013
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vtoolcutspline.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   15 12, 2013
+//
+//  @copyright
+//  Copyright (C) 2013 Valentina project.
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published
+//  by the Free Software Foundation, either version 3 of the License,
+//  or (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #include "vtoolcutspline.h"
 
@@ -83,28 +80,26 @@ const QString VToolCutSpline::ToolType   = QStringLiteral("cutSpline");
 const QString VToolCutSpline::AttrSpline = QStringLiteral("spline");
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VToolCutSpline constructor.
- * @param doc dom document container.
- * @param data container with variables.
- * @param id object id in container.
- * @param formula string with formula length first spline.
- * @param splineId id spline in data container.
- * @param typeCreation way we create this tool.
- * @param parent parent object.
- */
+/// @brief VToolCutSpline constructor.
+/// @param doc dom document container.
+/// @param data container with variables.
+/// @param id object id in container.
+/// @param formula string with formula length first spline.
+/// @param splineId id spline in data container.
+/// @param typeCreation way we create this tool.
+/// @param parent parent object.
+//---------------------------------------------------------------------------------------------------------------------
 VToolCutSpline::VToolCutSpline(VAbstractPattern *doc, VContainer *data, const quint32 &id,
-                               QString &direction, const QString &formula,
+                               QString &direction, const QString &formula, const QString &lineColor,
                                const quint32 &splineId, const Source &typeCreation, QGraphicsItem *parent)
-    : VToolCut(doc, data, id, direction, formula, splineId, parent)
+    : VToolCut(doc, data, id, direction, formula, lineColor, splineId, parent)
 {
     ToolCreation(typeCreation);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief setDialog set dialog when user want change tool option.
- */
+/// @brief setDialog set dialog when user want change tool option.
+//---------------------------------------------------------------------------------------------------------------------
 void VToolCutSpline::setDialog()
 {
     SCASSERT(!m_dialog.isNull())
@@ -112,19 +107,19 @@ void VToolCutSpline::setDialog()
     SCASSERT(!dialogTool.isNull())
     const QSharedPointer<VPointF> point = VAbstractTool::data.GeometricObject<VPointF>(m_id);
     dialogTool->setDirection(m_direction);
-    dialogTool->SetFormula(formula);
+    dialogTool->setFormula(formula);
+    dialogTool->setLineColor(lineColor);
     dialogTool->setSplineId(curveCutId);
-    dialogTool->SetPointName(point->name());
+    dialogTool->setPointName(point->name());
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Create help create tool from GUI.
- * @param dialog dialog.
- * @param scene pointer to scene.
- * @param doc dom document container.
- * @param data container with variables.
- */
+/// @brief Create help create tool from GUI.
+/// @param dialog dialog.
+/// @param scene pointer to scene.
+/// @param doc dom document container.
+/// @param data container with variables.
+//---------------------------------------------------------------------------------------------------------------------
 VToolCutSpline* VToolCutSpline::Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene,
                                        VAbstractPattern *doc, VContainer *data)
 {
@@ -133,10 +128,11 @@ VToolCutSpline* VToolCutSpline::Create(QSharedPointer<DialogTool> dialog, VMainG
     SCASSERT(!dialogTool.isNull())
     const QString pointName = dialogTool->getPointName();
     QString direction       = dialogTool->getDirection();
-    QString formula         = dialogTool->GetFormula();
+    QString formula         = dialogTool->getFormula();
+    const QString lineColor = dialogTool->getLineColor();
     const quint32 splineId  = dialogTool->getSplineId();
-    VToolCutSpline* point = Create(0, pointName, direction, formula, splineId, 5, 10, true, scene, doc, data,
-                                   Document::FullParse, Source::FromGui);
+    VToolCutSpline* point = Create(0, pointName, direction, formula, lineColor, splineId, 5, 10, true,
+                                   scene, doc, data, Document::FullParse, Source::FromGui);
     if (point != nullptr)
     {
         point->m_dialog = dialogTool;
@@ -145,24 +141,25 @@ VToolCutSpline* VToolCutSpline::Create(QSharedPointer<DialogTool> dialog, VMainG
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Create help create tool.
- * @param _id tool id, 0 if tool doesn't exist yet.
- * @param pointName point name.
- * @param formula string with formula length first spline.
- * @param splineId id spline in data container.
- * @param mx label bias x axis.
- * @param my label bias y axis.
- * @param scene pointer to scene.
- * @param doc dom document container.
- * @param data container with variables.
- * @param parse parser file mode.
- * @param typeCreation way we create this tool.
- */
+/// @brief Create help create tool.
+/// @param _id tool id, 0 if tool doesn't exist yet.
+/// @param pointName point name.
+/// @param formula string with formula length first spline.
+/// @param lineColor color for tool
+/// @param splineId id spline in data container.
+/// @param mx label bias x axis.
+/// @param my label bias y axis.
+/// @param scene pointer to scene.
+/// @param doc dom document container.
+/// @param data container with variables.
+/// @param parse parser file mode.
+/// @param typeCreation way we create this tool.
+//---------------------------------------------------------------------------------------------------------------------
 VToolCutSpline* VToolCutSpline::Create(const quint32 _id, const QString &pointName, QString &direction,
-                                       QString &formula, const quint32 &splineId, qreal mx, qreal my,
-                                       bool showPointName, VMainGraphicsScene *scene, VAbstractPattern *doc,
-                                       VContainer *data, const Document &parse, const Source &typeCreation)
+                                       QString &formula, const QString &lineColor, const quint32 &splineId,
+                                       qreal mx, qreal my, bool showPointName, VMainGraphicsScene *scene,
+                                       VAbstractPattern *doc, VContainer *data, const Document &parse,
+                                       const Source &typeCreation)
 {
     const auto spl = data->GeometricObject<VAbstractCubicBezier>(splineId);
     SCASSERT(splPath != nullptr)
@@ -206,7 +203,7 @@ VToolCutSpline* VToolCutSpline::Create(const quint32 _id, const QString &pointNa
     if (parse == Document::FullParse)
     {
         VDrawTool::AddRecord(id, Tool::CutSpline, doc);
-        VToolCutSpline *point = new VToolCutSpline(doc, data, id, direction, formula, splineId, typeCreation);
+        VToolCutSpline *point = new VToolCutSpline(doc, data, id, direction, formula, lineColor, splineId, typeCreation);
         scene->addItem(point);
         InitToolConnections(scene, point);
         VAbstractPattern::AddTool(id, point);
@@ -223,10 +220,9 @@ void VToolCutSpline::ShowVisualization(bool show)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief contextMenuEvent handle context menu events.
- * @param event context menu event.
- */
+/// @brief contextMenuEvent handle context menu events.
+/// @param event context menu event.
+//---------------------------------------------------------------------------------------------------------------------
 void VToolCutSpline::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id)
 {
     try
@@ -241,9 +237,8 @@ void VToolCutSpline::showContextMenu(QGraphicsSceneContextMenuEvent *event, quin
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief SaveDialog save options into file after change in dialog.
- */
+/// @brief SaveDialog save options into file after change in dialog.
+//---------------------------------------------------------------------------------------------------------------------
 void VToolCutSpline::SaveDialog(QDomElement &domElement)
 {
     SCASSERT(!m_dialog.isNull())
@@ -251,7 +246,8 @@ void VToolCutSpline::SaveDialog(QDomElement &domElement)
     SCASSERT(!dialogTool.isNull())
     doc->SetAttribute(domElement, AttrName,      dialogTool->getPointName());
     doc->SetAttribute(domElement, AttrDirection, dialogTool->getDirection());
-    doc->SetAttribute(domElement, AttrLength,    dialogTool->GetFormula());
+    doc->SetAttribute(domElement, AttrLength,    dialogTool->getFormula());
+    doc->SetAttribute(domElement, AttrLineColor, dialogTool->getLineColor());
     doc->SetAttribute(domElement, AttrSpline,    QString().setNum(dialogTool->getSplineId()));
 }
 
@@ -263,6 +259,7 @@ void VToolCutSpline::SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj
     doc->SetAttribute(tag, AttrDirection, m_direction);
     doc->SetAttribute(tag, AttrType,      ToolType);
     doc->SetAttribute(tag, AttrLength,    formula);
+    doc->SetAttribute(tag, AttrLineColor, lineColor);
     doc->SetAttribute(tag, AttrSpline,    curveCutId);
 }
 
@@ -271,6 +268,7 @@ void VToolCutSpline::ReadToolAttributes(const QDomElement &domElement)
 {
     m_direction = doc->GetParametrString(domElement, AttrDirection, "forward");
     formula     = doc->GetParametrString(domElement, AttrLength,    "");
+    lineColor   = doc->GetParametrString(domElement, AttrLineColor, ColorBlack);
     curveCutId  = doc->GetParametrUInt(domElement,   AttrSpline,    NULL_ID_STR);
 }
 
@@ -307,7 +305,7 @@ QString VToolCutSpline::makeToolTip() const
     VSpline spline1 = VSpline(spl->GetP1(), spl1p2, spl1p3, VPointF(point));
     VSpline spline2 = VSpline(VPointF(point), spl2p2, spl2p3, spl->GetP4());
 
-    const QString curveStr = tr("Curve");
+    const QString curveStr  = tr("Curve");
     const QString lengthStr = tr("length");
 
     const QString toolTip = QString("<table style=font-size:11pt; font-weight:600>"

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.h
@@ -1,53 +1,50 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//  @file   vtoolcutspline.h
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
- ************************************************************************
- **
- **  @file   vtoolcutspline.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   15 12, 2013
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vtoolcutspline.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   15 12, 2013
+//
+//  @copyright
+//  Copyright (C) 2013 Valentina project.
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published
+//  by the Free Software Foundation, either version 3 of the License,
+//  or (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #ifndef VTOOLCUTSPLINE_H
 #define VTOOLCUTSPLINE_H
@@ -79,7 +76,8 @@ public:
                                   VContainer *data);
 
     static VToolCutSpline *Create(const quint32 _id, const QString &pointName, QString &direction,
-                                  QString &formula, const quint32 &splineId, qreal mx, qreal my, bool showPointName,
+                                  QString &formula, const QString &lineColor, const quint32 &splineId,
+                                  qreal mx, qreal my, bool showPointName,
                                   VMainGraphicsScene *scene, VAbstractPattern *doc, VContainer *data,
                                   const Document &parse, const Source &typeCreation);
 
@@ -103,8 +101,9 @@ private:
     Q_DISABLE_COPY(VToolCutSpline)
 
                           VToolCutSpline(VAbstractPattern *doc, VContainer *data, const quint32 &id,
-                                         QString &direction, const QString &formula, const quint32 &splineId,
-                                         const Source &typeCreation, QGraphicsItem * parent = nullptr);
+                                         QString &direction, const QString &formula, const QString &lineColor,
+                                         const quint32 &splineId, const Source &typeCreation,
+                                         QGraphicsItem * parent = nullptr);
 };
 
 #endif // VTOOLCUTSPLINE_H

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.cpp
@@ -1,53 +1,50 @@
-/***************************************************************************
- **  @file   vtoolcutsplinepath.cpp
- **  @author Douglas S Caskey
- **  @date   17 Sep, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//  @file   vtoolcutsplinepath.cpp
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
-/************************************************************************
- **  @file   vtoolcutsplinepath.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   15 12, 2013
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vtoolcutsplinepath.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   15 12, 2013
+//
+//  @copyright
+//  Copyright (C) 2013 Valentina project.
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published
+//  by the Free Software Foundation, either version 3 of the License,
+//  or (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #include "vtoolcutsplinepath.h"
 
@@ -86,29 +83,27 @@ const QString VToolCutSplinePath::ToolType       = QStringLiteral("cutSplinePath
 const QString VToolCutSplinePath::AttrSplinePath = QStringLiteral("splinePath");
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VToolCutSplinePath constructor.
- * @param doc dom document container.
- * @param data container with variables.
- * @param id object id in container.
- * @param formula string with formula length first splinePath.
- * @param splinePathId id splinePath (we cut this splinePath) in data container.
- * @param typeCreation way we create this tool.
- * @param parent parent object.
- */
+/// @brief VToolCutSplinePath constructor.
+/// @param doc dom document container.
+/// @param data container with variables.
+/// @param id object id in container.
+/// @param formula string with formula length first splinePath.
+/// @param splinePathId id splinePath (we cut this splinePath) in data container.
+/// @param typeCreation way we create this tool.
+/// @param parent parent object.
+//---------------------------------------------------------------------------------------------------------------------
 VToolCutSplinePath::VToolCutSplinePath(VAbstractPattern *doc, VContainer *data, const quint32 &id,
-                                       QString &direction, const QString &formula,
+                                       QString &direction, const QString &formula, const QString &lineColor,
                                        const quint32 &splinePathId, const Source &typeCreation,
                                        QGraphicsItem *parent)
-    : VToolCut(doc, data, id, direction, formula, splinePathId, parent)
+    : VToolCut(doc, data, id, direction, formula, lineColor, splinePathId, parent)
 {
     ToolCreation(typeCreation);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief setDialog set dialog when user want change tool option.
- */
+/// @brief setDialog set dialog when user want change tool option.
+//---------------------------------------------------------------------------------------------------------------------
 void VToolCutSplinePath::setDialog()
 {
     SCASSERT(!m_dialog.isNull())
@@ -117,30 +112,31 @@ void VToolCutSplinePath::setDialog()
     const QSharedPointer<VPointF> point = VAbstractTool::data.GeometricObject<VPointF>(m_id);
     dialogTool->setDirection(m_direction);
     dialogTool->SetFormula(formula);
+    dialogTool->setLineColor(lineColor);
     dialogTool->setSplinePathId(curveCutId);
     dialogTool->SetPointName(point->name());
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Create help create tool form GUI.
- * @param dialog dialog.
- * @param scene pointer to scene.
- * @param doc dom document container.
- * @param data container with variables.
- */
+/// @brief Create help create tool form GUI.
+/// @param dialog dialog.
+/// @param scene pointer to scene.
+/// @param doc dom document container.
+/// @param data container with variables.
+//---------------------------------------------------------------------------------------------------------------------
 VToolCutSplinePath* VToolCutSplinePath::Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene,
                                                VAbstractPattern *doc, VContainer *data)
 {
     SCASSERT(!dialog.isNull())
     QSharedPointer<DialogCutSplinePath> dialogTool = dialog.objectCast<DialogCutSplinePath>();
     SCASSERT(!dialogTool.isNull())
-    const QString pointName = dialogTool->getPointName();
-    QString direction       = dialogTool->getDirection();
-    QString formula = dialogTool->GetFormula();
+    const QString pointName    = dialogTool->getPointName();
+    QString direction          = dialogTool->getDirection();
+    QString formula            = dialogTool->GetFormula();
+    const QString lineColor    = dialogTool->getLineColor();
     const quint32 splinePathId = dialogTool->getSplinePathId();
-    VToolCutSplinePath* point = Create(0, pointName, direction, formula, splinePathId, 5, 10, true, scene, doc, data,
-                                       Document::FullParse, Source::FromGui);
+    VToolCutSplinePath* point  = Create(0, pointName, direction, formula, lineColor, splinePathId, 5, 10, true,
+                                        scene, doc, data, Document::FullParse, Source::FromGui);
     if (point != nullptr)
     {
         point->m_dialog = dialogTool;
@@ -149,23 +145,23 @@ VToolCutSplinePath* VToolCutSplinePath::Create(QSharedPointer<DialogTool> dialog
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Create help create tool.
- * @param _id tool id, 0 if tool doesn't exist yet.
- * @param pointName point name.
- * @param formula string with formula length first splinePath.
- * @param splinePathId id of splinePath in data container.
- * @param mx label bias x axis.
- * @param my label bias y axis.
- * @param scene pointer to scene.
- * @param doc dom document container.
- * @param data container with variables.
- * @param parse parser file mode.
- * @param typeCreation way we create this tool.
- */
+/// @brief Create help create tool.
+/// @param _id tool id, 0 if tool doesn't exist yet.
+/// @param pointName point name.
+/// @param formula string with formula length first splinePath.
+/// @param lineColor color for tool
+/// @param splinePathId id of splinePath in data container.
+/// @param mx label bias x axis.
+/// @param my label bias y axis.
+/// @param scene pointer to scene.
+/// @param doc dom document container.
+/// @param data container with variables.
+/// @param parse parser file mode.
+/// @param typeCreation way we create this tool.
+//---------------------------------------------------------------------------------------------------------------------
 VToolCutSplinePath* VToolCutSplinePath::Create(const quint32 _id, const QString &pointName, QString &direction,
-                                               QString &formula, quint32 splinePathId, qreal mx, qreal my,
-                                               bool showPointName, VMainGraphicsScene *scene,
+                                               QString &formula, const QString &lineColor, quint32 splinePathId,
+                                               qreal mx, qreal my, bool showPointName, VMainGraphicsScene *scene,
                                                VAbstractPattern *doc, VContainer *data, const Document &parse,
                                                const Source &typeCreation)
 {
@@ -218,7 +214,7 @@ VToolCutSplinePath* VToolCutSplinePath::Create(const quint32 _id, const QString 
     if (parse == Document::FullParse)
     {
         VDrawTool::AddRecord(id, Tool::CutSplinePath, doc);
-        VToolCutSplinePath *point = new VToolCutSplinePath(doc, data, id, direction, formula, splinePathId, typeCreation);
+        VToolCutSplinePath *point = new VToolCutSplinePath(doc, data, id, direction, formula, lineColor, splinePathId, typeCreation);
         scene->addItem(point);
         InitToolConnections(scene, point);
         VAbstractPattern::AddTool(id, point);
@@ -311,10 +307,9 @@ VPointF *VToolCutSplinePath::CutSplinePath(qreal length, const QSharedPointer<VA
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief contextMenuEvent handle context menu events.
- * @param event context menu event.
- */
+/// @brief contextMenuEvent handle context menu events.
+/// @param event context menu event.
+//---------------------------------------------------------------------------------------------------------------------
 void VToolCutSplinePath::showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id)
 {
     try
@@ -329,17 +324,17 @@ void VToolCutSplinePath::showContextMenu(QGraphicsSceneContextMenuEvent *event, 
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief SaveDialog save options into file after change in dialog.
- */
+/// @brief SaveDialog save options into file after change in dialog.
+//---------------------------------------------------------------------------------------------------------------------
 void VToolCutSplinePath::SaveDialog(QDomElement &domElement)
 {
     SCASSERT(!m_dialog.isNull())
     QSharedPointer<DialogCutSplinePath> dialogTool = m_dialog.objectCast<DialogCutSplinePath>();
     SCASSERT(!dialogTool.isNull())
-    doc->SetAttribute(domElement, AttrName, dialogTool->getPointName());
-    doc->SetAttribute(domElement, AttrDirection, dialogTool->getDirection());
-    doc->SetAttribute(domElement, AttrLength, dialogTool->GetFormula());
+    doc->SetAttribute(domElement, AttrName,       dialogTool->getPointName());
+    doc->SetAttribute(domElement, AttrDirection,  dialogTool->getDirection());
+    doc->SetAttribute(domElement, AttrLength,     dialogTool->GetFormula());
+    doc->SetAttribute(domElement, AttrLineColor,  dialogTool->getLineColor());
     doc->SetAttribute(domElement, AttrSplinePath, QString().setNum(dialogTool->getSplinePathId()));
 }
 
@@ -348,18 +343,20 @@ void VToolCutSplinePath::SaveOptions(QDomElement &tag, QSharedPointer<VGObject> 
 {
     VToolCut::SaveOptions(tag, obj);
 
-    doc->SetAttribute(tag, AttrDirection, m_direction);
-    doc->SetAttribute(tag, AttrType, ToolType);
-    doc->SetAttribute(tag, AttrLength, formula);
+    doc->SetAttribute(tag, AttrDirection,  m_direction);
+    doc->SetAttribute(tag, AttrType,       ToolType);
+    doc->SetAttribute(tag, AttrLength,     formula);
+    doc->SetAttribute(tag, AttrLineColor,  lineColor);
     doc->SetAttribute(tag, AttrSplinePath, curveCutId);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 void VToolCutSplinePath::ReadToolAttributes(const QDomElement &domElement)
 {
-    m_direction = doc->GetParametrString(domElement, AttrDirection, "forward");
-    formula     = doc->GetParametrString(domElement, AttrLength, "");
-    curveCutId  = doc->GetParametrUInt(domElement, AttrSplinePath, NULL_ID_STR);
+    m_direction = doc->GetParametrString(domElement, AttrDirection,  "forward");
+    formula     = doc->GetParametrString(domElement, AttrLength,     "");
+    lineColor   = doc->GetParametrString(domElement, AttrLineColor,  ColorBlack);
+    curveCutId  = doc->GetParametrUInt(domElement,   AttrSplinePath, NULL_ID_STR);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -394,7 +391,7 @@ QString VToolCutSplinePath::makeToolTip() const
     VPointF *p = VToolCutSplinePath::CutSplinePath(qApp->toPixel(length), splPath, "X", &splPath1, &splPath2);
     delete p; // Don't need this point
 
-    const QString curveStr = tr("Curve");
+    const QString curveStr  = tr("Curve");
     const QString lengthStr = tr("length");
 
     const QString toolTip = QString("<table style=font-size:11pt; font-weight:600>"

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.h
@@ -1,53 +1,50 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//  @file   vtoolcutsplinepath.h
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @copyright
+//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
- ************************************************************************
- **
- **  @file   vtoolcutsplinepath.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   15 12, 2013
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vtoolcutsplinepath.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   15 12, 2013
+//
+//  @copyright
+//  Copyright (C) 2013 Valentina project.
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published
+//  by the Free Software Foundation, either version 3 of the License,
+//  or (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #ifndef VTOOLCUTSPLINEPATH_H
 #define VTOOLCUTSPLINEPATH_H
@@ -80,9 +77,10 @@ public:
     static VToolCutSplinePath *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene,
                                       VAbstractPattern *doc, VContainer *data);
     static VToolCutSplinePath *Create(const quint32 _id, const QString &pointName, QString &direction,
-                                      QString &formula, quint32 splinePathId, qreal mx, qreal my,
-                                      bool showPointName, VMainGraphicsScene *scene, VAbstractPattern *doc,
-                                      VContainer *data, const Document &parse, const Source &typeCreation);
+                                      QString &formula, const QString &lineColor, quint32 splinePathId,
+                                      qreal mx, qreal my, bool showPointName, VMainGraphicsScene *scene,
+                                      VAbstractPattern *doc, VContainer *data, const Document &parse,
+                                      const Source &typeCreation);
     static const QString ToolType;
     static const QString AttrSplinePath;
     virtual int          type() const Q_DECL_OVERRIDE {return Type;}
@@ -108,8 +106,8 @@ private:
     Q_DISABLE_COPY(VToolCutSplinePath)
 
     VToolCutSplinePath(VAbstractPattern *doc, VContainer *data, const quint32 &id, QString &direction,
-                       const QString &formula, const quint32 &splinePathId, const Source &typeCreation,
-                       QGraphicsItem * parent = nullptr);
+                       const QString &formula, const QString &lineColor, const quint32 &splinePathId,
+                       const Source &typeCreation, QGraphicsItem * parent = nullptr);
 };
 
 #endif // VTOOLCUTSPLINEPATH_H


### PR DESCRIPTION
This PR adds a color attribute to the following tools:

- Point on Curve 
![Screenshot 2024-11-23 041652](https://github.com/user-attachments/assets/2e652af6-06e3-4c84-a0db-5d06e5c27529)

- Point on Spline

![image](https://github.com/user-attachments/assets/f81e7328-a5ef-4915-9a57-48e441d87e8d)

- Point on Arc
![Screenshot 2024-11-23 042145](https://github.com/user-attachments/assets/64b83311-8f77-41e8-bb27-8a7b5ed61645)

Ths closes issue #1217