### PR TITLE
ci: update to ubuntu 22.04 as 20.04 will be removed in April

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
   linux:
     name: 'Linux: Build AppImage'
-    runs-on: ubuntu-20.04  # build on the oldest supported LTS so that resulting binaries are compatible with older and newer Linux releases
+    runs-on: ubuntu-22.04  # build on the oldest supported LTS so that resulting binaries are compatible with older and newer Linux releases
     needs: version
     env:
       VERSION_NUMBER: ${{ needs.version.outputs.version_number }}
@@ -87,7 +87,7 @@ jobs:
   linux-test:
     if: github.event_name == 'pull_request'
     name: 'Linux: Run unit tests'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The 20.04 image will be removed from Github Actions, see https://github.com/actions/runner-images/issues/11101

This means that Seamly also requires at least Ubuntu 22.04 or equvalent