### PR TITLE
fix: no more empty groups in generated svgs

### DIFF
--- a/src/libs/vformat/svg_generator.cpp
+++ b/src/libs/vformat/svg_generator.cpp
@@ -107,12 +107,24 @@ QDomDocument SvgGenerator::mergeSvgDoms()
  */
 void SvgGenerator::removeEmptyGroups(QDomElement &mainGroup)
 {
-    QDomNodeList groups = mainGroup.elementsByTagName("g");
-    for (int i = 0; i < groups.size(); ++i) {
-        QDomElement group = groups.at(i).toElement();
-        if (group.childNodes().isEmpty()) {
-            if (mainGroup.removeChild(group).isNull()) {
-                qDebug() << "Error : could not remove empty group";
+    bool svgCleaned = false;
+
+    //We must remove the empty groups one by one until no more empty group is found.
+    //Since removing a group modifies the QDomNodeList indexation, we start over
+    //the search from the beginning each time a group is removed.
+    while(!svgCleaned)
+    {
+        svgCleaned = true;
+        QDomNodeList groups = mainGroup.elementsByTagName("g");
+
+        for (int i = 0; i < groups.size(); ++i) {
+            QDomElement group = groups.at(i).toElement();
+            if (group.childNodes().isEmpty()) {
+                if (mainGroup.removeChild(group).isNull()) {
+                    qDebug() << "Error : could not remove empty group";
+                }
+                svgCleaned = false;
+                break;
             }
         }
     }


### PR DESCRIPTION
When the DOM tree was parsed to remove empty groups, the indexation of the QDomNodeList was being changed each time a node was deleted, to reflect the new state of the DOM tree. The code wasn't taking this into consideration and empty nodes were missed.

Now I'm removing the empty groups 1 by 1, starting the search over each time a node is deleted, to take into consideration the new indexation of the QDomNodeList.

There may be some more efficient ways of cleaning the empty groups, but this one is probably the easiest.