### PR TITLE
FIX:  draft block issue

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -4686,6 +4686,10 @@ Do you want to download it?</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7323,6 +7327,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11111,6 +11123,22 @@ When unchecked the period is used.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -4339,11 +4339,6 @@ Possibly the file is already being downloaded.</source>
         <translation>%1 - Kurve interaktiv</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <comment>Leave the _ symbol in translation</comment>
-        <translation>Spl_</translation>
-    </message>
-    <message>
         <source>%1 - Curve Fixed</source>
         <translation>%1 - Kurve fixiert</translation>
     </message>
@@ -4503,6 +4498,10 @@ Possibly the file is already being downloaded.</source>
         <source>Color</source>
         <translation>Farbe</translation>
     </message>
+    <message>
+        <source>Spl_</source>
+        <translation>Spl_</translation>
+    </message>
 </context>
 <context>
     <name>HistoryDialog</name>
@@ -4567,11 +4566,6 @@ Possibly the file is already being downloaded.</source>
         <translation>Punkt schneidet Linien %1_%2und %3_%4</translation>
     </message>
     <message>
-        <source>Spl_</source>
-        <comment>Leave the _ symbol in translation</comment>
-        <translation>Spl_</translation>
-    </message>
-    <message>
         <source>Curve Interactive</source>
         <translation>Kurve interaktiv</translation>
     </message>
@@ -4580,22 +4574,12 @@ Possibly the file is already being downloaded.</source>
         <translation>Kurve fixiert</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <comment>Leave the _ symbol in translation</comment>
-        <translation>Bogen_</translation>
-    </message>
-    <message>
         <source>Arc Radius &amp; Angles</source>
         <translation>Bogen Radius &amp; Winkel</translation>
     </message>
     <message>
         <source>Arc Radius &amp; Length %1</source>
         <translation>Bogen Radius &amp; Länge %1</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <comment>Leave the _ symbol in translation</comment>
-        <translation>SplPfad_</translation>
     </message>
     <message>
         <source>Spline Interactive</source>
@@ -4666,11 +4650,6 @@ Possibly the file is already being downloaded.</source>
         <translation>Endgültige Abnäherlänge  %1_%2_%3</translation>
     </message>
     <message>
-        <source>ElArc_</source>
-        <comment>Leave the _ symbol in translation</comment>
-        <translation>ElBogen_</translation>
-    </message>
-    <message>
         <source>Arc Elliptical with length %1</source>
         <translation>Bogen elliptisch mit Länge %1</translation>
     </message>
@@ -4693,6 +4672,26 @@ Possibly the file is already being downloaded.</source>
     <message>
         <source>Point Length and Angle from point %1</source>
         <translation>Punkt Länge und Winkel von Punkt %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation>Spl_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation>Bogen_</translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation>SplPfad_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation>ElBogen_</translation>
     </message>
 </context>
 <context>
@@ -7347,6 +7346,14 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <source>100%</source>
         <translation>100%</translation>
     </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation>Vorheriger Entwurfsblock</translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation>Nächster Entwurfsblock</translation>
+    </message>
 </context>
 <context>
     <name>MainWindowsNoGUI</name>
@@ -9940,11 +9947,11 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     </message>
     <message>
         <source>Images</source>
-        <translation type="unfinished">Bilder</translation>
+        <translation>Bilder</translation>
     </message>
     <message>
         <source>Open Image File</source>
-        <translation type="unfinished">Bilddatei öffnen</translation>
+        <translation>Bilddatei öffnen</translation>
     </message>
     <message>
         <source>Pattern</source>
@@ -11136,6 +11143,22 @@ You can change this setting in the Seamly2D preferences.</source>
         <source>Ctrl+9</source>
         <translation>Strg+9</translation>
     </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation>Vorheriger Entwurfsblock</translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation>Strg+Bild aufwärts</translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation>Nächster Entwurfsblock</translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
+        <translation>Strg+Bild abwärts</translation>
+    </message>
 </context>
 <context>
     <name>ShowDoublePointName</name>
@@ -11910,7 +11933,6 @@ wie gewohnt in SeamlyME laden können.
     </message>
     <message>
         <source>Line_</source>
-        <comment>Leave the _ symbol in translation</comment>
         <translation>Linie_</translation>
     </message>
 </context>
@@ -12719,31 +12741,6 @@ wie gewohnt in SeamlyME laden können.
         <translation>Gruppen Objekt entfernen</translation>
     </message>
     <message>
-        <source>Line_</source>
-        <comment>Leave the _ symbol in translation</comment>
-        <translation>Linie_</translation>
-    </message>
-    <message>
-        <source>Arc_</source>
-        <comment>Leave the _ symbol in translation</comment>
-        <translation>Bogen_</translation>
-    </message>
-    <message>
-        <source>ElArc_</source>
-        <comment>Leave the _ symbol in translation</comment>
-        <translation>ElBogen_</translation>
-    </message>
-    <message>
-        <source>Spl_</source>
-        <comment>Leave the _ symbol in translation</comment>
-        <translation>Spl_</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <comment>Leave the _ symbol in translation</comment>
-        <translation>SplPfad_</translation>
-    </message>
-    <message>
         <source>Copy</source>
         <translation>Kopie</translation>
     </message>
@@ -12756,8 +12753,27 @@ wie gewohnt in SeamlyME laden können.
         <translation>Winkel</translation>
     </message>
     <message>
+        <source>Line_</source>
+        <translation>Linie_</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation>Bogen_</translation>
+    </message>
+    <message>
+        <source>ElArc_</source>
+        <translation>ElBogen_</translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation>Spl_</translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation>SplPfad_</translation>
+    </message>
+    <message>
         <source>AngleLine_</source>
-        <comment>Leave the _ symbol in translation</comment>
         <translation>WinkelLinie_</translation>
     </message>
 </context>
@@ -13771,32 +13787,28 @@ wie gewohnt in SeamlyME laden können.
         <translation>Bogen - elliptisch</translation>
     </message>
     <message>
-        <source>Arc_</source>
-        <comment>Leave the _ symbol in translation</comment>
-        <translation>Bogen_</translation>
-    </message>
-    <message>
-        <source>Spl_</source>
-        <comment>Leave the _ symbol in translation</comment>
-        <translation>Spl_</translation>
-    </message>
-    <message>
-        <source>SplPath_</source>
-        <comment>Leave the _ symbol in translation</comment>
-        <translation>SplPfad_</translation>
-    </message>
-    <message>
-        <source>Line_</source>
-        <comment>Leave the _ symbol in translation</comment>
-        <translation>Linie_</translation>
-    </message>
-    <message>
         <source>Center point</source>
         <translation>Mittelpunkt</translation>
     </message>
     <message>
         <source>Direction:</source>
         <translation>Richtung:</translation>
+    </message>
+    <message>
+        <source>Arc_</source>
+        <translation>Bogen_</translation>
+    </message>
+    <message>
+        <source>Spl_</source>
+        <translation>Spl_</translation>
+    </message>
+    <message>
+        <source>SplPath_</source>
+        <translation>SplPfad_</translation>
+    </message>
+    <message>
+        <source>Line_</source>
+        <translation>Linie_</translation>
     </message>
 </context>
 <context>
@@ -14706,18 +14718,6 @@ wie gewohnt in SeamlyME laden können.
         <translation>zoll</translation>
     </message>
     <message>
-        <source>SplPath</source>
-        <translation>SplPfad</translation>
-    </message>
-    <message>
-        <source>Angle1SplPath</source>
-        <translation>Winkel1SplPfad</translation>
-    </message>
-    <message>
-        <source>Angle2SplPath</source>
-        <translation>Winkel2SplPfad</translation>
-    </message>
-    <message>
         <source>CurrentLength</source>
         <comment>Do not add space between words</comment>
         <translation>AktuelleLänge</translation>
@@ -14731,14 +14731,6 @@ wie gewohnt in SeamlyME laden können.
         <source>height</source>
         <comment>placeholder</comment>
         <translation>Körperhöhe</translation>
-    </message>
-    <message>
-        <source>C1LengthSplPath</source>
-        <translation>C1LängeSplPfad</translation>
-    </message>
-    <message>
-        <source>C2LengthSplPath</source>
-        <translation>C2LängeSplPfad</translation>
     </message>
     <message>
         <source>CurrentSeamAllowance</source>
@@ -15197,6 +15189,31 @@ Example: avg(2;3;4) = 3</comment>
 Usage: fmod(x; y)
 Example: fmod(3.3;2) = 1.3</comment>
         <translation>fmod</translation>
+    </message>
+    <message>
+        <source>SplPath</source>
+        <comment>Do not add symbol _ to the end of the name</comment>
+        <translation>SplPfad</translation>
+    </message>
+    <message>
+        <source>Angle1SplPath</source>
+        <comment>Do not add symbol _ to the end of the name</comment>
+        <translation>Winkel1SplPfad</translation>
+    </message>
+    <message>
+        <source>Angle2SplPath</source>
+        <comment>Do not add symbol _ to the end of the name</comment>
+        <translation>Winkel2SplPfad</translation>
+    </message>
+    <message>
+        <source>C1LengthSplPath</source>
+        <comment>Do not add symbol _ to the end of the name</comment>
+        <translation>C1LängeSplPfad</translation>
+    </message>
+    <message>
+        <source>C2LengthSplPath</source>
+        <comment>Do not add symbol _ to the end of the name</comment>
+        <translation>C2LängeSplPfad</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -4686,6 +4686,10 @@ Do you want to download it?</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7323,6 +7327,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11111,6 +11123,22 @@ When unchecked the period is used.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -4686,6 +4686,10 @@ Do you want to download it?</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7326,6 +7330,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11114,6 +11126,22 @@ When unchecked the period is used.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -4686,6 +4686,10 @@ Do you want to download it?</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7326,6 +7330,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11114,6 +11126,22 @@ When unchecked the period is used.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -4686,6 +4686,10 @@ Do you want to download it?</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7326,6 +7330,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11114,6 +11126,22 @@ When unchecked the period is used.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -4686,6 +4686,10 @@ Do you want to download it?</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7326,6 +7330,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11114,6 +11126,22 @@ When unchecked the period is used.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -4251,7 +4251,7 @@ Do you want to download it?</source>
 ¿Quiere descargarla?</translation>
     </message>
     <message>
-        <source>Unable to get exclusive access to file 
+        <source>Unable to get exclusive access to file
 %1
 Possibly the file is already being downloaded.</source>
         <translation type="unfinished"></translation>
@@ -4729,6 +4729,10 @@ Possibly the file is already being downloaded.</source>
     <message>
         <source>Point Length and Angle from point %1</source>
         <translation>Punto Largo y Ángulo desde el punto %1</translation>
+    </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5372,7 +5376,7 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
         <translation>Ninguno</translation>
     </message>
     <message>
-        <source>Margins go beyond printing. 
+        <source>Margins go beyond printing.
 
 Apply settings anyway?</source>
         <translation type="unfinished"></translation>
@@ -7381,6 +7385,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>100%</source>
         <translation>100%</translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation>Anterior Bloque de borrador</translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation>Próximo Bloque de borrador</translation>
     </message>
 </context>
 <context>
@@ -10431,13 +10443,13 @@ actualización:</translation>
         <translation>Pulgadas</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10505,13 +10517,13 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Establece el sonido del clic de selección del nodo.</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11188,6 +11200,22 @@ You can change this setting in the Seamly2D preferences.</source>
     <message>
         <source>Ctrl+9</source>
         <translation>Control+9</translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation>Anterior Bloque de borrador</translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation>Control+Re Pág</translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation>Próximo Bloque de borrador</translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
+        <translation>Control+Av Pág</translation>
     </message>
 </context>
 <context>
@@ -12772,15 +12800,15 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Line_</source>
-        <translation type="unfinished">Línea_</translation>
+        <translation>Línea_</translation>
     </message>
     <message>
         <source>Arc_</source>
-        <translation type="unfinished">Arco_</translation>
+        <translation>Arco_</translation>
     </message>
     <message>
         <source>ElArc_</source>
-        <translation type="unfinished">ElArco_</translation>
+        <translation>ElArco_</translation>
     </message>
     <message>
         <source>Spl_</source>
@@ -12796,15 +12824,15 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Length</source>
-        <translation type="unfinished">Longitud</translation>
+        <translation>Longitud</translation>
     </message>
     <message>
         <source>Angle</source>
-        <translation type="unfinished">Ángulo</translation>
+        <translation>Ángulo</translation>
     </message>
     <message>
         <source>AngleLine_</source>
-        <translation type="unfinished">AngleLine_</translation>
+        <translation>AngleLine_</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -4686,6 +4686,10 @@ Do you want to download it?</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7323,6 +7327,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11111,6 +11123,22 @@ When unchecked the period is used.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -4686,6 +4686,10 @@ Possibly the file is already being downloaded.</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7326,6 +7330,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11114,6 +11126,22 @@ You can change this setting in the Seamly2D preferences.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -4686,6 +4686,10 @@ Do you want to download it?</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7322,6 +7326,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11110,6 +11122,22 @@ When unchecked the period is used.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -4686,6 +4686,10 @@ Do you want to download it?</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7323,6 +7327,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11111,6 +11123,22 @@ When unchecked the period is used.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -4686,6 +4686,10 @@ Do you want to download it?</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7326,6 +7330,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11114,6 +11126,22 @@ When unchecked the period is used.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -4691,6 +4691,10 @@ Possibly the file is already being downloaded.</source>
         <source>Point Length and Angle from point %1</source>
         <translation>Punt Lengte en Hoek van punt %1</translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7332,6 +7336,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>100%</source>
         <translation>100%</translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11120,6 +11132,22 @@ You can change this setting in the Seamly2D preferences.</source>
     <message>
         <source>Ctrl+9</source>
         <translation>Ctrl+9</translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -4686,6 +4686,10 @@ Do you want to download it?</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7322,6 +7326,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11110,6 +11122,22 @@ When unchecked the period is used.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -4686,6 +4686,10 @@ Do you want to download it?</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7322,6 +7326,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11110,6 +11122,22 @@ When unchecked the period is used.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -4715,6 +4715,10 @@ Possibly the file is already being downloaded.</source>
         <source>Point Length and Angle from point %1</source>
         <translation>Точка на Расстоянии и под Углом из точки %1</translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7356,6 +7360,14 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>100%</source>
         <translation>100%</translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11147,6 +11159,22 @@ You can change this setting in the Seamly2D preferences.</source>
     <message>
         <source>Ctrl+9</source>
         <translation>Ctrl+9</translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -4686,6 +4686,10 @@ Do you want to download it?</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7325,6 +7329,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11113,6 +11125,22 @@ When unchecked the period is used.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -4686,6 +4686,10 @@ Do you want to download it?</source>
         <source>Point Length and Angle from point %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Can&apos;t create record.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -7322,6 +7326,14 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>100%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -11110,6 +11122,22 @@ When unchecked the period is used.</source>
     </message>
     <message>
         <source>Ctrl+9</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Previous Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgUp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Next Draft Block</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/app/seamly2d/dialogs/history_dialog.cpp
+++ b/src/app/seamly2d/dialogs/history_dialog.cpp
@@ -279,6 +279,9 @@ RowData HistoryDialog::record(const VToolRecord &tool)
     if (domElement.isElement() == false)
     {
         qDebug() << "Can't find element by id" << Q_FUNC_INFO;
+        rowData.icon = ":/icons/win.icon.theme/16x16/status/dialog-warning.png";
+        rowData.name = QString();
+        rowData.tool = tr("Can't create record.");
         return rowData;
     }
     try
@@ -638,7 +641,7 @@ void HistoryDialog::initializeTable()
 void HistoryDialog::showTool()
 {
     const QVector<VToolRecord> *history = m_doc->getHistory();
-    if (!history->empty())
+    if (history->size()>0)
     {
         QTableWidgetItem *item = ui->tableWidget->item(0, 1);
         item->setSelected(true);

--- a/src/app/seamly2d/dialogs/shortcuts_dialog.cpp
+++ b/src/app/seamly2d/dialogs/shortcuts_dialog.cpp
@@ -83,11 +83,15 @@ ShortcutsDialog::ShortcutsDialog(QWidget *parent)
     const QString edit = QString("<table style=font-size:11pt; font-weight:600>"
                                     "<tr><td width = 50%><b>%1</b></td><td></td></tr>"
                                     "<tr><td width = 50%>%2       </td><td></td>%3</tr>"
-                                    "<tr><td width = 50%>%4       </td><td>%5<br></td></tr>"
+                                    "<tr><td width = 50%>%4       </td><td></td>%5</tr>"
+                                    "<tr><td width = 50%>%6       </td><td></td>%7</tr>"
+                                    "<tr><td width = 50%>%8       </td><td>%9<br></td></tr>"
                                  "</table>")
                                  .arg(tr("Edit"))                                            //1
                                  .arg(tr("Undo")).arg(tr("Ctrl+Z"))                          //2 & 3
-                                 .arg(tr("Redo")).arg(tr("Ctrl+Y"));                         //4 & 5
+                                 .arg(tr("Redo")).arg(tr("Ctrl+Y"))                          //4 & 5
+                                 .arg(tr("Previous Draft Block")).arg(tr("Ctrl+PgUp"))       //6 & 7
+                                 .arg(tr("Next Draft Block")).arg(tr("Ctrl+PgDown"));        //8 & 9
 
     const QString view = QString("<table style=font-size:11pt; font-weight:600>"
                                     "<tr><td width = 50%><b>%1</b></td><td></td></tr>"

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -3748,18 +3748,18 @@ void MainWindow::RestoreCurrentScene()
 }
 
 //-----------------------------------------------------------------------------
-/// @brief incrementDraftBlock Switch draft block incrementally.
+/// @brief incrementDraftBlock Change draft block incrementally.
 ///
-/// This method switches the current draft block by incrementing the combobox box current item up or down.
+/// This method changes the current draft block by selecting the previous or next combobox box item.
 ///
-/// @param increment determines whether to increment up or down.
+/// @param selection determines whether to select previous or next draft block.
 ///
 /// @details
-///  - an increment value of DraftBlock::MovePrev changes to the previous block;
-///  - an increment value of DraftBlock::MovePrev changes to the next block.
-///  - incrementimg wraps at the first or last item.
+///  - an selection value of Selection::Prev selects the previous block;
+///  - an selection value of Selection::Next selects the next block.
+///  - selection wraps at the first or last item.
 //-----------------------------------------------------------------------------
-void MainWindow::changeDraftBlock(DraftBlock increment)
+void MainWindow::changeDraftBlock(Selection selection)
 {
     int index = draftBlockComboBox->currentIndex();
     const int count = draftBlockComboBox->count();
@@ -3769,17 +3769,31 @@ void MainWindow::changeDraftBlock(DraftBlock increment)
         return;
     }
 
-    if ((index == 0) && (increment == DraftBlock::MovePrev))
+    if ((index == 0) && (selection == Selection::Prev))
     {
         index = count - 1;
     }
-    else if ((index == count - 1) && (increment == DraftBlock::MoveNext))
+    else if ((index == count - 1) && (selection == Selection::Next))
     {
         index = 0;
     }
     else
     {
-        index = index + static_cast<int>(increment);
+        switch (static_cast<int>(selection))
+        {
+            case Selection::Prev:
+            {
+                index = index - 1;
+                break;
+            }
+            case Selection::Next:
+            {
+                index = index + 1;
+                break;
+            }
+            default:
+                break;
+        }
     }
 
     draftBlockComboBox->setCurrentIndex(index);
@@ -5762,12 +5776,12 @@ void MainWindow::createActions()
     //Edit Menu
     connect(ui->previousDraftBlock_Action, &QAction::triggered, this, [this]()
     {
-        changeDraftBlock(DraftBlock::MovePrev);
+        changeDraftBlock(Selection::Prev);
     });
 
     connect(ui->nextDraftBlock_Action, &QAction::triggered, this, [this]()
     {
-        changeDraftBlock(DraftBlock::MoveNext);  
+        changeDraftBlock(Selection::Next);
     });
 
     connect(ui->labelTemplateEditor_Action, &QAction::triggered, this, [this]()

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -141,11 +141,11 @@ const QString strQShortcut = QStringLiteral("QShortcut");
 const QString strCtrl      = QStringLiteral("Ctrl");
 
 
-//  @brief Seamly2D MainWindow constructor.
-//
-//  This is the constructor for the Mainwindow class.
-//
-//  @param parent parent widget.
+/// @brief Seamly2D MainWindow constructor.
+///
+/// This is the constructor for the Mainwindow class.
+///
+/// @param parent parent widget.
 
 MainWindow::MainWindow(QWidget *parent)
     : MainWindowsNoGUI(parent)
@@ -343,11 +343,11 @@ MainWindow::MainWindow(QWidget *parent)
     }
 
 
-//  @brief addDraftBlock Create a new draft block.
-//
-//  This method adds a draft block the the draft scene and the dradft block combobox
-//
-//  @param blockName blockname string.
+/// @brief addDraftBlock Create a new draft block.
+///
+/// This method adds a draft block the the draft scene and the dradft block combobox
+///
+/// @param blockName blockname string.
 
 void MainWindow::addDraftBlock(const QString &blockName)
 {
@@ -412,20 +412,20 @@ void MainWindow::addDraftBlock(const QString &blockName)
 }
 
 
-//  @brief draftBlockStartPosition Set start position for draft block.
+/// @brief draftBlockStartPosition Set start position for draft block.
+///
+/// This method determines where to place the next draft block.
+///
+/// @return QPointF position of base point of next draft block
 //
-//  This method determines where to place the next draft block.
-//
-//  @return QPointF position of base point of next draft block
-//
-//  @details
-//   - Declare and initialize the x & y start positions, and offset between draft blocks.
-//   - Check if there is more than one draft block.
-//   - If there is more than one get the bounding rect of all the visible items in the draftscene.
-//     to determine the placement of the next draft block.
-//   - If the rect width is less than or equal to the height, position the new block to the right of
-//     the existing blocks else position the new block below the existing blocks.
-//   - If this is the first draft block use the default positions.
+/// @details
+///  - Declare and initialize the x & y start positions, and offset between draft blocks.
+///  - Check if there is more than one draft block.
+///  - If there is more than one get the bounding rect of all the visible items in the draftscene.
+///    to determine the placement of the next draft block.
+///  - If the rect width is less than or equal to the height, position the new block to the right of
+///    the existing blocks else position the new block below the existing blocks.
+///  - If this is the first draft block use the default positions.
 
 QPointF MainWindow::draftBlockStartPosition() const
 {
@@ -450,22 +450,22 @@ QPointF MainWindow::draftBlockStartPosition() const
 }
 
 
-//  @brief initializeScenes Initialize scenes.
-//
-//  This method initializes the draft and piece mode graphics scenes.
-//
-//  @details
-//  - Create the draft mode scene and set it as the current scene.
-//  - Connects move, selection, and hover signals from MainWindow to slots in
-//    draftScene to toggle whether item is movable, selectable, or accepts hover events.
-//  - Connect mouse move events in the draft scene and display coordinates & units in status bar.
-//  - Create the piece mode scene.
-//  - Connects move, selection, and hover signals from MainWindow to slots in the
-//    piece scene to toggle whether item is movable, selectable, or accepts hover events.
-//  - Connect mouse move events in the piece scene and display coordinates & units in status bar.
-//  - Set the current scene for the view to the current scene.
-//  - Set the transforms of the draft and piece scenes to match the current view's transform.
-//  - Set the scene view in the application to the current view.
+/// @brief initializeScenes Initialize scenes.
+///
+/// This method initializes the draft and piece mode graphics scenes.
+///
+/// @details
+/// - Create the draft mode scene and set it as the current scene.
+/// - Connects move, selection, and hover signals from MainWindow to slots in
+///   draftScene to toggle whether item is movable, selectable, or accepts hover events.
+/// - Connect mouse move events in the draft scene and display coordinates & units in status bar.
+/// - Create the piece mode scene.
+/// - Connects move, selection, and hover signals from MainWindow to slots in the
+///   piece scene to toggle whether item is movable, selectable, or accepts hover events.
+/// - Connect mouse move events in the piece scene and display coordinates & units in status bar.
+/// - Set the current scene for the view to the current scene.
+/// - Set the transforms of the draft and piece scenes to match the current view's transform.
+/// - Set the scene view in the application to the current view.
 
 void MainWindow::initializeScenes()
 {
@@ -740,12 +740,12 @@ void MainWindow::checkRequiredMeasurements(const MeasurementDoc *measurements)
 }
 
 
-//  @brief SetToolButton set tool and show dialog.
-//  @param checked true if tool button checked.
-//  @param t tool type.
-//  @param cursor path tool cursor icon.
-//  @param toolTip first tooltipe.
-//  @param closeDialogSlot method to handle close of dialog.
+/// @brief SetToolButton set tool and show dialog.
+/// @param checked true if tool button checked.
+/// @param t tool type.
+/// @param cursor path tool cursor icon.
+/// @param toolTip first tooltipe.
+/// @param closeDialogSlot method to handle close of dialog.
 
 template <typename Dialog, typename Func>
 void MainWindow::SetToolButton(bool checked, Tool t, const QString &cursor, const QString &toolTip,
@@ -809,13 +809,13 @@ void MainWindow::SetToolButton(bool checked, Tool t, const QString &cursor, cons
 }
 
 
-//  @brief SetToolButtonWithApply set tool and show dialog.
-//  @param checked true if tool button checked.
-//  @param t tool type.
-//  @param cursor path tool cursor icon.
-//  @param toolTip first tooltipe.
-//  @param closeDialogSlot method to handle close of dialog.
-//  @param applyDialogSlot method to handle apply in dialog.
+/// @brief SetToolButtonWithApply set tool and show dialog.
+/// @param checked true if tool button checked.
+/// @param t tool type.
+/// @param cursor path tool cursor icon.
+/// @param toolTip first tooltipe.
+/// @param closeDialogSlot method to handle close of dialog.
+/// @param applyDialogSlot method to handle apply in dialog.
 
 template <typename Dialog, typename Func, typename Func2>
 void MainWindow::SetToolButtonWithApply(bool checked, Tool t, const QString &cursor, const QString &toolTip,
@@ -3399,15 +3399,15 @@ void MainWindow::handleImagesMenu()
 }
 
 
-// @brief mouseMove Handle mouse novement.
-//
-// This method takes the mouse postion in the scene and displays the coordinates & units in the status bar.
-//
-// @param scenePos position mouse.
-//
-// @details
-//  - If the MouseCoordinates class exists calls the updateCoordinates() method which formats and displays
-//    the mouse coordinates and units in framed labels in the status bar.
+/// @brief mouseMove Handle mouse novement.
+///
+/// This method takes the mouse postion in the scene and displays the coordinates & units in the status bar.
+///
+/// @param scenePos position mouse.
+///
+/// @details
+///  - If the MouseCoordinates class exists calls the updateCoordinates() method which formats and displays
+///    the mouse coordinates and units in framed labels in the status bar.
 void MainWindow::MouseMove(const QPointF &scenePos)
 {
     if (mouseCoordinates)
@@ -3745,6 +3745,44 @@ void MainWindow::RestoreCurrentScene()
     horScrollBar->setValue(scene->getHorScrollBar());
     QScrollBar *verScrollBar = ui->view->verticalScrollBar();
     verScrollBar->setValue(scene->getVerScrollBar());
+}
+
+//-----------------------------------------------------------------------------
+/// @brief incrementDraftBlock Switch draft block incrementally.
+///
+/// This method switches the current draft block by incrementing the combobox box current item up or down.
+///
+/// @param increment determines whether to increment up or down.
+///
+/// @details
+///  - an increent value of -1 increments down.
+///  - an increent value of +1 increments up.
+///  - incrementimg wraps at the first or last item.
+//-----------------------------------------------------------------------------
+void MainWindow::incrementDraftBlock(const int &increment)
+{
+    int index = draftBlockComboBox->currentIndex();
+    const int count = draftBlockComboBox->count();
+
+    if (index == -1 || count <= 1)
+    {
+        return;
+    }
+
+    if ((index == 0) && (increment == -1))
+    {
+        index = count - 1;
+    }
+    else if ((index == count - 1) && (increment == 1))
+    {
+        index = 0;
+    }
+    else
+    {
+        index = index + increment;
+    }
+
+    draftBlockComboBox->setCurrentIndex(index);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -4288,6 +4326,8 @@ void MainWindow::Clear()
     ui->save_Action->setEnabled(false);
     ui->saveAs_Action->setEnabled(false);
     ui->patternPreferences_Action->setEnabled(false);
+    ui->previousDraftBlock_Action->setEnabled(false);
+    ui->nextDraftBlock_Action->setEnabled(false);
 
     // disable zoom actions until a pattern is loaded
     zoomScaleSpinBox->setEnabled(false);
@@ -4589,6 +4629,8 @@ void MainWindow::setWidgetsEnabled(bool enable)
    // enable edit  menu actions
     undoAction->setEnabled(enable && designStage && qApp->getUndoStack()->canUndo());
     redoAction->setEnabled(enable && designStage && qApp->getUndoStack()->canRedo());
+    ui->previousDraftBlock_Action->setEnabled(enable && draftStage);
+    ui->nextDraftBlock_Action->setEnabled(enable && draftStage);
 
     // enable view menu actions
     ui->showDraftMode->setEnabled(enable);
@@ -5304,8 +5346,8 @@ void MainWindow::createMenus()
     undoAction->setShortcuts(undoShortcuts);
     undoAction->setIcon(QIcon::fromTheme("edit-undo"));
     connect(undoAction, &QAction::triggered, toolProperties, &VToolOptionsPropertyBrowser::refreshOptions);
-    ui->edit_Menu->addAction(undoAction);
-    ui->edit_Toolbar->addAction(undoAction);
+    ui->edit_Menu->insertAction(ui->previousDraftBlock_Action, undoAction);
+    ui->edit_Toolbar->insertAction(ui->previousDraftBlock_Action, undoAction);
 
     QList<QKeySequence> redoShortcuts;
     redoShortcuts.append(QKeySequence(Qt::ControlModifier + Qt::Key_Y));
@@ -5316,12 +5358,12 @@ void MainWindow::createMenus()
     redoAction->setShortcuts(redoShortcuts);
     redoAction->setIcon(QIcon::fromTheme("edit-redo"));
     connect(redoAction, &QAction::triggered, toolProperties, &VToolOptionsPropertyBrowser::refreshOptions);
-    ui->edit_Menu->addAction(redoAction);
-    ui->edit_Toolbar->addAction(redoAction);
+    ui->edit_Menu->insertAction(ui->previousDraftBlock_Action, redoAction);
+    ui->edit_Toolbar->insertAction(ui->previousDraftBlock_Action, redoAction);
 
     separatorAct = new QAction(this);
     separatorAct->setSeparator(true);
-    ui->edit_Menu->addAction(separatorAct);
+    ui->edit_Menu->insertAction(ui->previousDraftBlock_Action, separatorAct);
 
     AddDocks();
 
@@ -5718,6 +5760,16 @@ void MainWindow::createActions()
     connect(ui->exit_Action, &QAction::triggered, this, &MainWindow::close);
 
     //Edit Menu
+    connect(ui->previousDraftBlock_Action, &QAction::triggered, this, [this]()
+    {
+        incrementDraftBlock(-1); // previous draft block
+    });
+
+    connect(ui->nextDraftBlock_Action, &QAction::triggered, this, [this]()
+    {
+        incrementDraftBlock(1); // next draft block
+    });
+
     connect(ui->labelTemplateEditor_Action, &QAction::triggered, this, [this]()
     {
         EditLabelTemplateDialog editor(doc);

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -3779,20 +3779,13 @@ void MainWindow::changeDraftBlock(Selection selection)
     }
     else
     {
-        switch (static_cast<signed char>(selection))
+        if (selection == Selection::Prev)
         {
-            case Selection::Prev:
-            {
-                index = index - 1;
-                break;
-            }
-            case Selection::Next:
-            {
-                index = index + 1;
-                break;
-            }
-            default:
-                break;
+            --index;
+        }
+        else if (selection == Selection::Next)
+        {
+            ++index;
         }
     }
 

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -169,7 +169,6 @@ MainWindow::MainWindow(QWidget *parent)
     , fontSizeComboBox(nullptr)
     , draftBlockComboBox(nullptr)
     , draftBlockLabel(nullptr)
-    , mode(Draw::Calculation)
     , currentBlockIndex(0)
     , currentToolBoxIndex(0)
     , isToolOptionsDockVisible(true)
@@ -210,10 +209,9 @@ MainWindow::MainWindow(QWidget *parent)
         // Create instance of VPattern (a dom document) that represents the XML documnet.
         // Arguments:
         //  - pattern - is the data VContainer that is initialized in MainWindowsNoGUI.
-        //  - mode - initial mode is Draw::Calculation.
         //  - draftScene - draft mode scene.
         //  - pieceScene - piece mode scene.
-        doc = new VPattern(pattern, &mode, draftScene, pieceScene);
+        doc = new VPattern(pattern, draftScene, pieceScene);
 
         // Connect signals to slots for handling application events in the doc VPattern object.
         connect(doc, &VPattern::ClearMainWindow, this, &MainWindow::Clear);
@@ -1903,7 +1901,7 @@ void MainWindow::changeEvent(QEvent *event)
         helpLabel->setText(QObject::tr("Changes applied."));
         draftBlockLabel->setText(tr("Draft Block:"));
 
-        if (mode == Draw::Calculation)
+        if (doc->getDraftStage() == Draw::Calculation)
         {
             ui->groups_DockWidget->setWindowTitle(tr("Group Manager"));
         }
@@ -2504,7 +2502,7 @@ void MainWindow::initializeDraftToolBar()
     draftBlockComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     draftBlockComboBox->setEnabled(false);
 
-    connect(draftBlockComboBox,  static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+    connect(draftBlockComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
             this, [this](int index){changeDraftBlock(index);});
 
     connect(ui->renameDraft_Action, &QAction::triggered, this, [this]()
@@ -3715,7 +3713,7 @@ void MainWindow::keyReleaseEvent(QKeyEvent *event)
  */
 void MainWindow::SaveCurrentScene()
 {
-    if (mode == Draw::Calculation || mode == Draw::Modeling)
+    if (doc->getDraftStage() == Draw::Calculation || doc->getDraftStage() == Draw::Modeling)
     {
         VMainGraphicsScene *scene = qobject_cast<VMainGraphicsScene *>(currentScene);
         SCASSERT(scene != nullptr)
@@ -3775,7 +3773,7 @@ void MainWindow::showDraftMode(bool checked)
         ui->view->setScene(currentScene);
         RestoreCurrentScene();
 
-        mode = Draw::Calculation;
+        doc->setDraftStage(Draw::Calculation);
         draftBlockComboBox->setCurrentIndex(currentBlockIndex); //restore current draft block
         drawMode = true;
 
@@ -3858,11 +3856,11 @@ void MainWindow::showPieceMode(bool checked)
         ui->view->setScene(currentScene);
         RestoreCurrentScene();
 
-        if (mode == Draw::Calculation)
+        if (doc->getDraftStage() == Draw::Calculation)
         {
             currentToolBoxIndex = ui->piece_ToolBox->currentIndex();
         }
-        mode = Draw::Modeling;
+        doc->setDraftStage(Draw::Modeling);
         setToolsEnabled(true);
         setWidgetsEnabled(true);
 
@@ -3945,7 +3943,7 @@ void MainWindow::showLayoutMode(bool checked)
                     QMessageBox::information(this, tr("Layout mode"),  tr("You can't use Layout mode yet. Please, "
                                                                           "include at least one pattern piece in layout."),
                                              QMessageBox::Ok, QMessageBox::Ok);
-                    mode == Draw::Calculation ? showDraftMode(true) : showPieceMode(true);
+                    doc->getDraftStage() == Draw::Calculation ? showDraftMode(true) : showPieceMode(true);
                     return;
                 }
             }
@@ -3968,7 +3966,7 @@ void MainWindow::showLayoutMode(bool checked)
             QMessageBox::warning(this, tr("Layout mode"),
                                  tr("You can't use Layout mode yet.") + QLatin1String(" \n") + exception.ErrorMessage(),
                                  QMessageBox::Ok, QMessageBox::Ok);
-            mode == Draw::Calculation ? showDraftMode(true) : showPieceMode(true);
+            doc->getDraftStage() == Draw::Calculation ? showDraftMode(true) : showPieceMode(true);
             return;
         }
 
@@ -3976,11 +3974,11 @@ void MainWindow::showLayoutMode(bool checked)
         emit ui->view->itemClicked(nullptr);  // Clear Property Editor with non valid tool selection
         ui->view->setScene(currentScene);
 
-        if (mode == Draw::Calculation)
+        if (doc->getDraftStage() == Draw::Calculation)
         {
             currentToolBoxIndex = ui->layout_ToolBox->currentIndex();
         }
-        mode = Draw::Layout;
+        doc->setDraftStage(Draw::Layout);
         setToolsEnabled(true);
         setWidgetsEnabled(true);
         ui->layout_ToolBox->setCurrentIndex(ui->layout_ToolBox->indexOf(ui->layout_Page));
@@ -4465,15 +4463,15 @@ void MainWindow::fullParseFile()
     }
 
     QString draftBlock;
-    if (draftBlockComboBox->currentIndex() != -1)
+    qint32 index = draftBlockComboBox->currentIndex();
+    if (index != -1)
     {
-        draftBlock = draftBlockComboBox->itemText(draftBlockComboBox->currentIndex());
+        draftBlock = draftBlockComboBox->itemText(index);
     }
     draftBlockComboBox->blockSignals(true);
     draftBlockComboBox->clear();
 
     QStringList draftBlockNames = doc->getPatternPieces();
-    draftBlockNames.sort();
     draftBlockComboBox->addItems(draftBlockNames);
 
     if (!drawMode)
@@ -4482,7 +4480,7 @@ void MainWindow::fullParseFile()
     }
     else
     {
-        const qint32 index = draftBlockComboBox->findText(draftBlock);
+        index = draftBlockComboBox->findText(draftBlock);
         if (index != -1)
         {
             draftBlockComboBox->setCurrentIndex(index);
@@ -4575,10 +4573,10 @@ void MainWindow::setGuiEnabled(bool enabled)
  */
 void MainWindow::setWidgetsEnabled(bool enable)
 {
-    const bool draftStage = (mode == Draw::Calculation);
-    const bool pieceStage = (mode == Draw::Modeling);
+    const bool draftStage = (doc->getDraftStage() == Draw::Calculation);
+    const bool pieceStage = (doc->getDraftStage() == Draw::Modeling);
     const bool designStage = (draftStage || pieceStage);
-    const bool layoutStage = (mode == Draw::Layout);
+    const bool layoutStage = (doc->getDraftStage() == Draw::Layout);
 
     draftBlockComboBox->setEnabled(enable && draftStage);
     ui->arrow_Action->setEnabled(enable && designStage);
@@ -4879,7 +4877,7 @@ void MainWindow::setToolsEnabled(bool enable)
     bool pieceTools = false;
     bool layoutTools = false;
 
-    switch (mode)
+    switch (doc->getDraftStage())
     {
         case Draw::Calculation:
             draftTools = enable;
@@ -7144,7 +7142,8 @@ void MainWindow::changeDraftBlock(int index, bool zoomBestFit)
 {
     if (index != -1)
     {
-        doc->changeActiveDraftBlock(draftBlockComboBox->itemText(index));
+        QString name = draftBlockComboBox->itemText(index);
+        doc->changeActiveDraftBlock(name);
         doc->setCurrentData();
         emit RefreshHistory();
         if (drawMode)

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -3779,7 +3779,7 @@ void MainWindow::changeDraftBlock(Selection selection)
     }
     else
     {
-        switch (static_cast<int>(selection))
+        switch (static_cast<signed char>(selection))
         {
             case Selection::Prev:
             {

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -3755,11 +3755,11 @@ void MainWindow::RestoreCurrentScene()
 /// @param increment determines whether to increment up or down.
 ///
 /// @details
-///  - an increent value of -1 increments down.
-///  - an increent value of +1 increments up.
+///  - an increment value of DraftBlock::MovePrev changes to the previous block;
+///  - an increment value of DraftBlock::MovePrev changes to the next block.
 ///  - incrementimg wraps at the first or last item.
 //-----------------------------------------------------------------------------
-void MainWindow::incrementDraftBlock(const int &increment)
+void MainWindow::changeDraftBlock(DraftBlock increment)
 {
     int index = draftBlockComboBox->currentIndex();
     const int count = draftBlockComboBox->count();
@@ -3769,17 +3769,17 @@ void MainWindow::incrementDraftBlock(const int &increment)
         return;
     }
 
-    if ((index == 0) && (increment == -1))
+    if ((index == 0) && (increment == DraftBlock::MovePrev))
     {
         index = count - 1;
     }
-    else if ((index == count - 1) && (increment == 1))
+    else if ((index == count - 1) && (increment == DraftBlock::MoveNext))
     {
         index = 0;
     }
     else
     {
-        index = index + increment;
+        index = index + static_cast<int>(increment);
     }
 
     draftBlockComboBox->setCurrentIndex(index);
@@ -5762,12 +5762,12 @@ void MainWindow::createActions()
     //Edit Menu
     connect(ui->previousDraftBlock_Action, &QAction::triggered, this, [this]()
     {
-        incrementDraftBlock(-1); // previous draft block
+        changeDraftBlock(DraftBlock::MovePrev);
     });
 
     connect(ui->nextDraftBlock_Action, &QAction::triggered, this, [this]()
     {
-        incrementDraftBlock(1); // next draft block
+        changeDraftBlock(DraftBlock::MoveNext);  
     });
 
     connect(ui->labelTemplateEditor_Action, &QAction::triggered, this, [this]()

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -239,6 +239,8 @@ private slots:
 
     void handleNewLayout(bool checked);
 
+    void incrementDraftBlock(const int &increment);
+
     void showDraftMode(bool checked);
     void showPieceMode(bool checked);
     void showLayoutMode(bool checked);

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -239,7 +239,7 @@ private slots:
 
     void handleNewLayout(bool checked);
 
-    void changeDraftBlock(DraftBlock increment);
+    void changeDraftBlock(Selection selection);
 
     void showDraftMode(bool checked);
     void showPieceMode(bool checked);

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -319,7 +319,6 @@ private:
     QComboBox                        *basePointComboBox;
     QComboBox                        *draftBlockComboBox;  /** @brief draftBlockComboBox stores names of draft blocks.*/
     QLabel                           *draftBlockLabel;
-    Draw                              mode;                /** @brief mode stores current draw mode. */
     qint32                            currentBlockIndex;   /** @brief currentBlockIndex  current selected draft block.*/
     qint32                            currentToolBoxIndex; /** @brief currentToolBoxIndex  current set of tools. */
     bool                              isToolOptionsDockVisible;

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -239,7 +239,7 @@ private slots:
 
     void handleNewLayout(bool checked);
 
-    void incrementDraftBlock(const int &increment);
+    void changeDraftBlock(DraftBlock increment);
 
     void showDraftMode(bool checked);
     void showPieceMode(bool checked);

--- a/src/app/seamly2d/mainwindow.ui
+++ b/src/app/seamly2d/mainwindow.ui
@@ -183,6 +183,9 @@
     <property name="title">
      <string>Edit</string>
     </property>
+    <addaction name="separator"/>
+    <addaction name="previousDraftBlock_Action"/>
+    <addaction name="nextDraftBlock_Action"/>
    </widget>
    <widget class="QMenu" name="tools_Menu">
     <property name="title">
@@ -4755,6 +4758,28 @@
    </property>
    <property name="shortcut">
     <string>Alt+I</string>
+   </property>
+  </action>
+  <action name="previousDraftBlock_Action">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Previous Draft Block</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+PgUp</string>
+   </property>
+  </action>
+  <action name="nextDraftBlock_Action">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Next Draft Block</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Ctrl+PgDown</string>
    </property>
   </action>
  </widget>

--- a/src/app/seamly2d/xml/vpattern.cpp
+++ b/src/app/seamly2d/xml/vpattern.cpp
@@ -103,13 +103,12 @@ QString FileComment()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-VPattern::VPattern(VContainer *data, Draw *mode, VMainGraphicsScene *draftScene,
-                   VMainGraphicsScene *pieceScene, QObject *parent)
-    : VAbstractPattern(parent),
-      data(data),
-      mode(mode),
-      draftScene(draftScene),
-      pieceScene(pieceScene)
+VPattern::VPattern(VContainer *data, VMainGraphicsScene *draftScene, VMainGraphicsScene *pieceScene, QObject *parent)
+    : VAbstractPattern(parent)
+    , data(data)
+    , m_stage(Draw::Calculation)
+    , draftScene(draftScene)
+    , pieceScene(pieceScene)
 {
     SCASSERT(draftScene != nullptr)
     SCASSERT(pieceScene != nullptr)
@@ -156,7 +155,7 @@ void VPattern::setXMLContent(const QString &fileName)
 //---------------------------------------------------------------------------------------------------------------------
 /**
  * @brief Parse parse file.
- * @param parse parser file mode.
+ * @param parse parsing mode.
  */
 void VPattern::Parse(const Document &parse)
 {
@@ -197,7 +196,7 @@ void VPattern::Parse(const Document &parse)
                         qCDebug(vXML, "Tag draw.");
                         if (parse == Document::FullParse)
                         {
-                            if (activeDraftBlock.isEmpty())
+                            if (m_activeDraftBlock.isEmpty())
                             {
                                 setActiveDraftBlock(GetParametrString(domElement, AttrName));
                             }
@@ -264,22 +263,21 @@ void VPattern::Parse(const Document &parse)
     emit patternParsed();
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief setCurrentData set current data set.
- *
- * Each time after parsing need set correct data set for current draft block. After parsing it is always last.
- * Current data set for draft block it is data set for last object in draft block (point, arc, spline, spline path so
- * on).
- */
+//-----------------------------------------------------------------------------
+/// @brief setCurrentData set current data set.
+///
+/// Each time after parsing need set correct data set for current draft block. After parsing it is always last.
+/// Current data set for draft block it is data set for last object in draft block
+/// (point, arc, spline, spline path so on).
+//-----------------------------------------------------------------------------
 void VPattern::setCurrentData()
 {
-    if (*mode == Draw::Calculation)
+    if (m_stage == Draw::Calculation)
     {
         if (draftBlockCount() > 1)//don't need to update data if we have only one draft block
         {
             qCDebug(vXML, "Setting current data");
-            qCDebug(vXML, "Current Draft block name %s", qUtf8Printable(activeDraftBlock));
+            qCDebug(vXML, "Current Draft block name %s", qUtf8Printable(m_activeDraftBlock));
             qCDebug(vXML, "Draftf block count %d", draftBlockCount());
 
             quint32 id = 0;
@@ -291,7 +289,7 @@ void VPattern::setCurrentData()
             for (qint32 i = 0; i < history.size(); ++i)
             {
                 const VToolRecord tool = history.at(i);
-                if (tool.getDraftBlockName() == activeDraftBlock)
+                if (tool.getDraftBlockName() == m_activeDraftBlock)
                 {
                     id = tool.getId();
                 }
@@ -300,7 +298,7 @@ void VPattern::setCurrentData()
             if (id == NULL_ID)
             {
                 qCDebug(vXML, "Could not find record for this current draft block %s",
-                        qUtf8Printable(activeDraftBlock));
+                        qUtf8Printable(m_activeDraftBlock));
 
                 const VToolRecord tool = history.at(history.size()-1);
                 id = tool.getId();
@@ -380,6 +378,26 @@ quint32 VPattern::getActiveBasePoint()
         }
     }
     return 0;
+}
+
+//-----------------------------------------------------------------------------
+//  @brief getDraftStage Get draft stage.
+//
+//  This method gets the current draft stage.
+//-----------------------------------------------------------------------------
+const Draw &VPattern::getDraftStage() const
+{
+    return m_stage;
+}
+
+//-----------------------------------------------------------------------------
+//  @brief setDraftStage Set draft stage.
+//
+//  This method sets the current draft stage.
+//-----------------------------------------------------------------------------
+void VPattern::setDraftStage(const Draw &stage)
+{
+    m_stage = stage;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -516,7 +534,7 @@ void VPattern::LiteParseVariables()
 void VPattern::LiteParseTree(const Document &parse)
 {
     // Save current draft block name
-    QString draftBlockName = activeDraftBlock;
+    QString draftBlockName = m_activeDraftBlock;
 
     try
     {
@@ -611,8 +629,8 @@ void VPattern::LiteParseTree(const Document &parse)
     }
 
     // Restore name current draft block
-    activeDraftBlock = draftBlockName;
-    qCDebug(vXML, "Current draft block %s", qUtf8Printable(activeDraftBlock));
+    m_activeDraftBlock = draftBlockName;
+    qCDebug(vXML, "Current draft block %s", qUtf8Printable(m_activeDraftBlock));
     setCurrentData();
     emit FullUpdateFromFile();
     // Recalculate scene rect
@@ -680,7 +698,7 @@ VNodeDetail VPattern::parsePieceNode(const QDomElement &domElement) const
 /**
  * @brief parseDraftBlockElement parse draw tag.
  * @param node node.
- * @param parse parser file mode.
+ * @param parse parsing mode.
  */
 void VPattern::parseDraftBlockElement(const QDomNode &node, const Document &parse)
 {
@@ -698,11 +716,11 @@ void VPattern::parseDraftBlockElement(const QDomNode &node, const Document &pars
                     case 0: // TagCalculation
                         qCDebug(vXML, "Tag calculation.");
                         data->ClearCalculationGObjects();
-                        ParseDrawMode(domElement, parse, Draw::Calculation);
+                        ParseDraftStage(domElement, parse, Draw::Calculation);
                         break;
                     case 1: // TagModeling
                         qCDebug(vXML, "Tag modeling.");
-                        ParseDrawMode(domElement, parse, Draw::Modeling);
+                        ParseDraftStage(domElement, parse, Draw::Modeling);
                         break;
                     case 2: // TagPieces
                         qCDebug(vXML, "Tag pieces.");
@@ -726,19 +744,21 @@ void VPattern::parseDraftBlockElement(const QDomNode &node, const Document &pars
     }
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief ParseDrawMode parse draw tag with draw mode.
- * @param node node.
- * @param parse parser file mode.
- * @param mode draw mode.
- */
-void VPattern::ParseDrawMode(const QDomNode &node, const Document &parse, const Draw &mode)
+//-----------------------------------------------------------------------------
+/// @brief ParseDraftStage parse draw tag with drft stage.
+///
+/// This parses the calculation stage of each the draft blocks.
+///
+/// @param node node.
+/// @param parse parsing mode.
+/// @param stage drft stage.
+//-----------------------------------------------------------------------------
+void VPattern::ParseDraftStage(const QDomNode &node, const Document &parse, const Draw &stage)
 {
     SCASSERT(draftScene != nullptr)
     SCASSERT(pieceScene != nullptr)
     VMainGraphicsScene *scene = nullptr;
-    if (mode == Draw::Calculation)
+    if (stage == Draw::Calculation)
     {
         scene = draftScene;
     }
@@ -838,7 +858,7 @@ void VPattern::parseDraftImages(const QDomNode &node, const Document &parse)
 /**
  * @brief parsePieceElement parse piece tag.
  * @param domElement tag in xml tree.
- * @param parse parser file mode.
+ * @param parse parsing mode.
  */
 void VPattern::parsePieceElement(QDomElement &domElement, const Document &parse)
 {
@@ -1066,7 +1086,7 @@ void VPattern::ParsePieceGrainline(const QDomElement &domElement, VPiece &piece)
 /**
  * @brief parsePatternPieces parse pieces tag.
  * @param domElement tag in xml tree.
- * @param parse parser file mode.
+ * @param parse parsing mode.
  */
 void VPattern::parsePatternPieces(const QDomElement &domElement, const Document &parse)
 {
@@ -1130,7 +1150,7 @@ void VPattern::PointsCommonAttributes(const QDomElement &domElement, quint32 &id
  * @brief ParsePointElement parse point tag.
  * @param scene scene.
  * @param domElement tag in xml tree.
- * @param parse parser file mode.
+ * @param parse parsing mode.
  * @param type type of point.
  */
 void VPattern::ParsePointElement(VMainGraphicsScene *scene, QDomElement &domElement,
@@ -1249,7 +1269,7 @@ void VPattern::ParsePointElement(VMainGraphicsScene *scene, QDomElement &domElem
  * @brief ParseLineElement parse line tag.
  * @param scene scene.
  * @param domElement tag in xml tree.
- * @param parse parser file mode.
+ * @param parse parsing mode.
  */
 void VPattern::ParseLineElement(VMainGraphicsScene *scene, const QDomElement &domElement,
                                 const Document &parse)
@@ -1391,7 +1411,7 @@ void VPattern::ParseToolBasePoint(VMainGraphicsScene *scene, const QDomElement &
 
         VPointF *point = new VPointF(x, y, name, mx, my);
         point->setShowPointName(showPointName);
-        spoint = VToolBasePoint::Create(id, activeDraftBlock, point, scene, this, data, parse, Source::FromFile);
+        spoint = VToolBasePoint::Create(id, m_activeDraftBlock, point, scene, this, data, parse, Source::FromFile);
     }
     catch (const VExceptionBadId &error)
     {
@@ -3288,7 +3308,7 @@ void VPattern::GarbageCollector()
  * @brief ParseSplineElement parse spline tag.
  * @param scene scene.
  * @param domElement tag in xml tree.
- * @param parse parser file mode.
+ * @param parse parsing mode.
  * @param type type of spline.
  */
 void VPattern::ParseSplineElement(VMainGraphicsScene *scene, QDomElement &domElement,
@@ -3351,7 +3371,7 @@ void VPattern::ParseSplineElement(VMainGraphicsScene *scene, QDomElement &domEle
  * @brief ParseArcElement parse arc tag.
  * @param scene scene.
  * @param domElement tag in xml tree.
- * @param parse parser file mode.
+ * @param parse parsing mode.
  * @param type type of spline.
  */
 void VPattern::ParseArcElement(VMainGraphicsScene *scene, QDomElement &domElement, const Document &parse,
@@ -3387,7 +3407,7 @@ void VPattern::ParseArcElement(VMainGraphicsScene *scene, QDomElement &domElemen
  * @brief ParseEllipticalArcElement parse elliptical arc tag.
  * @param scene scene.
  * @param domElement tag in xml tree.
- * @param parse parser file mode.
+ * @param parse parsing mode.
  * @param type type of spline.
  */
 void VPattern::ParseEllipticalArcElement(VMainGraphicsScene *scene, QDomElement &domElement, const Document &parse,
@@ -3419,7 +3439,7 @@ void VPattern::ParseEllipticalArcElement(VMainGraphicsScene *scene, QDomElement 
  * @brief ParseToolsElement parse tools tag.
  * @param scene scene.
  * @param domElement tag in xml tree.
- * @param parse parser file mode.
+ * @param parse parsing mode.
  * @param type type of spline.
  */
 void VPattern::ParseToolsElement(VMainGraphicsScene *scene, const QDomElement &domElement,
@@ -3551,7 +3571,7 @@ void VPattern::parseVariablesElement(const QDomNode &node)
             {
                 if (domElement.tagName() == TagVariable)
                 {
-                    const QString name = GetParametrString(domElement, VariableName, "");
+                    const QString name = GetParametrString(domElement, VariableName, QString()).simplified();
 
                     QString desc;
                     try
@@ -4043,7 +4063,7 @@ void VPattern::PrepareForParse(const Document &parse)
         pieceScene->clear();
         pieceScene->initializeOrigins();
         data->ClearForFullParse();
-        activeDraftBlock.clear();
+        m_activeDraftBlock.clear();
         patternPieces.clear();
         clearBackgroundImageMap();
 
@@ -4087,7 +4107,7 @@ QRectF VPattern::ActiveDrawBoundingRect() const
     for (qint32 i = 0; i< history.size(); ++i)
     {
         const VToolRecord tool = history.at(i);
-        if (tool.getDraftBlockName() == activeDraftBlock)
+        if (tool.getDraftBlockName() == m_activeDraftBlock)
         {
             switch ( tool.getTypeTool() )
             {
@@ -4149,7 +4169,7 @@ QRectF VPattern::ActiveDrawBoundingRect() const
                 case Tool::Move:
                     rect = ToolBoundingRect<VAbstractOperation>(rect, tool.getId());
                     break;
-                //These tools are not accesseble in Draw mode, but still 'history' contains them.
+                //These tools are not accesseble in Draft mode, but 'history' still contains them.
                 case Tool::Piece:
                 case Tool::Union:
                 case Tool::NodeArc:

--- a/src/app/seamly2d/xml/vpattern.h
+++ b/src/app/seamly2d/xml/vpattern.h
@@ -31,7 +31,7 @@
  **  @brief
  **  @copyright
  **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
+ **  program, whose allow create and stageling patterns of clothing.
  **  Copyright (C) 2013-2015 Valentina project
  **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
  **
@@ -68,7 +68,7 @@ class VPattern : public VAbstractPattern
 {
     Q_OBJECT
 public:
-    VPattern(VContainer *data, Draw *mode, VMainGraphicsScene *draftScene, VMainGraphicsScene *pieceScene,
+    VPattern(VContainer *data, VMainGraphicsScene *draftScene, VMainGraphicsScene *pieceScene,
              QObject *parent = nullptr);
 
     virtual void   CreateEmptyFile() Q_DECL_OVERRIDE;
@@ -82,6 +82,9 @@ public:
     virtual void   DecrementReferens(quint32 id) const Q_DECL_OVERRIDE;
 
     quint32        getActiveBasePoint();
+
+    const Draw     &getDraftStage() const;
+    void           setDraftStage(const Draw &stage);
 
     QVector<quint32> getActivePatternPieces() const;
 
@@ -135,15 +138,15 @@ protected:
 private:
     Q_DISABLE_COPY(VPattern)
 
-    VContainer         *data;        /** @brief data container with data. */
-    Draw               *mode;        /** @brief mode current draw mode. */
+    VContainer         *data;        /** @brief container with data. */
+    Draw                m_stage;     /** @brief current draft stage. */
     VMainGraphicsScene *draftScene;
     VMainGraphicsScene *pieceScene;
 
     VNodeDetail    parsePieceNode(const QDomElement &domElement) const;
 
     void           parseDraftBlockElement(const QDomNode &node, const Document &parse);
-    void           ParseDrawMode(const QDomNode &node, const Document &parse, const Draw &mode);
+    void           ParseDraftStage(const QDomNode &node, const Document &parse, const Draw &stage);
     void           parseDraftImages(const QDomNode &node, const Document &parse);
     void           parseImageElement(QDomElement &domElement, const Document &parse);
     void           parsePieceElement(QDomElement &domElement, const Document &parse);

--- a/src/libs/ifc/xml/vabstractpattern.cpp
+++ b/src/libs/ifc/xml/vabstractpattern.cpp
@@ -284,7 +284,7 @@ void ReadExpressionAttribute(QVector<VFormulaField> &expressions, const QDomElem
 VAbstractPattern::VAbstractPattern(QObject *parent)
     : QObject(parent)
     , VDomDocument()
-    , activeDraftBlock(QString())
+    , m_activeDraftBlock(QString())
     , m_DefaultLineColor(qApp->Settings()->getDefaultLineColor())
     , m_DefaultLineWeight(qApp->Settings()->getDefaultLineWeight())
     , m_DefaultLineType(qApp->Settings()->getDefaultLineType())
@@ -357,10 +357,10 @@ QStringList VAbstractPattern::ListMeasurements() const
  */
 void VAbstractPattern::changeActiveDraftBlock(const QString &name, const Document &parse)
 {
-    Q_ASSERT_X(not name.isEmpty(), Q_FUNC_INFO, "name draft block is empty");
-    if (draftBlockNameExists(name))
+    Q_ASSERT_X(!name.isEmpty(), Q_FUNC_INFO, "name draft block is empty");
+    if (draftBlockNameExists(name) && m_activeDraftBlock != name)
     {
-        this->activeDraftBlock = name;
+        m_activeDraftBlock = name;
         if (parse == Document::FullParse)
         {
             emit activeDraftBlockChanged(name);
@@ -375,7 +375,7 @@ void VAbstractPattern::changeActiveDraftBlock(const QString &name, const Documen
  */
 QString VAbstractPattern::getActiveDraftBlockName() const
 {
-    return activeDraftBlock;
+    return m_activeDraftBlock;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -386,7 +386,7 @@ QString VAbstractPattern::getActiveDraftBlockName() const
  */
 bool VAbstractPattern::getActiveDraftElement(QDomElement &element) const
 {
-    if (activeDraftBlock.isEmpty() == false)
+    if (m_activeDraftBlock.isEmpty() == false)
     {
         const QDomNodeList elements = this->documentElement().elementsByTagName(TagDraftBlock);
         if (elements.size() == 0)
@@ -399,7 +399,7 @@ bool VAbstractPattern::getActiveDraftElement(QDomElement &element) const
             if (element.isNull() == false)
             {
                 const QString fieldName = element.attribute( AttrName );
-                if ( fieldName == activeDraftBlock )
+                if ( fieldName == m_activeDraftBlock )
                 {
                     return true;
                 }
@@ -418,7 +418,7 @@ bool VAbstractPattern::getActiveDraftElement(QDomElement &element) const
  */
 bool VAbstractPattern::draftBlockNameExists(const QString &name) const
 {
-    Q_ASSERT_X(not name.isEmpty(), Q_FUNC_INFO, "draft block name is empty");
+    Q_ASSERT_X(!name.isEmpty(), Q_FUNC_INFO, "draft block name is empty");
     const QDomNodeList elements = this->documentElement().elementsByTagName(TagDraftBlock);
     if (elements.size() == 0)
     {
@@ -447,7 +447,7 @@ bool VAbstractPattern::draftBlockNameExists(const QString &name) const
  */
 bool VAbstractPattern::getActiveNodeElement(const QString &name, QDomElement &element) const
 {
-    Q_ASSERT_X(not name.isEmpty(), Q_FUNC_INFO, "draft block name is empty");
+    Q_ASSERT_X(!name.isEmpty(), Q_FUNC_INFO, "draft block name is empty");
     QDomElement draftBlockElement;
     if (getActiveDraftElement(draftBlockElement))
     {
@@ -472,7 +472,7 @@ bool VAbstractPattern::getActiveNodeElement(const QString &name, QDomElement &el
 //---------------------------------------------------------------------------------------------------------------------
 void VAbstractPattern::parseGroups(const QDomElement &domElement)
 {
-    Q_ASSERT_X(not domElement.isNull(), Q_FUNC_INFO, "domElement is null");
+    Q_ASSERT_X(!domElement.isNull(), Q_FUNC_INFO, "domElement is null");
 
     QMap<quint32, quint32> itemTool;
     QMap<quint32, bool> itemVisibility;
@@ -494,7 +494,7 @@ void VAbstractPattern::parseGroups(const QDomElement &domElement)
                     auto i = group.constBegin();
                     while (i != group.constEnd())
                     {
-                        if (not itemTool.contains(i.key()))
+                        if (!itemTool.contains(i.key()))
                         {
                             itemTool.insert(i.key(), i.value());
                         }
@@ -585,9 +585,9 @@ bool VAbstractPattern::renameDraftBlock(const QString &oldName, const QString &n
     QDomElement ppElement = getDraftBlockElement(oldName);
     if (ppElement.isElement())
     {
-        if (activeDraftBlock == oldName)
+        if (m_activeDraftBlock == oldName)
         {
-            activeDraftBlock = newName;
+            m_activeDraftBlock = newName;
         }
         ppElement.setAttribute(AttrName, newName);
         emit patternChanged(false);//For situation when we change name directly, without undocommands.
@@ -612,7 +612,7 @@ bool VAbstractPattern::renameDraftBlock(const QString &oldName, const QString &n
  */
 bool VAbstractPattern::appendDraftBlock(const QString &name)
 {
-    Q_ASSERT_X(not name.isEmpty(), Q_FUNC_INFO, "name draft block is empty");
+    Q_ASSERT_X(!name.isEmpty(), Q_FUNC_INFO, "name draft block is empty");
     if (name.isEmpty())
     {
         return false;
@@ -713,7 +713,7 @@ VPiecePath VAbstractPattern::ParsePieceNodes(const QDomElement &domElement)
     for (qint32 i = 0; i < nodeList.size(); ++i)
     {
         const QDomElement element = nodeList.at(i).toElement();
-        if (not element.isNull())
+        if (!element.isNull())
         {
             path.Append(ParseSANode(element));
         }
@@ -729,7 +729,7 @@ QVector<CustomSARecord> VAbstractPattern::ParsePieceCSARecords(const QDomElement
     for (qint32 i = 0; i < nodeList.size(); ++i)
     {
         const QDomElement element = nodeList.at(i).toElement();
-        if (not element.isNull())
+        if (!element.isNull())
         {
             CustomSARecord record;
             record.startPoint = GetParametrUInt(element, VAbstractPattern::AttrStart, NULL_ID_STR);
@@ -753,7 +753,7 @@ QVector<quint32> VAbstractPattern::ParsePieceInternalPaths(const QDomElement &do
     for (qint32 i = 0; i < nodeList.size(); ++i)
     {
         const QDomElement element = nodeList.at(i).toElement();
-        if (not element.isNull())
+        if (!element.isNull())
         {
             const quint32 path = GetParametrUInt(element, VAbstractPattern::AttrPath, NULL_ID_STR);
             if (path > NULL_ID)
@@ -773,7 +773,7 @@ QVector<quint32> VAbstractPattern::ParsePieceAnchors(const QDomElement &domEleme
     for (qint32 i = 0; i < nodeList.size(); ++i)
     {
         const QDomElement element = nodeList.at(i).toElement();
-        if (not element.isNull())
+        if (!element.isNull())
         {
             const quint32 path = element.text().toUInt();
             if (path > NULL_ID)
@@ -1716,7 +1716,7 @@ VPiecePath VAbstractPattern::ParsePathNodes(const QDomElement &domElement)
     for (qint32 i = 0; i < nodeList.size(); ++i)
     {
         const QDomElement element = nodeList.at(i).toElement();
-        if (not element.isNull() && element.tagName() == VAbstractPattern::TagNode)
+        if (!element.isNull() && element.tagName() == VAbstractPattern::TagNode)
         {
             path.Append(ParseSANode(element));
         }
@@ -1731,8 +1731,8 @@ VPiecePath VAbstractPattern::ParsePathNodes(const QDomElement &domElement)
  */
 void VAbstractPattern::setActiveDraftBlock(const QString &name)
 {
-    Q_ASSERT_X(not name.isEmpty(), Q_FUNC_INFO, "name draft block is empty");
-    this->activeDraftBlock = name;
+    Q_ASSERT_X(!name.isEmpty(), Q_FUNC_INFO, "name draft block is empty");
+    m_activeDraftBlock = name;
     emit activeDraftBlockChanged(name);
 }
 
@@ -1805,7 +1805,7 @@ void VAbstractPattern::InsertTag(const QStringList &tags, const QDomElement &ele
     for (int i = tags.indexOf(element.tagName())-1; i >= 0; --i)
     {
         const QDomNodeList list = elementsByTagName(tags.at(i));
-        if (not list.isEmpty())
+        if (!list.isEmpty())
         {
             pattern.insertAfter(element, list.at(0));
             break;
@@ -1820,12 +1820,12 @@ int VAbstractPattern::getActiveDraftBlockIndex() const
     const QDomNodeList blockList = elementsByTagName(TagDraftBlock);
 
     int index = 0;
-    if (not blockList.isEmpty())
+    if (!blockList.isEmpty())
     {
         for (int i = 0; i < blockList.size(); ++i)
         {
             QDomElement node = blockList.at(i).toElement();
-            if (node.attribute(AttrName) == activeDraftBlock)
+            if (node.attribute(AttrName) == m_activeDraftBlock)
             {
                 index = i;
                 break;
@@ -2035,7 +2035,7 @@ QVector<VFormulaField> VAbstractPattern::ListNodesExpressions(const QDomElement 
     for (qint32 i = 0; i < nodeList.size(); ++i)
     {
         const QDomElement element = nodeList.at(i).toElement();
-        if (not element.isNull() && element.tagName() == VAbstractPattern::TagNode)
+        if (!element.isNull() && element.tagName() == VAbstractPattern::TagNode)
         {
             ReadExpressionAttribute(expressions, element, VAbstractPattern::AttrSABefore);
             ReadExpressionAttribute(expressions, element, VAbstractPattern::AttrSAAfter);
@@ -2072,7 +2072,7 @@ QVector<VFormulaField> VAbstractPattern::ListPathExpressions() const
 QVector<VFormulaField> VAbstractPattern::ListGrainlineExpressions(const QDomElement &element) const
 {
     QVector<VFormulaField> expressions;
-    if (not element.isNull())
+    if (!element.isNull())
     {
         // Each tag can contains several attributes.
         ReadExpressionAttribute(expressions, element, AttrRotation);
@@ -2162,7 +2162,7 @@ bool VAbstractPattern::IsFunction(const QString &token) const
 //---------------------------------------------------------------------------------------------------------------------
 QPair<bool, QMap<quint32, quint32> > VAbstractPattern::parseItemElement(const QDomElement &domElement)
 {
-    Q_ASSERT_X(not domElement.isNull(), Q_FUNC_INFO, "domElement is null");
+    Q_ASSERT_X(!domElement.isNull(), Q_FUNC_INFO, "domElement is null");
 
     try
     {
@@ -2175,7 +2175,7 @@ QPair<bool, QMap<quint32, quint32> > VAbstractPattern::parseItemElement(const QD
         for (qint32 i = 0; i < num; ++i)
         {
             const QDomElement element = nodeList.at(i).toElement();
-            if (not element.isNull() && element.tagName() == TagGroupItem)
+            if (!element.isNull() && element.tagName() == TagGroupItem)
             {
                 const quint32 object = GetParametrUInt(element, AttrObject, NULL_ID_STR);
                 const quint32 tool = GetParametrUInt(element, AttrTool, NULL_ID_STR);
@@ -2328,7 +2328,7 @@ QString VAbstractPattern::getGroupName(quint32 id)
 {
     QString name = tr("New group");
     QDomElement groups = createGroups();
-    if (not groups.isNull())
+    if (!groups.isNull())
     {
         QDomElement group = elementById(id, TagGroup);
         if (group.isElement())
@@ -2359,7 +2359,7 @@ QString VAbstractPattern::getGroupName(quint32 id)
 void VAbstractPattern::setGroupName(quint32 id, const QString &name)
 {
     QDomElement groups = createGroups();
-    if (not groups.isNull())
+    if (!groups.isNull())
     {
         QDomElement group = elementById(id, TagGroup);
         if (group.isElement())
@@ -2394,7 +2394,7 @@ QMap<quint32, GroupAttributes> VAbstractPattern::getGroups()
     try
     {
         QDomElement groups = createGroups();
-        if (not groups.isNull())
+        if (!groups.isNull())
         {
             QDomNode domNode = groups.firstChild();
             while (domNode.isNull() == false)
@@ -2456,7 +2456,7 @@ QStringList VAbstractPattern::groupListByName()
     try
     {
         QDomElement groups = createGroups();
-        if (not groups.isNull())
+        if (!groups.isNull())
         {
             QDomNode domNode = groups.firstChild();
             if (domNode.isNull() == false)
@@ -2504,7 +2504,7 @@ QDomElement VAbstractPattern::getGroupByName(const QString &name)
 {
 
     QDomElement groups = createGroups();
-    if (not groups.isNull())
+    if (!groups.isNull())
     {
         QDomNode domNode = groups.firstChild();
         if (domNode.isNull() == false)
@@ -2548,7 +2548,7 @@ quint32 VAbstractPattern::getGroupIdByName(const QString &name)
 {
 
     QDomElement groups = createGroups();
-    if (not groups.isNull())
+    if (!groups.isNull())
     {
         QDomNode domNode = groups.firstChild();
         if (domNode.isNull() == false)
@@ -2600,7 +2600,7 @@ QMap<quint32, QString> VAbstractPattern::getGroupsContainingItem(quint32 toolId,
     }
 
     QDomElement groups = createGroups();
-    if (not groups.isNull())
+    if (!groups.isNull())
     {
         QDomNode domNode = groups.firstChild();
         while (domNode.isNull() == false) // iterate through the groups
@@ -2613,7 +2613,7 @@ QMap<quint32, QString> VAbstractPattern::getGroupsContainingItem(quint32 toolId,
                     if (group.tagName() == TagGroup)
                     {
                         bool groupHasItem = hasGroupItem(group, toolId, objectId);
-                        if((containsItem && groupHasItem) || (not containsItem && not groupHasItem))
+                        if((containsItem && groupHasItem) || (!containsItem && not groupHasItem))
                         {
                             const quint32 groupId = GetParametrUInt(group, AttrId, "0");
                             const QString name = GetParametrString(group, AttrName, tr("New group"));
@@ -2723,7 +2723,7 @@ void VAbstractPattern::addToolToGroup(quint32 toolId, quint32 objectId, const QS
             emit patternChanged(false);
             emit updateGroups();
             QDomElement groups = createGroups();
-            if (not groups.isNull())
+            if (!groups.isNull())
             {
                 parseGroups(groups);
             }
@@ -2769,7 +2769,7 @@ QDomElement VAbstractPattern::addGroupItem(quint32 toolId, quint32 objectId, qui
         emit updateGroups();
 
         QDomElement groups = createGroups();
-        if (not groups.isNull())
+        if (!groups.isNull())
         {
             parseGroups(groups);
         }
@@ -2832,7 +2832,7 @@ QDomElement VAbstractPattern::removeGroupItem(quint32 toolId, quint32 objectId, 
 
                         // parse the groups to update the drawing, in case the item was removed from an invisible group
                         QDomElement groups = createGroups();
-                        if (not groups.isNull())
+                        if (!groups.isNull())
                         {
                             parseGroups(groups);
                         }
@@ -2899,7 +2899,7 @@ void VAbstractPattern::setGroupVisibility(quint32 id, bool visible)
         emit patternChanged(false);
 
         QDomElement groups = createGroups();
-        if (not groups.isNull())
+        if (!groups.isNull())
         {
             parseGroups(groups);
         }
@@ -2944,7 +2944,7 @@ void VAbstractPattern::setGroupLock(quint32 id, bool locked)
         //qDebug("VAbstractPattern::setGroupLock - Group %u is locked.", id);
 
         QDomElement groups = createGroups();
-        if (not groups.isNull())
+        if (!groups.isNull())
         {
             parseGroups(groups);
         }

--- a/src/libs/ifc/xml/vabstractpattern.h
+++ b/src/libs/ifc/xml/vabstractpattern.h
@@ -503,7 +503,7 @@ public slots:
 
 protected:
     /** @brief activeBlockName name current pattern peace. */
-    QString        activeDraftBlock;
+    QString        m_activeDraftBlock;
 
     QString        m_DefaultLineColor;
     qreal          m_DefaultLineWeight;

--- a/src/libs/vmisc/def.h
+++ b/src/libs/vmisc/def.h
@@ -62,7 +62,7 @@ class QGraphicsItem;
 
 #define HANDLE_SIZE 12
 
-enum DraftBlock : signed char {MovePrev = -1, MoveNext = 1};
+enum class Selection : signed char {Prev = -1, Next = 1};
 
 // Bit flags to identify parent dialog type for the Edit Formula dialog and which tabs to hide
 enum DialogSource : quint16

--- a/src/libs/vmisc/def.h
+++ b/src/libs/vmisc/def.h
@@ -62,6 +62,8 @@ class QGraphicsItem;
 
 #define HANDLE_SIZE 12
 
+enum DraftBlock : signed char {MovePrev = -1, MoveNext = 1};
+
 // Bit flags to identify parent dialog type for the Edit Formula dialog and which tabs to hide
 enum DialogSource : quint16
 {


### PR DESCRIPTION
The resolves issue #1251. 

1.  Patterns now open on the first draft block.
2.  Application no longer throws Unknown Id warnings  after making changes in Piece mode.
3.  Application no longer crashes when opening History after making changes in Piece mode.
4.  Added menu actions to select Previous / Next Draft Block with Ctrl + PgUp / Ctrl + PgDown keyboard shortcuts.
5. 
![image](https://github.com/user-attachments/assets/58e6c2ed-236c-46fe-8818-c839208c7e59)

5) Updated Keyboard shortcuts Dialog.
![image](https://github.com/user-attachments/assets/8c902f67-77ae-43fd-bc31-6cb1e171d7f4)

6 Updated language translations. 

Closes issue #1251