### PR TITLE
bug: Remove minimum point name font size when zooming

### DIFF
--- a/src/libs/vwidgets/vscenepoint.cpp
+++ b/src/libs/vwidgets/vscenepoint.cpp
@@ -89,7 +89,7 @@ void VScenePoint::paint(QPainter *painter, const QStyleOptionGraphicsItem *optio
     setPointPen(scale);
     scaleCircleSize(this, scale * .75);
 
-    if (qApp->Settings()->getPointNameSize()*scale < 6 || !qApp->Settings()->getHidePointNames())
+    if (!qApp->Settings()->getHidePointNames())
     {
         m_pointName->setVisible(false);
         m_pointLeader->setVisible(false);


### PR DESCRIPTION
This PR addresses the issue of operation tool objects deselecting when zooming out and back in. By removing the minimum pt 5 font size, objects do not get deselected when zooming out past the minimum font size. 

Closes issue #1219