### PR TITLE
feature: Add context menu copy tool name

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -12686,6 +12686,42 @@ load in SeamlyME as usual.
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished">Čára_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished">Oblouk_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished">Křivka_</translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Délka</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Úhel</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished">Úhelčáry_</translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -4340,6 +4340,7 @@ Possibly the file is already being downloaded.</source>
     </message>
     <message>
         <source>Spl_</source>
+        <comment>Leave the _ symbol in translation</comment>
         <translation>Spl_</translation>
     </message>
     <message>
@@ -4364,7 +4365,7 @@ Possibly the file is already being downloaded.</source>
     </message>
     <message>
         <source>SplPath_</source>
-        <translation>SplVerzeichnis_</translation>
+        <translation>SplPfad_</translation>
     </message>
     <message>
         <source>%1 - Spline Fixed</source>
@@ -4567,6 +4568,7 @@ Possibly the file is already being downloaded.</source>
     </message>
     <message>
         <source>Spl_</source>
+        <comment>Leave the _ symbol in translation</comment>
         <translation>Spl_</translation>
     </message>
     <message>
@@ -4579,6 +4581,7 @@ Possibly the file is already being downloaded.</source>
     </message>
     <message>
         <source>Arc_</source>
+        <comment>Leave the _ symbol in translation</comment>
         <translation>Bogen_</translation>
     </message>
     <message>
@@ -4591,7 +4594,8 @@ Possibly the file is already being downloaded.</source>
     </message>
     <message>
         <source>SplPath_</source>
-        <translation>SplVerzeichnis_</translation>
+        <comment>Leave the _ symbol in translation</comment>
+        <translation>SplPfad_</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4663,6 +4667,7 @@ Possibly the file is already being downloaded.</source>
     </message>
     <message>
         <source>ElArc_</source>
+        <comment>Leave the _ symbol in translation</comment>
         <translation>ElBogen_</translation>
     </message>
     <message>
@@ -11905,6 +11910,7 @@ wie gewohnt in SeamlyME laden können.
     </message>
     <message>
         <source>Line_</source>
+        <comment>Leave the _ symbol in translation</comment>
         <translation>Linie_</translation>
     </message>
 </context>
@@ -12711,6 +12717,48 @@ wie gewohnt in SeamlyME laden können.
     <message>
         <source>Remove Group Object</source>
         <translation>Gruppen Objekt entfernen</translation>
+    </message>
+    <message>
+        <source>Line_</source>
+        <comment>Leave the _ symbol in translation</comment>
+        <translation>Linie_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <comment>Leave the _ symbol in translation</comment>
+        <translation>Bogen_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <comment>Leave the _ symbol in translation</comment>
+        <translation>ElBogen_</translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <comment>Leave the _ symbol in translation</comment>
+        <translation>Spl_</translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <comment>Leave the _ symbol in translation</comment>
+        <translation>SplPfad_</translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation>Kopie</translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation>Länge</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation>Winkel</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <comment>Leave the _ symbol in translation</comment>
+        <translation>WinkelLinie_</translation>
     </message>
 </context>
 <context>
@@ -13724,18 +13772,22 @@ wie gewohnt in SeamlyME laden können.
     </message>
     <message>
         <source>Arc_</source>
+        <comment>Leave the _ symbol in translation</comment>
         <translation>Bogen_</translation>
     </message>
     <message>
         <source>Spl_</source>
+        <comment>Leave the _ symbol in translation</comment>
         <translation>Spl_</translation>
     </message>
     <message>
         <source>SplPath_</source>
-        <translation>SplVerzeichnis</translation>
+        <comment>Leave the _ symbol in translation</comment>
+        <translation>SplPfad_</translation>
     </message>
     <message>
         <source>Line_</source>
+        <comment>Leave the _ symbol in translation</comment>
         <translation>Linie_</translation>
     </message>
     <message>
@@ -14655,18 +14707,15 @@ wie gewohnt in SeamlyME laden können.
     </message>
     <message>
         <source>SplPath</source>
-        <comment>Do not add symbol _ to the end of the name</comment>
-        <translation>SplVerzeichnis</translation>
+        <translation>SplPfad</translation>
     </message>
     <message>
         <source>Angle1SplPath</source>
-        <comment>Do not add symbol _ to the end of the name</comment>
-        <translation>Winkel1SplVerzeichnis</translation>
+        <translation>Winkel1SplPfad</translation>
     </message>
     <message>
         <source>Angle2SplPath</source>
-        <comment>Do not add symbol _ to the end of the name</comment>
-        <translation>Winkel2SplVerzeichnis</translation>
+        <translation>Winkel2SplPfad</translation>
     </message>
     <message>
         <source>CurrentLength</source>
@@ -14685,13 +14734,11 @@ wie gewohnt in SeamlyME laden können.
     </message>
     <message>
         <source>C1LengthSplPath</source>
-        <comment>Do not add symbol _ to the end of the name</comment>
-        <translation>C1LängeSplVerzeichnis</translation>
+        <translation>C1LängeSplPfad</translation>
     </message>
     <message>
         <source>C2LengthSplPath</source>
-        <comment>Do not add symbol _ to the end of the name</comment>
-        <translation>C2LängeSplVerzeichnis</translation>
+        <translation>C2LängeSplPfad</translation>
     </message>
     <message>
         <source>CurrentSeamAllowance</source>
@@ -14836,7 +14883,7 @@ wie gewohnt in SeamlyME laden können.
     <message>
         <source>AngleLine_</source>
         <comment>Leave the _ symbol in translation</comment>
-        <translation>Winkellinie_</translation>
+        <translation>WinkelLinie_</translation>
     </message>
     <message>
         <source>Arc_</source>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -12685,6 +12685,42 @@ load in SeamlyME as usual.
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished">Γραμμή_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished">Τόξο_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Μήκος</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Γωνία</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -12690,6 +12690,42 @@ load in SeamlyME as usual.
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished">Line_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished">Arc_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished">Spl_</translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Length</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Angle</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished">AngleLine_</translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -12690,6 +12690,42 @@ load in SeamlyME as usual.
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished">Line_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished">Arc_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished">Spl_</translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Length</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Angle</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -12690,6 +12690,42 @@ load in SeamlyME as usual.
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished">Line_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished">Arc_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished">Spl_</translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Length</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Angle</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished">AngleLine_</translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -12690,6 +12690,42 @@ load in SeamlyME as usual.
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished">Line_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished">Arc_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished">Spl_</translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Length</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Angle</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -4251,7 +4251,7 @@ Do you want to download it?</source>
 ¿Quiere descargarla?</translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file
+        <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
@@ -5372,7 +5372,7 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
         <translation>Ninguno</translation>
     </message>
     <message>
-        <source>Margins go beyond printing.
+        <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
@@ -10431,13 +10431,13 @@ actualización:</translation>
         <translation>Pulgadas</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed.
+        <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10505,13 +10505,13 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Establece el sonido del clic de selección del nodo.</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed.
+        <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12769,6 +12769,42 @@ load in SeamlyME as usual.
     <message>
         <source>Remove Group Object</source>
         <translation>Eliminar Objeto de Grupo</translation>
+    </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished">Línea_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished">Arco_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished">ElArco_</translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Longitud</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Ángulo</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished">AngleLine_</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -12686,6 +12686,42 @@ load in SeamlyME as usual.
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished">Viiva_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished">Kaari_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished">Spl_</translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Pituus</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Kulma</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished">KulmaViiva_</translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -4190,12 +4190,6 @@ for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file
-%1
-Possibly the file is already being downloaded.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>File download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4210,6 +4204,12 @@ Possibly the file is already being downloaded.</source>
     <message>
         <source>A new release %1 is available.
 Do you want to download it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to get exclusive access to file 
+%1
+Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5191,12 +5191,6 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Surface décroissante</translation>
     </message>
     <message>
-        <source>Margins go beyond printing.
-
-Apply settings anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Centimeters</source>
         <translation>Centimètres</translation>
     </message>
@@ -5322,6 +5316,12 @@ Apply settings anyway?</source>
     <message>
         <source>Millimeters</source>
         <translation type="unfinished">Millimètres</translation>
+    </message>
+    <message>
+        <source>Margins go beyond printing. 
+
+Apply settings anyway?</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10330,17 +10330,6 @@ Press enter to temporarily add it to the list.</source>
         <translation>Séparateur décimal :</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
-When unchecked the period is used.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>When checked the Welcome window will not be displayed.
-You can change this setting in the SeamlyMe preferences.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>GUI language:</source>
         <translation>Langue de l&apos;interface:</translation>
     </message>
@@ -10368,6 +10357,17 @@ You can change this setting in the SeamlyMe preferences.</source>
         <source>Inches</source>
         <translation>Pouces</translation>
     </message>
+    <message>
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
+When unchecked the period is used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When checked the Welcome window will not be displayed. 
+You can change this setting in the SeamlyMe preferences.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10394,11 +10394,6 @@ You can change this setting in the SeamlyMe preferences.</source>
     <message>
         <source>GUI language:</source>
         <translation>Langue de l&apos;interface:</translation>
-    </message>
-    <message>
-        <source>When checked the Welcome window will not be displayed.
-You can change this setting in the Seamly2D preferences.</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Do not show again</source>
@@ -10429,18 +10424,23 @@ You can change this setting in the Seamly2D preferences.</source>
         <translation>Veuillez choisir les unités, le séparateur décimal, la langue et le son de sélection que vous préférez. (Vous pourrez les modifier ultérieurement.)</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
-When unchecked the period is used.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Sound:</source>
         <translation>Le son:</translation>
     </message>
     <message>
         <source>Sets the node selection click  sound.</source>
         <translation>Définit le son du clic de sélection du nœud.</translation>
+    </message>
+    <message>
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
+When unchecked the period is used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When checked the Welcome window will not be displayed. 
+You can change this setting in the Seamly2D preferences.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12688,6 +12688,42 @@ load in SeamlyME as usual.
     <message>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished">Ligne_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished">Arc_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished">Spl_</translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Longueur</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Angle</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished">AngleLine_</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -12683,6 +12683,42 @@ load in SeamlyME as usual.
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">אורך</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -12684,6 +12684,42 @@ load in SeamlyME as usual.
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">panjang</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">sudut</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -12688,6 +12688,42 @@ load in SeamlyME as usual.
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished">Linea_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished">Arco_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Lunghezza</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Angolo</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -4212,7 +4212,7 @@ Do you want to download it?</source>
         <translation>Een nieuwe versie %1 is beschikbaar. Wil je het downloaden?</translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file
+        <source>Unable to get exclusive access to file 
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
@@ -5323,7 +5323,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Millimeters</translation>
     </message>
     <message>
-        <source>Margins go beyond printing.
+        <source>Margins go beyond printing. 
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
@@ -10363,13 +10363,13 @@ Press enter to temporarily add it to the list.</source>
         <translation>Inches</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed.
+        <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10437,13 +10437,13 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Stelt het klikgeluid van de knooppuntselectie in.</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed.
+        <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12699,6 +12699,42 @@ load in SeamlyME as usual.
     <message>
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished">Lijn_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished">Boog_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished">EllBoog_</translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished">Spl_</translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished">Splinepad_</translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Lengte</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Hoek</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished">HoekLijn_</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -12683,6 +12683,42 @@ load in SeamlyME as usual.
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished">Linha_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished">Arco_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Comprimento</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Ângulo</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished">LinhaDeAngulo_</translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -12683,6 +12683,42 @@ load in SeamlyME as usual.
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Lungime</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Unghi</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -4218,12 +4218,6 @@ for writing</source>
 для записи</translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file
-%1
-Possibly the file is already being downloaded.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>File download failed: %1.</source>
         <translation>Не удалось загрузить файл: %1.</translation>
     </message>
@@ -4240,6 +4234,12 @@ Possibly the file is already being downloaded.</source>
 Do you want to download it?</source>
         <translation>Появилось новое обновление %1.
 Хотите скачать его?</translation>
+    </message>
+    <message>
+        <source>Unable to get exclusive access to file 
+%1
+Possibly the file is already being downloaded.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5220,12 +5220,6 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>По убыванию площади</translation>
     </message>
     <message>
-        <source>Margins go beyond printing.
-
-Apply settings anyway?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Centimeters</source>
         <translation>Сантиметры</translation>
     </message>
@@ -5352,6 +5346,12 @@ Apply settings anyway?</source>
     <message>
         <source>Millimeters</source>
         <translation>Миллиметры</translation>
+    </message>
+    <message>
+        <source>Margins go beyond printing. 
+
+Apply settings anyway?</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10362,17 +10362,6 @@ Press enter to temporarily add it to the list.</source>
         <translation>Десятичный Разделитель:</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
-When unchecked the period is used.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>When checked the Welcome window will not be displayed.
-You can change this setting in the SeamlyMe preferences.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>GUI language:</source>
         <translation>Язык интерфейса:</translation>
     </message>
@@ -10400,6 +10389,17 @@ You can change this setting in the SeamlyMe preferences.</source>
         <source>Inches</source>
         <translation>Дюймы</translation>
     </message>
+    <message>
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
+When unchecked the period is used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When checked the Welcome window will not be displayed. 
+You can change this setting in the SeamlyMe preferences.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SeamlyWelcomeDialog</name>
@@ -10424,19 +10424,8 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Десятичный Разделитель:</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
-When unchecked the period is used.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>GUI language:</source>
         <translation>Язык интерфейса:</translation>
-    </message>
-    <message>
-        <source>When checked the Welcome window will not be displayed.
-You can change this setting in the Seamly2D preferences.</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Do not show again</source>
@@ -10473,6 +10462,17 @@ You can change this setting in the Seamly2D preferences.</source>
     <message>
         <source>Sets the node selection click  sound.</source>
         <translation>Устанавливает звук щелчка при выборе узла.</translation>
+    </message>
+    <message>
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
+When unchecked the period is used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>When checked the Welcome window will not be displayed. 
+You can change this setting in the Seamly2D preferences.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12727,6 +12727,42 @@ load in SeamlyME as usual.
     <message>
         <source>Remove Group Object</source>
         <translation>Удалить Группу Объектов</translation>
+    </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished">Линия_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished">Дуга_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished">Дуга_</translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished">Спл_</translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished">СплКонтур_</translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Длина</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Угол</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished">УголЛинии_</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -12688,6 +12688,42 @@ load in SeamlyME as usual.
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished">Лінія_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished">Дуга_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished">Спл_</translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">Довжина</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished">Кут</translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished">КутЛінії_</translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -12683,6 +12683,42 @@ load in SeamlyME as usual.
         <source>Remove Group Object</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Line_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Length</source>
+        <translation type="unfinished">长度</translation>
+    </message>
+    <message>
+        <source>Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AngleLine_</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/src/libs/vgeometry/vabstractarc.cpp
+++ b/src/libs/vgeometry/vabstractarc.cpp
@@ -193,7 +193,7 @@ void VAbstractArc::setId(const quint32 &id)
 //---------------------------------------------------------------------------------------------------------------------
 QString VAbstractArc::NameForHistory(const QString &toolName) const
 {
-    QString name = toolName + QString(" %1").arg(GetCenter().name());
+    QString name = toolName + QString("%1").arg(GetCenter().name());
 
     if (VAbstractCurve::id() != NULL_ID)
     {

--- a/src/libs/vgeometry/vabstractcubicbezier.cpp
+++ b/src/libs/vgeometry/vabstractcubicbezier.cpp
@@ -158,7 +158,7 @@ QPointF VAbstractCubicBezier::CutSpline(qreal length, QPointF &spl1p2, QPointF &
 //---------------------------------------------------------------------------------------------------------------------
 QString VAbstractCubicBezier::NameForHistory(const QString &toolName) const
 {
-    QString name = toolName + QString(" %1_%2").arg(GetP1().name()).arg(GetP4().name());
+    QString name = toolName + QString("%1_%2").arg(GetP1().name()).arg(GetP4().name());
     if (GetDuplicate() > 0)
     {
         name += QString("_%1").arg(GetDuplicate());

--- a/src/libs/vgeometry/vabstractcubicbezierpath.cpp
+++ b/src/libs/vgeometry/vabstractcubicbezierpath.cpp
@@ -245,7 +245,7 @@ QString VAbstractCubicBezierPath::NameForHistory(const QString &toolName) const
     QString name = toolName;
     if (CountPoints() > 0)
     {
-        name += QString(" %1").arg(FirstPoint().name());
+        name += QString("%1").arg(FirstPoint().name());
         if (CountSubSpl() >= 1)
         {
             name += QString("_%1").arg(LastPoint().name());

--- a/src/libs/vtools/tools/drawTools/vdrawtool.h
+++ b/src/libs/vtools/tools/drawTools/vdrawtool.h
@@ -56,6 +56,12 @@
 #include "../vinteractivetool.h"
 #include "../ifc/exception/vexceptionbadid.h"
 #include "../vdatatool.h"
+#include "../vgeometry/vabstractarc.h"
+#include "../vgeometry/varc.h"
+#include "../vgeometry/vellipticalarc.h"
+#include "../vgeometry/vcubicbezier.h"
+#include "../vgeometry/vsplinepath.h"
+#include "../vgeometry/vcubicbezierpath.h"
 #include "../vgeometry/vpointf.h"
 #include "../vmisc/vabstractapplication.h"
 #include "../vmisc/def.h"
@@ -70,6 +76,7 @@
 #include <qcompilerdetection.h>
 #include <QAction>
 #include <QByteArray>
+#include <QClipboard>
 #include <QColor>
 #include <QDomElement>
 #include <QGraphicsSceneContextMenuEvent>
@@ -191,8 +198,17 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
         }
     }
 
+    quint32 toolId = this->getId();
+    QMap<quint32, Tool> history = doc->getGroupObjHistory();
+    Tool tooltype = history.value(toolId);
+
     qCDebug(vTool, "Creating tool context menu.");
     QMenu menu;
+
+    // Actions for copying tool length and angle
+    QAction *actionCopyToolLength = nullptr;
+    QAction *actionCopyLineAngle = nullptr;
+
     QAction *actionOption = menu.addAction(QIcon::fromTheme("preferences-other"), tr("Properties"));
 
     // Show object name menu item
@@ -206,6 +222,24 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
     else
     {
        actionShowPointName->setVisible(false);
+    }
+
+    // Add Copy menu
+    QMenu *copyMenu = menu.addMenu(QIcon("://icon/32x32/clipboard_icon.png"), tr("Copy"));
+    actionCopyToolLength  = copyMenu->addAction(tr("Length"));
+    actionCopyLineAngle = copyMenu->addAction(tr("Angle"));
+
+    // Only add the Angle submneu for the point tools that add a line.
+    if (tooltype != Tool::Line &&
+        tooltype != Tool::EndLine &&
+        tooltype != Tool::Bisector &&
+        tooltype != Tool::Height &&
+        tooltype != Tool::Normal &&
+        tooltype != Tool::LineIntersectAxis &&
+        tooltype != Tool::AlongLine &&
+        tooltype != Tool::CurveIntersectAxis)
+    {
+        actionCopyLineAngle->setVisible(false);
     }
 
     QAction *actionDelete = menu.addAction(QIcon::fromTheme("edit-delete"), tr("Delete"));
@@ -240,7 +274,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
     QMap<quint32,QString> groupsNotContainingItem =  doc->getGroupsContainingItem(this->getId(), itemId, false);
     QActionGroup* actionAddGroupMenu= new QActionGroup(this);
 
-    if(not groupsNotContainingItem.empty())
+    if (!groupsNotContainingItem.empty())
     {
         QMenu *menuAddGroupItem = menu.addMenu(QIcon("://icon/32x32/add.png"), tr("Add Group Object"));
         QStringList list = QStringList(groupsNotContainingItem.values());
@@ -260,7 +294,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
     QMap<quint32,QString> groupsContainingItem =  doc->getGroupsContainingItem(this->getId(), itemId, true);
     QActionGroup* actionDeleteGroupMenu = new QActionGroup(this);
 
-    if(not groupsContainingItem.empty())
+    if (!groupsContainingItem.empty())
     {
         QMenu *menuRemoveGroupItem = menu.addMenu(QIcon("://icon/32x32/remove.png"), tr("Remove Group Object"));
 
@@ -306,6 +340,115 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
     {
         updatePointNameVisibility(itemId, selectedAction->isChecked());
     }
+
+    else if (selectedAction == actionCopyToolLength)
+    {
+        QString text = QString("");
+
+        switch (tooltype)
+        {
+            case Tool::Line:
+            {
+                const QDomElement domElement = doc->elementById(toolId);
+                if (domElement.isElement())
+                {
+                    text = tr("Line_") +
+                            data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, AttrFirstPoint, "0"))->name() +
+                            "_"+
+                            data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, AttrSecondPoint, "0"))->name();
+                    break;
+                }
+            }
+            case Tool::Arc:
+            case Tool::ArcWithLength:
+            {
+                const QSharedPointer<VArc> arc = data.GeometricObject<VArc>(toolId);
+                SCASSERT(!arc.isNull())
+                text = arc->NameForHistory(tr("Arc_"));
+                break;
+            }
+            case Tool::ShoulderPoint:
+            case Tool::Normal:
+            case Tool::Bisector:
+            case Tool::LineIntersect:
+            case Tool::BasePoint:
+            case Tool::EndLine:
+            case Tool::PointOfContact:
+            case Tool::Height:
+            case Tool::Triangle:
+            case Tool::PointOfIntersection:
+            case Tool::CutArc:
+            case Tool::CutSpline:
+            case Tool::CutSplinePath:
+            case Tool::LineIntersectAxis:
+            case Tool::CurveIntersectAxis:
+            case Tool::PointOfIntersectionArcs:
+            case Tool::PointOfIntersectionCircles:
+            case Tool::PointOfIntersectionCurves:
+            case Tool::PointFromCircleAndTangent:
+            case Tool::PointFromArcAndTangent:
+            {
+                const QSharedPointer<VGObject> obj = data.GetGObject(toolId);
+                SCASSERT(!obj.isNull())
+                text = obj->name();
+                break;
+            }
+
+            case Tool::EllipticalArc:
+            {
+                const QSharedPointer<VEllipticalArc> elArc = data.GeometricObject<VEllipticalArc>(toolId);
+                SCASSERT(!elArc.isNull())
+                text = elArc->NameForHistory(tr("ElArc_"));
+                break;
+            }
+
+            case Tool::Spline:
+            {
+                const QSharedPointer<VSpline> spl = data.GeometricObject<VSpline>(toolId);
+                SCASSERT(!spl.isNull())
+                text = spl->NameForHistory(tr("Spl_"));
+                break;
+            }
+
+            case Tool::SplinePath:
+            {
+                const QSharedPointer<VSplinePath> splPath = data.GeometricObject<VSplinePath>(toolId);
+                SCASSERT(!splPath.isNull())
+                text = splPath->NameForHistory(tr("SplPath_"));
+                break;
+            }
+
+            case Tool::CubicBezier:
+            {
+                const QSharedPointer<VCubicBezier> spl = data.GeometricObject<VCubicBezier>(toolId);
+                SCASSERT(!spl.isNull())
+                text = spl->NameForHistory(tr("Spl_"));
+                break;
+            }
+
+            case Tool::CubicBezierPath:
+            {
+                const QSharedPointer<VCubicBezierPath> splPath = data.GeometricObject<VCubicBezierPath>(toolId);
+                SCASSERT(!splPath.isNull())
+                text = splPath->NameForHistory(tr("SplPath_"));
+                break;
+            }
+
+            case Tool::Rotation:
+            case Tool::Move:
+            case Tool::MirrorByLine:
+            case Tool::MirrorByAxis:
+            {
+                const QSharedPointer<VGObject> obj = data.GetGObject(itemId);
+                SCASSERT(!obj.isNull())
+                text = obj->name();
+                break;
+            }
+        }
+
+        QClipboard *clipboard = QApplication::clipboard();
+        clipboard->setText(text);
+    }
     else if (selectedAction->actionGroup() == actionAddGroupMenu)
     {
         quint32 groupId = selectedAction->data().toUInt();
@@ -323,6 +466,66 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
             qApp->getUndoStack()->push(command);
         }
     }
+    else if (selectedAction == actionCopyLineAngle)
+    {
+        QString angleName = QString("");
+
+        switch (tooltype)
+        {
+            case Tool::Line:
+            {
+                const QDomElement domElement = doc->elementById(toolId);
+                if (domElement.isElement())
+                {
+                    angleName = tr("AngleLine_") +
+                            data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, AttrFirstPoint, "0"))->name() +
+                            "_"+
+                            data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, AttrSecondPoint, "0"))->name();
+                    break;
+                }
+            }
+            case Tool::AlongLine:
+            case Tool::Normal:
+            {
+                const QDomElement domElement = doc->elementById(toolId);
+                if (domElement.isElement())
+                {
+                    angleName = tr("AngleLine_") +
+                    data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, AttrFirstPoint, "0"))->name() +
+                    "_" +  data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, "id", "0"))->name();
+                    break;
+                }
+            }
+            case Tool::Bisector:
+            {
+                const QDomElement domElement = doc->elementById(toolId);
+                if (domElement.isElement())
+                {
+                    angleName = tr("AngleLine_") +
+                    data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, AttrSecondPoint, "0"))->name() +
+                    "_" +  data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, "id", "0"))->name();
+                    break;
+                }
+            }
+            case Tool::EndLine:
+            case Tool::Height:
+            case Tool::LineIntersectAxis:
+            case Tool::CurveIntersectAxis:
+            {
+                const QDomElement domElement = doc->elementById(toolId);
+                if (domElement.isElement())
+                {
+                    angleName = tr("AngleLine_") +
+                    data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, AttrBasePoint, "0"))->name() +
+                    "_" +  data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, "id", "0"))->name();
+                    break;
+                }
+            }
+        }
+        QClipboard *clipboard = QApplication::clipboard();
+        clipboard->setText(angleName);
+    }
+
     else if (selectedAction->actionGroup() == actionDeleteGroupMenu)
     {
         quint32 groupId = selectedAction->data().toUInt();


### PR DESCRIPTION
This PR adds a "Copy"  context menu item to draft block tools. 

- Adds a "Length" submenu item which is the tool name .

- When applicable adds an  "Angle" submenu item for the line angle. 

![Screenshot 2024-12-15 160044](https://github.com/user-attachments/assets/cfb9fbc9-1667-4d9c-afee-a0bade0b2296)

Closes issue #1233
