### PR TITLE
correctly name cuff

### DIFF
--- a/src/app/share/samples/patterns/male_shirt.sm2d
+++ b/src/app/share/samples/patterns/male_shirt.sm2d
@@ -463,7 +463,7 @@ Delete layouts which are not needed.</description>
             <point id="299" idObject="97" inUse="true" mx="-0.222289" my="0.696084" type="modeling"/>
         </modeling>
         <pieces>
-            <piece closed="1" id="204" mx="27.4551" my="0.587081" name="Collar" seamAllowance="1" version="2" width="1">
+            <piece closed="1" id="204" mx="27.4551" my="0.587081" name="Cuff" seamAllowance="1" version="2" width="1">
                 <nodes>
                     <node idObject="200" type="NodePoint"/>
                     <node idObject="201" type="NodePoint"/>


### PR DESCRIPTION
Cuff was incorrectly labeled. Correct it.