### PR TITLE
fix: fx dialog positioning

### DIFF
--- a/src/libs/vtools/dialogs/support/edit_formula_dialog.cpp
+++ b/src/libs/vtools/dialogs/support/edit_formula_dialog.cpp
@@ -120,6 +120,19 @@ EditFormulaDialog::EditFormulaDialog(const VContainer *data, const quint32 &tool
     ui->setupUi(this);
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
+    // Resize the dialog based on last saved size.
+    const QSize size = qApp->Settings()->GetFormulaWizardDialogSize();
+    if (!size.isEmpty())
+    {
+        // Block signals to prevent a resize event that will only save the size again. 
+        blockSignals(true);
+        resize(size);
+        blockSignals(false);
+    }
+
+    // Set the position that the dialog opens based on user preference.
+    setDialogPosition();
+
     initializeVariables();
     initializeFormulaUi(ui);
     ui->plainTextEditFormula->installEventFilter(this);
@@ -462,7 +475,6 @@ void EditFormulaDialog::closeEvent(QCloseEvent *event)
     DialogTool::closeEvent(event);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
 void EditFormulaDialog::showEvent(QShowEvent *event)
 {
     QDialog::showEvent(event);
@@ -470,23 +482,6 @@ void EditFormulaDialog::showEvent(QShowEvent *event)
     {
         return;
     }
-
-    if (isInitialized)
-    {
-        return;
-    }
-    // do your init stuff here
-
-    const QSize size = qApp->Settings()->GetFormulaWizardDialogSize();
-    if (!size.isEmpty())
-    {
-        resize(size);
-    }
-
-    // Set the position that the dialog opens based on user preference.
-    setDialogPosition();
-
-    isInitialized = true;//first show windows are held
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -494,10 +489,8 @@ void EditFormulaDialog::resizeEvent(QResizeEvent *event)
 {
     // remember the size for the next time this dialog is opened, but only
     // if widget was already initialized.
-    if (isInitialized)
-    {
-        qApp->Settings()->SetFormulaWizardDialogSize(size());
-    }
+    qApp->Settings()->SetFormulaWizardDialogSize(size());
+
     DialogTool::resizeEvent(event);
 }
 

--- a/src/libs/vtools/dialogs/support/edit_formula_dialog.ui
+++ b/src/libs/vtools/dialogs/support/edit_formula_dialog.ui
@@ -38,6 +38,9 @@
    <iconset resource="../../../vmisc/share/resources/icon.qrc">
     <normaloff>:/icon/32x32/edit.png</normaloff>:/icon/32x32/edit.png</iconset>
   </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
   <property name="modal">
    <bool>true</bool>
   </property>


### PR DESCRIPTION
This PR fixes the positioning of the fx dialog. It now positions correctly according to the settings in the Preferences. For some reason having the resize() and a call to the position code inside the overriding showEvent() was causing unpredicatable placement of the dialog.  

closes issue #1224