### PR TITLE
fix: replace duplicate Finnish translation

### DIFF
--- a/share/translations/measurements_fi_FI.ts
+++ b/share/translations/measurements_fi_FI.ts
@@ -853,7 +853,7 @@
         <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
-        <translation>lonkan_ympärysmitta</translation>
+        <translation>korkea_rintakehän_ympärysmitta</translation>
     </message>
     <message>
         <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>


### PR DESCRIPTION
This fixes the Finnish translations by replacing the translation for highbust_circ which was a duplcate of hip_circ with a correct translation. Both measurements can now be used. 

![image](https://github.com/user-attachments/assets/901a115d-43a9-48ed-bf30-3a5f9255812f)

This closes issue #1249 