### PR TITLE
Feature: Enhance node point context menu

### DIFF
--- a/share/translations/measurements_cs_CZ.ts
+++ b/share/translations/measurements_cs_CZ.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>výška</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>délka_ruky</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>šířka_chodidla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>délka_chodidla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>délka_ramene</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>od_bradavky_k_bradavce</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>délka_rozkroku</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>

--- a/share/translations/measurements_de_DE.ts
+++ b/share/translations/measurements_de_DE.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Total</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung vom Scheitel zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_halswirbel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Nacken hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung vom Halswirbel zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_schulterblatt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Schulterblatt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessumg vom Schulterblatt zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_achsel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Achse</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung von der Achsel zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_seitliche_taillie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Seitliche Taillie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung der Tallie bis zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_hüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Hüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung vom Hüfte zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_gesäß</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Gesäß</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung vom Gesäß, bei dem die Po-Muskeln die Schenkel berühren, bis zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_knie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Knie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung von der Kniekehle bis zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_wade</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Wade</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung vom dicksten Punkt der Wade zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_knöchel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Knöchel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung vom tiefsten Einschnitt des Sprunggelenks bis zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_spunggelenk</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Sprunggelenk</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung von der Stelle an der das Vorderbein den Fuß berührt bis zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_hohehüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Hohe Hüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_vordere_taillie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: vordere Taillie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung von der vorderen Taillie zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_brustpunkt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Brustpunkt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikaler Abstand vom Brustpunkt bis zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_schulterspitze</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Schulterspitze</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung von der Schulterspitze zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_hals_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Hals vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung von der vorderseite des Halses zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_halsseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Halsseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung von der Halsseiten zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_halswirbel_zu_den_knien</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Halswirbel zu den Knien</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung vom Halswirbel (cervicale vertebra) zur Kniekehle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_seitliche_taillie_zu_den_knien</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Seitliche Taillie zu den Knien</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung von der seitlichen Taillie zu der Kniekehle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_seitliche_taillie_zu_der_hüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: seitliche Taillie zu der Hüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung von der seitlichen Taillie zum Hüftgelenk</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_knie_zu_der_achsel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Knie zu der Achsel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung von der Kniekehle zu dem Punkt an dem sich das Vorderbein und der Fuß treffen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_halswirbel_zu_der_seitlichen_taillie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Halswirbel zu der seitlichen Taillie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung vom Halswirbel zu der seitlichen Taillie. (&apos;Höhe Halswirbel&apos; - &apos;Höhe: seitliche Taillie&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>höhe_taille_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Höhe: Taille hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>breite_schulter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Breite: Schulter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale Abmessung von Schulterspitze zu Schulterspitze</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>breite_brust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Breite: Brust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale Abmessung von der Brustseite zur Brustseite.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>breite_taillie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Breite: Taillie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale Abmessung von der einen Seite der Taillie zur anderen Seite.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>breite_hüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Breite: Hüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale Abmessung von der einen Seite der Hüfte zur anderen Seite.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>breite_bauch_zu_der_hüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Breite: Bauch zu der Hüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontaler Abstand von der stärksten Stelle des vorderen Bauches bis zur stärksten Stelle des größten Hüftumfanges.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vertiefung_genick</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Vertiefung: Nacken hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontalen Abstand von Schulterblatt (Ansatzpunkt) bis zum Halswirbel.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vertiefung_taille_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Vertiefung: Taille hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale Abstand zwischen einer flachen Linie senkrecht aufgestellt, um Ferse und tiefste Einbuchtung am Knöchel.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Vertiefung_knöchel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Vertiefung: Knöchel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation>Abstand zwischen der Fersen-Lotlinie und der tiefsten Stelle auf Knöchelhöhe hinten.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Handfläche_länge</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Länge der Handfläche</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Länge vom Handgelenk bis zum Ansatz des Mittelfingers.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_länge</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Länge</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Länge vom Handgelenk bis zum Ende des Mittelfingers. </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>handfläche_weite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation>Weite: Handfläche</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Messen des größten Handflächenumfanges.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Handfläche_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Handflächenumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Umfang, an der die Handfläche am stärksten ist.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation>Finger zusammenhalten und um kleinen Finger und Daumen messen. Umfang an der stärksten Stelle nehmen..</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>fuss_breite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Fuss: Breite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>An der stärksten Stelle des Fusses messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>fuss_länge</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Fuss: Länge</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation>Messen Sie von der Ferse bis zum Ende der längsten Zehe.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>fuss_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Fuss: Umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Umfang am breitesten Teil des Fußes messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>fuss_spannumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Fuß: Spannumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation>Am höchsten Teil der Spanns messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kopf_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Kopf: Umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Messen der stärksten Stelle des Kopfumfanges.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kopf_länge</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Kopf: Länge</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung vom Scheitel zur Unterseite des Kiefers.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kopf_tiefe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation>Kopf: Tiefe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontalen Abstand vor der Stirn zum Hinterkopf.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kopf_breite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Kopf: Breite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale Abstand von Schläfe zu Schläfe , wo der Kopf am breitesten ist.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kopf_scheitel_bis_zum_hinteren_halsansatz</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Kopf: Scheitel bis zum hinteren Halsansatz</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung vom Scheitel bis zum hinteren Halsansatz (&apos;Höhe: Gesamt&apos; - &apos;Höhe: hinterer Halsansatz&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kopf_kinn_zum_hinteren_halsansatz</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Kopf: Kinn zum hinteren Halsansatz</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikale Abmessung vom Kinn zum hinteren Halsansatz. (&apos;Höhe&apos; . &apos;Höhe hinterer Halsansatz&apos; - &apos;Kopf: Länge&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Halsumfang_Mitteilteil</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation>Halsumfang, in der Mitte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation>Halsumfang, auf halbem Weg zwischen Kiefer und Oberkörper.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>halsumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Halsumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Halsumfang am Halsansatz, berührend den Hals hinten, Halsseiten und vorderen Halsansatz.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hohebrust_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hoher Brustumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation>Oberbrustumfang, kürzeste Strecke über die Brüste gemessen unter den Achseln entlang.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brust_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Brustumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Brustumfang, parallel zum Boden gemessen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>unterbrust_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Unterbrust Umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Unterbrustumfang, unter den Brüsten, parallel zum Boden gemessen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umfang_rippen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Umfang der Rippen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Umfang der Rippen auf der Ebene der untersten Rippe an der Seite, parallel zum Boden gemessen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Taillenumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation>Umfang der Taille, folgen der natürlichen Form. Taillen sind in der Regel auf der Rückseite höher</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hohehüfte_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Umfang hohe Hüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Umfang der hohen Höfte , Stelle des stärksten Bauchumfanges, parallel zum Boden gemessen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hüfte_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hüftumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Stärkste Stelle des Hüftumfanges, parallel zum Boden gemessen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Hals_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Halsumfang vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von Halsseite zur Halsseite über den vorderen Halsansatz.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Oberbrustumfang_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Oberbrustumfang vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Oberbrustumfang von Seite  (Achselhöhle) zu Seite (Achselhöhle), gemessen über die Brüste.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Brustumfang_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Brustumfang vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Von Brustseite zu Brustseite über die Brüste gemessen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Unterbrustumfang_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Unterbrustumfang_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von Unterbrustseite bis Unterbrustseite über die Vorderseite.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Rippenumfang_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Rippenumfang vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von Rippenseite zur Rippenseite, gemessen über die Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taillenumfang_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Taillenumfang vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von Taillenseite zu Taillenseite über die Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hohe_hüfte_umfang_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Umfang hohe Hüfte vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von hohe Hüfte Seite zu hohe Hüfte Seite über die Front gemessen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hüftumfang_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Hüftumfang vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Hüftumfang vorne von Seite zu Seite gemessen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>halsumfang_vorne_hälfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte des vorderen Halsumfanges</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte des vorderen Halsumfanges. (&apos;Halsumfang vorne&apos;/2&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoher_brustumfang_vorne_hälfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte des vorderen Brustumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte des vorderen Brustumfanges. Von Seite zu Seite über die Brüste gemessen. (&apos;Hoher Brustumfang vorne&apos;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brustumfang_vorne_hälfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte des vorderen Brustumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte des vorderen Brustumfang. (&apos;Brustumfang vorne&apos;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>unterbrustumfang_vorne_hälfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte Unterbrustumfang, vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte des vorderen Unterbrustumfanges. (&apos;Vorderer Unterbrustumfang&apos;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rippenumfang_vorne_hälfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte Rippenumfang vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte des vorderen Rippenumfang. (&apos;Rippenumfang vorne&apos;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taillenumfang_vorne_hälfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte Taillenumfang vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte des vorderen Taillenumfang. (&apos;Taillenumfang vorne&apos;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hohehüfte_vorne_hälfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte Umfang der hohen Hüfte vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte des vorderen hohen Hüfte. (&apos;Umfang hohe Hüfte, vorne&apos;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hüftumfang_vorne_hälfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte des vorderen Hüftumfanges</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Hälfte von &apos;Hüftumfang vorne&apos;. (&apos;Hüftumfang vorne&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>halsumfang_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte des hinteren Halsumfanges</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von Halsseite zur anderen Halsseite über den Rücken gemessen(&apos;Halsumfang&apos;-&apos;Halsumfang vorne&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoherbrustumfang_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Hoher Brustumfang hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte des hinteren Brustumfanges. Von Seite zu Seite über den Rücken gemessen. (&apos;Hoher Brustumfang vorne&apos;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brustumfang_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Brustumfang, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von Brustseite zu Brustseite über den Rücken gemessen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>unterbrustumfang_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Unterbrustumfang, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von Unterbrustseite bis Unterbrustseite über den Rücken.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rippenumfang_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Rippenumfang, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von Rippenseite zur Rippenseite, gemessen über den Rücken.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taillenumfang_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Taillenumfang, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von Taillenseite zu Taillenseite über den Rücken. (&apos;Taillenumfang&apos; - &apos;Taillenumfang, vorne&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hohehüfte_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Hohe Hüfte, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von hohe Hüfte Seite zu hohe Hüfte Seite über den Rücken gemessen. (&apos;Hohe Hüfte Umfang&apos; - &apos;Hohe Hüfte Umfang, vorne&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hüftumfang_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Hüftumfang, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von Hüftseite zu Hüfteseite über die Rückseite. (&apos;Hüftumfang&apos; - &apos;Hüftumfang vorne&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hälfte_hinterer_halsumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte des hinteren Halsumfanges</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte des hinteren Halsumfanges. (&apos;Halsumfang hinten&apos;/2&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brustumfang_hälfte_rücken</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte des hinteren Brustumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte des hinteren Brustumfanges. Von Seite zu Seite über den Rücken gemessen. (&apos;Hoher Brustumfang hinten&apos;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brustumfang_hälfte_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte des hinterer Brustumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte &apos;Brustumfang hinten&apos;. (&apos;Brustumfang, hinten&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hälfte_unterbrustumfang_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Die Hälfte des hohen Brustumfanges hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte von &apos;Hoher Brustumfang, hinten&apos;. (&apos;Hoher Brustumfang, hinten&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hälfte_rippenumfang_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Die Hälfte des Rippenumfanges hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte von &apos;Rippenumfang, hinten&apos;. (&apos;Rippenumfang, hinten&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hälfte_taillenumfang_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Die Hälfte des Tailenumfanges hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte von &apos;hinterer Taillenumfang&apos;. (&apos;hinterer Taillenumfang&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hälfte_hoher_hüftumfang_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Die Hälfte des hinteren Umfangs hohe Hüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Häfte &apos;der hohen Hüfte hinten&apos;. Von der Mitte des Rücken bis zur Seite gemessen, auf dem Niveau der hohen Hüfte. (&apos;Hohe Hüfte hinten/2&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hüfte_bogen_halb_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte des hinteren Hüftumfanges</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Hälfte vom &apos;Hüftumfang hinten&apos;. (&apos;Hüftumfang hinten&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vorne_hüftumfang_mit_bauch</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation>Vorderer Hüftumfang mit Bauch</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>körper_achsel_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation>Körperumfang auf Achselhöhe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation>Um Arme und Brustkorb herum auf Achselhöhe messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>körper_brustumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation>Körperumfang auf Brusthöhe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Um Arme und Brustkorb herum auf Brusthöhe messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Körper_Brustkorb_Umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation>Körperumfang des gesamten Brustkorbs</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation>Torsoumfang von der Schultermitte durch den Schritt zurück zur Schultermitte.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hüftumfang_mit_bauch</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation>Hüftumfang, inklusive Bauch</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation>Auf Höhe der Hüfte messen, den Bauch mit berücksichtigen. (Hüftumfang hinten + Vorderer Hüftumfang mit Bauch)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nacken_vorne_zur_taille_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Hals vorne zu Taille vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_vorne_zur_taille_vorne_flach</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation>Hals vorne zur Taille vorne, flach</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Vorderseite des Nackens zwischen den Brüsten runter zur Taille messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>achsel_bis_taillenseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Achselhöhle zur Taillenseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Achselhöhle zur Seite der Taille messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulterspitze_zur_taillenseite_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Schulterspitze zur Taillenseite, vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Schulterspitze um die Vorderseite des Ärmellochs runter zur Taillenseite messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_taille_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Taillenhöhe vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Halsseite gerade runter zur Taillenhöhe messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_taille_über_brust_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Von der Seite des Halses über den Brustpunkt zur Taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>In einer geraden Linie von der Seite des Halses über den Brustpunkt zur Taille messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_vorne_zur_oberbrust_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Hals vorne zur Oberbrust vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Vorderseite des Halses bis zur Oberbrust messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>oberbrust_zur_taille_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Oberbrust vorne zur Taille vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_vorne_zur_brust_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Hals vorne zur Brust vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brust_zur_taille_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Brust vorne zur Taille vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Vorderseite der Brust bis zur Taille messen. (&apos;Hals vorne zur Taille vorne&apos; - &apos;Hals vorne zur Brust vorne&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>unterbrust_zur_taille_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Unterbrust vorne zur Taille vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der vorderen Unterbrust zur Taille messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rippen_zur_taille_seite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Rippenseite zur Taillenseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der tiefsten Rippe auf der Seite runter zur Taillenseite messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulterspitze_zur_achsel_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Schulterspitze zur Achsel, vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Schulterspitze um das Ärmelloch runter zur Achsel messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_brust_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Brust, vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Halsseite gerade runter zur Vorderseite der Brust messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_oberbrust_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Oberbrust, vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Halsseite gerade runter zur Oberbrust vorne messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schultermitte_zur_oberbrusthöhe_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Schultermitte zur Oberbrusthöhe, vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Schulterhöhe vorne zur Höhe der Oberbrust messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulterspitze_zur_taillenseite_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Schulterspitze zur Taillenseite, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Schulterspitze über den Rücken in einer Kurve um das Ärmelloch runter zur Taillenseite messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_taille_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Taillenhöhe, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Halsseite gerade herunter zur Taille messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nacken_hinten_bis_taille_h</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Nacken hinten bis Taille hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Nacken hinten runter bis Taille hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_taille_schulterblatt_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Taille, über das Schulterblatt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>In einer geraden Linie von der Halsseite über das Schulterblatt herunter zur Taille messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nacken_zur_oberbrust_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Nacken zur Oberbrust hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Nacken zur Höhe der Oberbrust auf dem Rücken messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>oberbrust_zur_taille_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Oberbrust hinten zur Taille hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Auf dem Rücken messen: Von der Oberbrust zur Taille. (&apos;Nacken hinten bis Taille hinten&apos; - &apos;Nacken zur Oberbrust hinten&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nacken_zur_brust_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Nacken zum Rücken auf Brusthöhe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Nacken zur Höhe der Brust auf dem Rücken messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brust_hinten_zur_taille_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Brust hinten zur Taille hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Brust zur Taille, über den Rücken gemessen. (&apos;Nacken hinten bis Taille hinten&apos; - &apos;Nacken zum Rücken auf Brusthöhe&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>unterbrust_hinten_zur_taille_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Unterbrust hinten zur Taille hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Auf dem Rücken von der Unterbrusthöhe zur Taillenhöhe messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulterspitze_zur_achsel_rücken</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Schulterspitze zur Achsel hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Schulterspitze um das Ärmelloch runter zur Achsel messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_brust_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Brust, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Seite des Halses gerade runter zur Brust messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_oberbrust_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Oberbrusthöhe, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Halsseite gerade den Rücken herunter bis zur Höhe der Oberbrust messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schultermitte_zur_oberbrusthöhe_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Schultermitte zur Oberbrusthöhe, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Schulterhöhe hinten zwischen den Schulterblättern zur Höhe der Oberbrust messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_zur_hohen_hüfte_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Taille vorne zur hohen Hüfte vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Vroderseite der Taille zur Vorderseite der hohen Hüfte messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_zur_hüfte_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Taille vorne zur Hüfte vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Vorderseite der Taille zur Vorderseite der Hüfte messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_zur_hohen_hüfte_seite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Taillenseite zur Seite der hohen Hüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Seite der Taille zur Seite der hohen Hüfte messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_zur_hohen_hüfte_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Taille hinten zur hohen Hüfte hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Auf dem Rücken von der Taillenhöhe zur Höhe der hohen Hüfte messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_zur_hüfte_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Taille hinten zur Hüfte hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_zur_hüftseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Taillenseite zur Hüftseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Taillenseite zur Hüftseite messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulter_neigung_hals_seiten_winkel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Neigungswinkel der Schulter ab der Halsseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Der Winkel der Linie von der Halsseite zur Schulterspitze und der Linie von der Halsseite zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulter_neigung_hals_seite_länge</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Länge der Schulterneigung ab der Halsseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikaler Abstand zwischen der Halsseite und der Schulterspitze.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulter_neigung_nacken_winkel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neigungswinkel der Schulter ab dem Nacken</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Der Winkel der Linie vom Nacken zur Schulterspitze und der Linie vom Nacken zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulter_neigung_nacken_länge</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Länge der Schulterneigung vom Nacken</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikaler Abstand zwischen dem Nacken und der Schulterspitze.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulter_neigung_schulterspitze_winkel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Neigungswinkel der Schulter ab der Schulterspitze</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Der Winkel der Linie von der Halsseite zur Schulterspitze und einer vertikalen Linie ab der Schulterspitze.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nacken_zu_über_rücken</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Nacken zu &apos;Über den Rücken gemessen&apos;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Nacken runter zur Höhe von &apos;Über den Rücken gemessen&apos; messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>über_rücken_zur_taille_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation>Von &apos;Über den Rücken gemessen&apos; zur Taille hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Mitte von &apos;Über den Rücken gemessen&apos; zur Taille hinten messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulterbreite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation>Schulterbreite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Seite des Halses bis zur Schulterspitze messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulterspitze_zur_schulterspitze_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation>Schulterspitze zur Schulterspitze, vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der einen Schulterspitze zur anderen auf der Vorderseite messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>über_die_brust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation>Über die Brust gemessen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der einen Achsel zur anderen die kürzeste Strecke über die Brust messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>achsel_zu_achsel_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation>Achsel zu Achsel, vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der einen Achsel zur anderen messen. Die kürzeste Strecke wählen, diese muss nicht parallel zum Boden sein.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulterspitze_zur_schulterspitze_halb_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte der horizontalen Abmessung von Schulterspitze zu Schulterspitze vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte von &apos;Schulterspitze zur Schulterspitze, vorne&apos;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>über_die_brust_halb</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation>Über die Brust gemessen, halb</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte von &apos;Über die Brust gemessen&apos; (&apos;Über die Brust gemessen&apos; / 2)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulterspitze_zur_schulterspitze_rücken</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation>Horizontale Abmessung von Schulterspitze zu Schulterspitze, am Rücken</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale Abmessung von Schulterspitze zu Schulterspitze, am Rücken.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>über_rücken_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Über den Rücken gemessen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der einen Achsel zur anderen die kürzeste Strecke über den Rücken messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>achsel_zur_achsel_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation>Achsel zur Achsel, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der einen Achsel zur anderen über den Rücken messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulterspitze_zur_schulterspitze_halb_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hälfte der horizontalen Abmessung von Schulterspitze zu Schulterspitze am Rücken</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte von &apos;Schulterspitze zu Schulterspitze, hinten&apos;. (&apos;Schulterspitze zu Schulterspitze, hinten&apos; / 2)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>über_rücken_halb_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Über den Rücken gemessen, halb</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte von &apos;Über den Rücken gemessen&apos; (&apos;Über den Rücken gemessen&apos; / 2)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_vorne_zur_schulterspitze_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Hals vorne zur Schulterspitze</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Vorderseite des Halses bis zur Schulterspitze messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_hinten_zur_schulterspitze_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Nacken zur Schulterspitze</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Nacken zur Schulterspitze messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Halsbreite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation>Halsbreite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation>Zwischen den Enden einer ungeschlossenen Kette, die um den Hals gehängt wurde, messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brustpukt_zu_brustpunkt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Brustpunkt zu Brustpunkt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom einen Brustpunkt zum anderen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brustpunkt_zur_halsseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Brustpunkt zur Halsseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Brustpunkt zur Seite des Halses messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brustpunkt_zur_unterbrust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation>Brustpunkt zur Unterbrust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Brustpunkt zur Höhe der Unterbrust messen, dabei der Kurve der Brust folgen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brustpunkt_zur_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>Brustpunkt zur Taillenhöhe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Brustpunkt in einer geraden Linie runter zur Taillenhöhe messen (nicht am Körper entlang messen).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brustpunkt_zum_brustpunkt_hälfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation>Brustpunkt zu Brustpunkt, Hälfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Die Hälfte von &apos;Brustpunkt zu Brustpunkt&apos;. (&apos;Brustpunkt zu Brustpunkt&apos; / 2)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brustpunkt_nacken_seite_zur_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>Brustpunkt, von der Nackenseite bis zur Taillenhöhe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Halsseite zum Brustpunkt, dann gerade herunter zur Taillenhöhe messen. (&apos;Halsseite zum Brustpunkt&apos; + &apos;Brustpunkt zur Taillenhöhe&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brustpunkt_zur_schulterspitze</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Brustpunkt zur Schulterspitze</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Brustpunkt zur Schulterspitze messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brustpunkt_zur_taille_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Brustpunkt zur Taille vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Brustpunkt in einer geraden Linie runter zur Vorderseite der Taille messen (nicht am Körper entlang messen).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brustpunkt_zu_brustpunkt_träger</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation>Brustpunkt zu Brustpunkt Träger</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom einen Brustpunkt um den Nacken runter zum anderen Brustpunkt messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>brustpunkt_zur_schultermitte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation>Brustpunkt zur Schultermitte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Schultermitte zum Brustpunkt messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulterspitze_zur_taille_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Schulterspitze zur Taille vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Schulterspitze diagonal zur Vorderseite der Taille messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_vorne_zur_taille_seite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Hals vorne zur Taillenseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Vorderseite des Halses diagonal zur Seite der Taille messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_taillenseite_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Taillenseite, vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Seite des Halses diagonal über die Brust zur Taillenseite messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulterspitze_zur_taille_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Schulterspitze zur Rückseite der Taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Schulterspitze diagonal zur Rückseite der Taille messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schulterspitze_zur_taille_hinten_1zoll_abw</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation>Schulterspitze zur Rückseite der Taille mit 1 Zoll (2,54 cm) Abweichung</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation>Einen Zoll (2,54 cm) nach außen auf Taillenhöhe von der Rückseite der Taille aus markieren. Von der Schulterspitze diagonal zu dieser Markierung messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_hinten_zur_taillenseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Nacken zur Taillenseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Nacken diagonal über den Rücken zur Taillenseite messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_taillenseite_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Taillenseite, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Halsseite diagonal über den Rücken zur Taillenseite messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_armfalte_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Achsel vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Halsseite diagonal zur Vorderseite der Achsel messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_achsel_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Oberbrustseite, vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Seite des Halses diagonal über die Brust zur Oberbrustseite (Achsel) messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_brust_seite_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Brustseite, vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Seite des Halses schräg über die Brust zur Brustseite messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_achsel_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Achsel, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Halsseite diagonal zur Rückseite der Achsel messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_oberbrust_seite_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Oberbrustseite, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Seite des Halses diagonal über den Rücken zur Oberbrustseite (Achsel) messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_seite_zur_brust_seite_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Halsseite zur Brustseite, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Seite des Halses schräg über den Rücken zur Brustseite messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Arm_Schulterspitze_zum_Handgelenk_gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Schulterspitze zum Handgelenk, gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm beugen, von der Schulterspitze über den Ellenbogen bis zum Handgelenkknochen messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Arm_Schulterspitze_zum_Ellbogen_gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Schulterspitze zum Ellbogen, gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm beugen, von der Schulterspitze bis zum Ellbogen messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Arm_Ellbogen_zum_Handgelenk_gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Ellbogen zum Handgelenk, gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Ellenbogen zum Handgelenk. (&apos;Arm: Schulterspitze zum Handgelenk, gebogen&apos; - &apos;Arm: Schulterspitze zum Ellbogen, gebogen&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Arm_Ellenbogen_Umfang_gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Umfang des Ellenbogens, gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation>Umfang des Ellenbogens messen, während dieser gebeugt ist.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Arm_Schulterspitze_bis_Handgelenk</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Schulterspitze zum Handgelenk</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Schulterspitze zum Handgelenk messen, während der Arm gerade gehalten wird.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Arm_Schulterspitze_bis_Elllenbogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Schulterspitze zum Ellbogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm gerade ausstrecken, von der Schulterspitze bis zum Ellbogen messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Arm_Ellenbogen_zum_Handgelenk</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Ellbogen zum Handgelenk</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Ellenbogen zum Handgelenk messen, den Arm dabei gestreckt halten.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_achsel_zum_handgelenk</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Achsel zum Handgelenk, innen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Bei gestrecktem Arm von der Achsel zum Handgelenk messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_achsel_zum_ellenbogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Achsel zum Ellenbogen, innen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Bei gestrecktem Arm von der Achsel zum Ellenbogen messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_ellenbogen_zum_handgelenk_innen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Ellenbogen zum Handgelenk, innen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Innenseite des Ellenbogens zum Handgelenk messen. (&apos;Arm: Achsel zum Handgelenk, innen&apos; - &apos;Arm: Achsel zum Ellenbogen, innen&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_oberarm_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Umfang des Oberarms</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>Der Umfang des Oberarms auf Höhe der Achsel.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_über_ellenbogen_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Umfang über dem Ellenbogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation>Der Umfang des Oberarms auf Höhe des Bizeps.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Arm_Ellenbogen_Umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Umfang des Ellenbogens</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm: Umfang des Ellenbogens, gestreckt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Unterarm_Umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Umfang des Unterarms</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Umfang der breitesten Stelle des Unterarms.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_handgelenk_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Handgelenksumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation>Der Umfang des Handgelenks.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_schulterspitze_zur_achsel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Schulterspitze zur Achsel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Schulterspitze zur Achselhöhe messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_hals_seite_zum_handgelenk</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Halsseite zum Handgelenk</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Seite des Halses zum Handgelenk messen. (&apos;Schulterbreite&apos; + &apos;Arm: Schulterspitze zum Handgelenk&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_hals_seite_zu_fingerspitzen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Halsseite zu Fingerspitzen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Seite des Halses zum Handgelenk messen. (&apos;Schulterbreite&apos; + &apos;Arm: Schulterspitze zum Handgelenk&apos; + &apos;Handgelenk&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ärmelloch_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Ärmelloch: Umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm seitlich hängen lassen. Umfang des Ärmellochs über die Schulterspitze und die Achsel messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ärmelloch_länge</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Ärmelloch: Länge</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikaler Abstand von der Schulterspitze zur Achsel.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ärmelloch_breite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Ärmelloch: Breite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontaler Abstand zwischen der Vorder- und Rückseite des Ärmellochs.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_hals_seite_zum_ellenbogen_außen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Halsseite zum äußeren Ellenbogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Halsseite über die Schulterspitze herunter zum Ellenbogen messen. (&apos;Schulterlänge&apos; + &apos;Arm: Schulterspitze zum Ellenbogen&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bein_schritt_bis_zum_boden</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Beine: Vom Schritt bis Boden</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Füße eng zusammen stellen. Messen Sie vom Schritt-Höhe (Körper berühren, keine zusätzlichen Platz) bis zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>beine_taille_seite_bis_boden</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Beine: Taille an der Seite bis zum Boden</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Taille entlang der Seite und Hüftkurve, ab Hüfthöhe gerade nach unten bis zum Boden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>beine_oberschenkel_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Beine: Oberschenkel-Umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation>Oberschenkelumfang an der breitesten Stelle des Oberschenkels in der Nähe des Schrittes.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>beine_oberschenkel_umfang_mitte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Beine: Oberschenkel-Mittelumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Oberschenkelumfang etwa auf halbem Weg zwischen Schritt und Knie.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>beine_knieumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Beine: Knieumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Knie Umfang mit geradem Bein.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>beine_kleinster_knieumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Beine: kleinster Knieumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Beinumfang knapp unter dem Knie.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bein_wadenumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Bein: Wadenumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Wadenumfang an der stärksten Stelle des Unterschenkels.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bein_oberer_knöchelumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Bein: oberer Knöchelumfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation>Umfang des Knöchels da, wo die Einbuchtung an der Rückseite des Knöchels am stärksten ausgeprägt ist.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bein_umfang_knöchel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Bein: Umfang des Knöchels</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bein_umfang_gewinkeltes_knie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Bein: Umfang des gewinkelten Knies</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation>Knieumfang mit abgewinkeltem Bein.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bein_diagonaler_umfang_knöchel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Bein: Diagonaler Umfang des Knöchels</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation>Der Umfang des Knöchels diagonal von der Oberseite des Fußes zur Unterseite der Ferse.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bein_schritt_zum_knöchel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Bein: Schritt zum Knöchel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Schritt zum Knöchel messen. (&apos;Bein: Schritt zum Boden&apos; - &apos;Höhe: Knöchel&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bein_taillenseite_zum_knöchel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Bein: Taillenseite zum Knöchel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Taillenseite zum Knöchel messen. (&apos;Bein: Taillenseite zum Boden&apos; - &apos;Höhe: Knöchel&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bein_taillenseite_bis_knie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Bein: Seitliche Taille zu den Knien</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Taille entlang der Seite und Hüftkurve, ab Hüfthöhe gerade nach unten bis zum Knie. (&apos;Bein: Taillenseite zum Boden&apos; - &apos;Höhe: Knie&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schritt_länge</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation>Schrittlänge</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schrittlänge_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation>Schrittlänge, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schrittlänge_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation>Schrittlänge, vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Vorderseite der Taille zur Scheide oder zum Ende der Testikel messen. (&apos;Schrittlänge&apos; - &apos;Schrittlänge, hinten&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Leibhöhe_sitzend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation>Leibhöhe, sitzend an der Seite gemessen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation>Leibhöhe. Von Taille über die Seite bis zur Sitzfläche (auf festem Untergrund) gemessen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Senkrechter Abstand von der Taillenrückseite zur Schritthöhe. (&apos;Höhe: Taille hinten&apos; - &apos;Bein: Schritt zum Boden&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Senkrechter Abstand von der Taille vorne zur Schritthöhe. (&apos;Höhe: Taille vorne&apos; - &apos;Bein: Schritt zum Boden&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Leibhöhe_Seite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation>Leibhöhe,  an der Seite gemessen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leibhöhe_diagonal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation>Leibhöhe, diagonal gemessen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Taille über die Seite diagonal bis zum Beinansatz gemessen. Auf festem Untergrund sitzen, ein Maßband um den Beinansatz legen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Leibhöhe_h</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation>Leibhöhe, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Leibhöhe_v</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation>Leibhöhe, von vorne gemessen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation>Vertikaler Abstand von der Taillenseite zur Schritthöhe. (&apos;Höhe: Taillenseite&apos; - &apos;Bein: Schritt zum Boden&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nacken_zur_taille_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Nacken zur Taille vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Nacken über die Seite des Halses runter zur Vorderseite der Taille messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_zur_taille_über_nacken</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Von Taille über Nacken zur Taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Taillenhöhe um den Nacken zurück zur Taille messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_natürlich_umfang</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Umfang der natürlichen Taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation>Rumpfumfang auf der Höhe der natürlichen Einbuchtung beim äußeren schrägen Bauchmuskel (bei Männern). Wenn die EInbuchtung nicht gefunden werden kann, misst man direkt unter dem Nabel.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_natürlich_bogen_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Bogen der natürlichen Taille, vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von Seite zu Seite auf der Höhe der natürlichen Taille über dem Bauch messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_natürlich_bogen_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Bogen der natürlichen Taille, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation>Von Seite zu Seite auf der Höhe der natürlichen Taille über dem Rücken messen. (&apos;Umfang natürliche Taille&apos; - &apos;Bogen der natürlichen Taille, vorne&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_zur_natürlichen_taille_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Taillen zur natürlichen Taille, vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Vorderseite der Taille zur Vorderseite der natürlichen Taille messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_zur_natürlichen_taille_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Taille zur natürlichen Taille, hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Rückseite der Taille zur Rückseite der natürlichen Taille messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_hinterseite_nacken_bis_ellenbogen_gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Hinterseite des Nachens bis zum Ellenbogen, hoch gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm mit dem Ellenbogen nach außen beugen, die Hand nach vorn gehalten. Von der Hinterseite des Nackens zur Ellenbogenspitze messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_nacken_zum_handgelenk_hoch_gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Nacken zum Handgelenk, hoch gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm mit dem Ellenbogen nach außen beugen, die Hand nach vorn gehalten. Vom Nacken über den Ellenbogen zum Handgelenk messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_hals_seite_zum_ellenbogen_gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Halsseite zum Ellenbogen, hoch gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm mit dem Ellenbogen nach außen beugen, die Hand nach vorn gehalten. Von der Seite des Halses zur Ellenbogenspitze messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_hals_seite_zum_handgelenk_gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Halsseite zum Handgelenk, hoch gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm mit dem Ellenbogen nach außen beugen, die Hand nach vorn gehalten. Von der Seite des Halses über den Ellenbogen zum Handgelenk messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_mitte_über_rücken_zum_ellenbogen_hoch_gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Mitte von &quot;Über den Rücken&quot; zum Ellenbogen, hoch gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm mit dem Ellenbogen nach außen beugen, die Hand nach vorn gehalten. Von der Mitte des Rückens zur Ellenbogenspitze messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_mitte_rücken_zum_handgelenk_hoch_gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Mitte von &quot;Über den Rücken&quot; zum Handgelenk, hoch gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm mit dem Ellenbogen nach außen beugen, die Hand nach vorn gehalten. Von der Mitte des Rückens über den Ellenbogen zum Handgelenk messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Arm_ärmelloch_rücken_zum_handgelenk_gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Ärmelloch-Rückseite zum Handgelenk, hoch gebeugt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm mit dem Ellenbogen nach außen beugen, die Hand nach vorn gehalten. Von der Rückseite des Ärmellochs zur Ellenbogenspitze messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hals_hinten_zur_brust_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Hals hinten zur Brust vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Nacken über die Schulter bis zur Vorderseite der Brust messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nacken_zur_achsel_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Nacken zur Achsel vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Nacken über die Schulter bis zur Vorderseite der Achsel messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nacken_zur_achsel_vorne_zur_taillenseite</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Nacken zur Taillenseite über Schulter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Nacken über die Schulter zur Taillenseite messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>oberbrust_hinten_über_schulter_zur_achsel_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Oberbrust hinten über Schulter zur Achsel vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Rücken auf Höhe der Oberbrust über die Schulter zur Achsel vorne messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>oberbrust_hinten_über_schulter_zur_taille_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Oberbrust hinten über Schulter zur Taille vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Rücken auf Höhe der Oberbrust über die Schulter (den Halls berührend) zur Taillenvorderseite messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nacken_zur_achsel_vorne_zum_nacken</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Nacken zur Achsel vorne zum Nacken</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Nacken über die Schulter bis zur Vorderseite der Achsel, dann unter dem Arm durch zurück zum Nacken messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>über_rücken_zentrum_zur_achsel_vorne_zu_über_rücken_zentrum</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>&apos;Über den Rücken gemessen&apos;-Zentrum, um die Schulter herum messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Zentrum von &apos;Über den Rücken gemessen&apos; über die Schulter, unter dem Arm durch und zurück zum Anfang messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nacken_zur_achsel_vorne_zur_oberbrust_hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Nacken zur Achsel vorne zur Oberbrust hinten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Vom Nacken über die Schulter bis zur Vorderseite der Achsel, dann unter dem Arm durch auf dem Rücken bis zur Oberbrusthöhe messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>achsel_zur_achsel_über_brust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Achsel zu Achsel, vorne, als Kurve über die Brust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation>In einer Kurve von der linken Achsel über das Zentrum der Brust zur rechten Achsel messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>achsel_zur_brust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Achsel zur Brust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation>In einer geraden, kürzestmöglichen Linie von der Achsel vorne zur Mitte der Brust messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>oberbrust_hinten_über_schulter_zur_oberbrust_vorne</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation>Oberbrust hinten über Schulter zur Oberbrusthöhe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Von der Höhe der Oberbrust hinten über die Schulter Richtung Brustpunkt zur Oberbrust messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ärmelloch_bogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation>Ärmelloch: Bogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Auf der Höhe von &apos;Über die Brust/den Rücken gemessen&apos; vom Ärmelloch vorne über die Schulterspitze zum Ärmelloch hinten messen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>abnäher_breite_schulter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Abnäherbreite: Schulter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>Diese Informationen wurden von den Schnittmuster-Tabellen von einigen Schnittmustersystemen wie z. B.  Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;. übernommen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>abnäher_breite_brust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Abnäherbreite: Brust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Abnäher_breite_hüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Abnäherbreite: Hüfte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>Diese Informationen wurden von den Schnittmuster-Tabellen von einigen Schnittmustersystemen wie z. B.  Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;. übernommen.</translation>

--- a/share/translations/measurements_el_GR.ts
+++ b/share/translations/measurements_el_GR.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Σύνολο</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση απο την κορώνα του κεφαλιού ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_πίσω_λαιμού</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Πίσω λαιμός</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση απο τον Πίσω Λαιμό ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_ωμοπλάτης</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Ωμοπλάτη</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση απο τη Ωμοπλάτη ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_μασχάλης</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Μασχάλη</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση απο τη Μασχάλη ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>πλαϊνό_ύψος_μέσης</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Πλαϊνή μέση</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση απο τη Πλαϊνή Μέση ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_γοφών</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Γοφοί</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση απο το ύψος Γοφών ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_δίπλωσης_γλουτών</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Δίπλωση γλουτών</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση απο τη δίπλωση Γλουτών, όπου ο Γλουτιαίος μυς συναντάει το επάνω μέρος του πίσω μηρού, ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_γονάτου</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Γόνατο</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση απο τη δίπλωση του πίσω μέρους του Γονάτου ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_γάμπας</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Γάμπα</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση απο το φαρδύτερο σημείο της γάμπας ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_επάνω_αστραγάλου</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Επάνω αστράγαλος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση απο το βαθύτερο σημείο της εσοχής του πίσω αστραγάλου ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_αατραγάλου</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Αστράγαλος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση απο το σημείο οπου το μπροστινό μέρος του ποδιού ως το πόδι στο έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_επάνω_γοφοί</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Επάνω γοφοί</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση από το επίπεδο του Επάνω Γοφού, όπου η κοιλιά μπροστά προεξέχει πιο πολύ, ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_μέσης_μπροστά</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Μπροστινή μέση</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση από τη Μέση Μπροστά ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_αιχμή_στήθους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Αιχμή στήθους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση από την Αιχμή Στήθους ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_κορυφής_ώμου</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Άκρη ώμου</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση από την Κορυφή Ώμου ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_λαιμού_μπροστά</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Μπροστινός λαιμός</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση από το Μπροστά Λαιμό ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_πλαϊνού_λαιμού</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Πλαϊνός λαιμός</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση από τον Πλαϊνό Λαιμό ως το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_πίσω_λαιμού_ως_το_γόνατο</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Πίσω λαιμός ως γόνατο</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση από τον Πίσω Λαιμό ως το δίπλωμα στο πίσω μέρος του γονάτου (γραμμή γονάτου).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_μέσης_πλάϊ_ως_το_γόνατο</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Πλαϊνή μέση ως γόνατο</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση από τη Μέση Πλάϊ ως τη γραμμή του γονάτου.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_μέση_πλάϊ_ως_τον_γοφό</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Πλαϊνή μέση ως γοφούς</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση από τη Μέση Πλάϊ ως το ύψος των Γοφών.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ύψος_γονάτου_ως_τον_αστράγαλο</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Γόνατο ως αστράγαλο</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Πίσω λαιμός ως πλαϊνή μέση</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση από το Λαιμό Πίσω ως την Πλαϊνή Μέση. (&apos;ύψος: Λαιμός Πίσω&apos; - &apos;ύψος: Πλαϊνή Μέση&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>φάρδος_ώμου</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Φάρδος: Ώμος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Οριζόντια απόσταση απο Άκρη Ώμου ως Άκρη Ώμου</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>φάρδος_στήθους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Φάρδος: Στήθος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>φάρδος_μέσης</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Φάρδος: Μέση</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>φάρδος_γοφών</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Φάρδος: Γοφοί</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>μήκος_παλάμης</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation>Χέρι: Μήκος παλάμης</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Μήκος απο τη γραμμή καρπού ως τη βάση του μέσου δάκτυλου.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>μήκος_χεριού</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Χέρι: Μήκος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Μήκος από τη γραμμή του Καρπού ως το τέλος του μεσαίου δαχτύλου.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>παλάμη_φάρδος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation>Χέρι: Φάρδος παλάμης</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Μετρήστε εκεί που υπαρχει το μεγαλύτερο φάρδος παλάμης</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>παλάμη_περιφέρεια</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Χέρι: Περίμετρος παλάμης</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Περιφέρεια όπου η Παλάμη είναι φαρδύτερη.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>χέρι_περιφέρεια</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Χέρι: Περίμετρος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>πατούσα_φάρδος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Πόδι: Φάρδος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Μέτρηση στο φαρδύτερο μέρος του ποδιού.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>πόδι_μήκος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Πόδι: Μήκος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>πατούσα_περιφέρεια</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Πόδι: Περίμετρος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Μέτρηση περιφέρειας του φαρδύτερου μέρους της πατούσας.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Πόδι: Περίμετρος ταρσού</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>κεφάλι_περιφέρεια</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Κεφάλι: Περίμετρος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>κεφάλι_μήκος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Κεφάλι: Μήκος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>κεφάλι_βάθος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation>Κεφάλι: Βάθος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>κεφάλι_πλάτος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Κεφάλι: Πλάτος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>κεφάλι_πηγούνι_ως_το_λαιμό_πίσω</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Κεφάλι: Πηγούνι ως το Λαιμό Πίσω</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Κάθετη απόσταση από το Πηγούνι ως το Λαιμό Πίσω. (&apos;Ύψος&apos; - &apos;Ύψος: Λαιμός Πίσω&apos; - &apos;Κεφάλι: Μήκος&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Περίμετρος λαιμού</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Περίμετρος στήθους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Περίμετρος στήθους, παράλληλα με το έδαφος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Κάτω περίμετρος στήθους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Χαμηλή περίμετρος στήθους κάτω απο τους μαστούς, παράλληλα με το έδαφος.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Περίμετρος πλευρών</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Περίμετρος μέσης</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Επάνω περίμετρος γοφών</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Ύψος: Πίσω μέση</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Περίμετρος γοφών</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation>Περίμετρος σώματος στο ύψος του στήθους</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Χέρι: Περίμετρος αγκώνα, λυγισμένος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Χέρι: Επάνω περίμετρος μπράτσου</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Χέρι: Περίμετρος καρπού</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation>Περίμετρος καρπού</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>καβάλο_ποδιού_ως_έδαφος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Πόδι: Απο καβάλο ως έδαφος</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>Αυτές οι πληροφορίες έχουν ληφθεί απο πίνακες σε κάποιες μεθόδους σχεδίασης πατρόν, π.χ.&quot;Metric Pattern Cutting&quot; της Winifred P. Aldrich.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Πόδι: Περίμετρος στο πάνω μέρος του μηρού</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Πόδι: Περίμετρος στο μέσο του μηρού</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Πόδι: Περίμετρος γονάτου</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Περίμετρος γονάτου σε ίσιο πόδι.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Πόδι: Μικρή περίμετρος γονάτου</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Περίμετρος γονάτου ακριβώς κάτω απο το γόνατο.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Πόδι: Περίμετρος γάμπας</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Περίμετρος γάμπας στο φαρδύτερο σημείο του κάτω ποδιού.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Πόδι: Περίμετρος αστράγαλου</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Πόδι: Περίμετρος γονάτου, λυγισμένο</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Περίμετρος μέσης</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>Αυτές οι πληροφορίες έχουν ληφθεί απο πίνακες σε κάποιες μεθόδους σχεδίασης πατρόν, π.χ.&quot;Metric Pattern Cutting&quot; της Winifred P. Aldrich</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>

--- a/share/translations/measurements_en_CA.ts
+++ b/share/translations/measurements_en_CA.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Total</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from crown of head to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_scapula</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Scapula</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Scapula (Blade point) to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_armpit</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Armpit</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Armpit to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Waist Side to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Hip level to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_gluteal_fold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Gluteal Fold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the fold at the back of the Knee to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_calf</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Calf</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the widest point of the calf to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_ankle_high</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Ankle High</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the deepest indentation of the back of the ankle to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from point where the front leg meets the foot to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_highhip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Highhip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Waist Front to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Bustpoint to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_shoulder_tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Shoulder Tip to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Neck Front to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Neck Side to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_back_to_knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Back to Knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_side_to_knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Side to Knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Waist Side to the fold at the back of the knee.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_side_to_hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Side to Hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Waist Side to the Hip level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_knee_to_ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Knee to Ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_back_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Back to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation>Vertical height from Waist Back to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Shoulder Tip to Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Bust Side to Bust Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Waist Side to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Hip Side to Hip Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_abdomen_to_hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Abdomen to Hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>indent_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Indent: Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Scapula (Blade point) to the Neck Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>indent_waist_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Indent: Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>indent_ankle_high</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Indent: Ankle High</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_palm_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Palm length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Length from Wrist line to base of middle finger.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Length from Wrist line to end of middle finger.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_palm_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Palm width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure where Palm is widest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_palm_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Palm circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference where Palm is widest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Foot: Width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure at widest part of foot.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Foot: Length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure from back of heel to end of longest toe.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Foot: Circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure circumference around widest part of foot.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_instep_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Foot: Instep circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure circumference at tallest part of instep.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure circumference at largest level of head.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Head Crown to bottom of jaw.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_depth</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Depth</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from front of forehead to back of head.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Head Side to Head Side, where Head is widest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_crown_to_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Crown to Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_chin_to_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Chin to Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_mid_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation>Neck circumference, midsection</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference of Neck midsection, about halfway between jaw and torso.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Neck circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Bust circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Bust, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around LowBust under the breasts, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Rib circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Waist circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Waist, following natural contours. Waists are  typically higher in back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hip circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Neck Side through Neck Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Bust arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bust Side to Bust Side across chest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>size</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation>Same as bust_arc_f.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Lowbust Side to Lowbust Side across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Rib arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Rib Side to Rib Side, across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Waist arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Waist Side across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highhip Side to Highhip Side across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Hip Side to Hip Side across Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Neck arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Bust arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Rib arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Waist arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Bust arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Rib arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Neck arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Bust arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Rib arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Waist arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_with_abdomen_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc with Abdomen, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>body_armfold_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation>Body circumference at Armfold level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure around arms and torso at Armfold level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>body_bust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation>Body circumference at Bust level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure around arms and torso at Bust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>body_torso_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation>Body circumference of full torso</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_circ_with_abdomen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation>Hip circumference, including Abdomen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_waist_flat_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Waist Front flat</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front down between breasts to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armpit_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Armpit to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armpit down to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_side_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Side, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist level, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down front to Waist level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_bustpoint_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist level, through Bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side over Bustpoint to Waist level, forming a straight line.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Highbust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Neck Front down to Highbust Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Front to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_bust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Bust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Bust Front to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust Front to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Lowbust Front down to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Rib Side to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From lowest rib at side down to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_armfold_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Armfold Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip around Armscye down to Armfold Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_bust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Bust level, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down front to Bust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Highbust level, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down front to Highbust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_center_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder center to Highbust level, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_side_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Side, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist level, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down back to Waist level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back down to Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_scapula_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist level, through Scapula</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side across Scapula down to Waist level, forming a straight line.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_highbust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Highbust Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back down to Highbust Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Back to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_bust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Bust Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back down to Bust Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Bust Back to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust Back to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Lowbust Back down to Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_armfold_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Armfold Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip around Armscye down to Armfold Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_bust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Bust level, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down back to Bust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_highbust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Highbust level, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down back to Highbust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_center_to_highbust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder center to Highbust level, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation>From mid-Shoulder down back to Highbust level, aimed through Scapula.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_highhip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Front to Highhip Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Front to Highhip Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_hip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Front to Hip Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Front to Hip Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_highhip_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Side to Highhip Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Highhip Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_highhip_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Back to Highhip Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Back down to Highhip Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_hip_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Back to Hip Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_hip_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Side to Hip Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Hip Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_side_angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope Angle from Neck Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_side_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope length from Neck Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance between Neck Side and Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_back_angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope Angle from Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_back_height</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope length from Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance between Neck Back and Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_shoulder_tip_angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope Angle from Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_across_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Across Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation>From neck back, down to level of Across Back measurement.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_back_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation>Across Back to Waist back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation>From middle of Across Back down to Waist back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_shoulder_tip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Shoulder Tip, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip to Shoulder Tip, across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_chest_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation>Across Chest</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armscye to Armscye at narrowest width across chest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armfold_to_armfold_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation>Armfold to Armfold, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_shoulder_tip_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Shoulder Tip, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_chest_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation>Across Chest, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_shoulder_tip_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Shoulder Tip, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip to Shoulder Tip, across the back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_back_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Across Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armscye to Armscye at the narrowest width of the back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armfold_to_armfold_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation>Armfold to Armfold, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armfold to Armfold across the back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_shoulder_tip_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Shoulder Tip, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_back_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Across Back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_shoulder_tip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front to Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_shoulder_tip_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back to Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint to Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_neck_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Neck Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_lowbust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Lowbust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint down to Lowbust level, following curve of bust or chest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Waist level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_bustpoint_half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Bustpoint, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_neck_side_to_waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint, Neck Side to Waist level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_shoulder_tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint to Shoulder tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_bustpoint_halter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Bustpoint Halter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint around Neck Back down to other Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_shoulder_center</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Shoulder Center</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From center of Shoulder to Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_neck_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Neck Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front to Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip diagonal to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front diagonal to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_side_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist Side, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal across front to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip diagonal to Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_b_1in_offset</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back diagonal across back to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_side_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist Side, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal across back to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_armfold_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Armfold Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal to Armfold Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_armpit_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Highbust Side, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal across front to Highbust Side (Armpit).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_bust_side_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Bust Side, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Neck Side diagonal across front to Bust Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_armfold_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Armfold Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal to Armfold Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_armpit_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Highbust Side, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal across back to Highbust Side (Armpit).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_bust_side_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Bust Side, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Neck Side diagonal across back to Bust Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Wrist, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_elbow_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Elbow, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm, measure from Shoulder Tip to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow to Wrist, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_circ_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow circumference, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation>Elbow circumference, arm is bent.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip to Wrist bone, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder tip to Elbow Tip, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_to_wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow to Wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_armpit_to_wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Armpit to Wrist, inside</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armpit to ulna Wrist bone, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_armpit_to_elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Armpit to Elbow, inside</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armpit to inner Elbow, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_to_wrist_inside</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow to Wrist, inside</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_upper_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Upper Arm circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm circumference at Armpit level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_above_elbow_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Above Elbow circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm circumference at Bicep level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Elbow circumference, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_lower_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Lower Arm circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm circumference where lower arm is widest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_wrist_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Wrist circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation>Wrist circumference.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_armfold_line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Armfold line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip down to Armpit level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Side to Wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_finger_tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Side to Finger Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armscye_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Armscye: Circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armscye_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Armscye: Length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Shoulder Tip to Armpit.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armscye_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Armscye: Width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance between Armscye Front and Armscye Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_outer_elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck side to Elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_crotch_to_floor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Crotch to floor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation>Put tape across gap between buttocks at Hip level. Measure from Waist &quot;Back to mid-Crotch, either at the vagina or between testicles and anus).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_side_sitting</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_waist_side_to_floor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front, over tape between Breastpoints, down to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Waist Side to floor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side along curve to Hip level then straight down to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_thigh_upper_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Thigh Upper circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_thigh_mid_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Thigh Middle circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Thigh circumference about halfway between Crotch and Knee.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_knee_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Knee circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Knee circumference with straight leg.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_knee_small_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Knee Small circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Leg circumference just below the knee.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_calf_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Calf circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Calf circumference at the largest part of lower leg.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_ankle_high_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Ankle High circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation>Ankle circumference where the indentation at the back of the ankle is the deepest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_ankle_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Ankle circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Ankle circumference where front of leg meets the top of the foot.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_knee_circ_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Knee circumference, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation>Knee circumference with leg bent.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_ankle_diag_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Ankle diagonal circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation>Ankle circumference diagonal from top of foot to bottom of heel.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_crotch_to_ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Crotch to Ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_waist_side_to_ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Waist Side to Ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_waist_side_to_knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Waist Side to Knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>crotch_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation>Crotch length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>crotch_length_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation>Crotch length, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>crotch_length_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation>Crotch length, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, side, sitting</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side around hip curve down to surface, while seated on hard surface.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_diag</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, diagonal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back around Neck Side down to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_waist_halter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist to Waist Halter, around Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist level around Neck Back to Waist level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_natural_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Natural Waist circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_natural_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Natural Waist arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Side to Side at the Natural Waist level, across the front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_natural_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Natural Waist arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_natural_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Front to Natural Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Length from Waist Front to Natural Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_natural_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Back to Natural Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Length from Waist Back to Natural Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_back_to_elbow_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Back to Elbow, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_back_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Back to Wrist, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_elbow_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Side to Elbow, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Side to Wrist, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_across_back_center_to_elbow_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Across Back Center to Elbow, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_across_back_center_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Across Back Center to Wrist, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_armscye_back_center_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Armscye Back Center to Wrist, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_bust_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Bust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back, over Shoulder, to Bust Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_armfold_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Armfold Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back over Shoulder to Armfold Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_armfold_front_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back, over Shoulder, to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back, over Shoulder, down chest to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_back_over_shoulder_to_armfold_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Back, over Shoulder, to Armfold Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Back over Shoulder to Armfold Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_back_over_shoulder_to_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Back, over Shoulder, to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_armfold_front_to_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back, to Armfold Front, to Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_back_center_to_armfold_front_to_across_back_center</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Across Back Center, circled around Shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation>From center of Across Back, over Shoulder, under Arm, and return to start.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_armfold_front_to_highbust_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back, to Armfold Front, to Highbust Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armfold_to_armfold_bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Armfold to Armfold, front, curved through Bust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armfold_to_bust_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Armfold to Bust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_b_over_shoulder_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Back, over Shoulder, to Highbust level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armscye_arc</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation>Armscye: Arc</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>dart_width_shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Dart Width: Shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>dart_width_bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Dart Width: Bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>dart_width_waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Dart Width: Waist</translation>

--- a/share/translations/measurements_en_GB.ts
+++ b/share/translations/measurements_en_GB.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>

--- a/share/translations/measurements_en_IN.ts
+++ b/share/translations/measurements_en_IN.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Total</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from crown of head to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_scapula</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Scapula</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Scapula (Blade point) to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_armpit</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Armpit</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Armpit to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Waist Side to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Hip level to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_gluteal_fold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Gluteal Fold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the fold at the back of the Knee to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_calf</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Calf</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the widest point of the calf to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_ankle_high</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Ankle High</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the deepest indentation of the back of the ankle to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from point where the front leg meets the foot to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_highhip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Highhip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Waist Front to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Bustpoint to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_shoulder_tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Shoulder Tip to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Neck Front to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Neck Side to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_back_to_knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Back to Knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_side_to_knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Side to Knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Waist Side to the fold at the back of the knee.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_side_to_hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Side to Hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Waist Side to the Hip level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_knee_to_ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Knee to Ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_back_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Back to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation>Vertical height from Waist Back to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Shoulder Tip to Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Bust Side to Bust Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Waist Side to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Hip Side to Hip Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_abdomen_to_hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Abdomen to Hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>indent_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Indent: Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Scapula (Blade point) to the Neck Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>indent_waist_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Indent: Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>indent_ankle_high</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Indent: Ankle High</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_palm_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Palm length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Length from Wrist line to base of middle finger.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Length from Wrist line to end of middle finger.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_palm_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Palm width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure where Palm is widest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_palm_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Palm circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference where Palm is widest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Foot: Width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure at widest part of foot.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Foot: Length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure from back of heel to end of longest toe.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Foot: Circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure circumference around widest part of foot.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_instep_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Foot: Instep circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure circumference at tallest part of instep.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure circumference at largest level of head.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Head Crown to bottom of jaw.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_depth</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Depth</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from front of forehead to back of head.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Head Side to Head Side, where Head is widest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_crown_to_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Crown to Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_chin_to_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Chin to Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_mid_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation>Neck circumference, midsection</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference of Neck midsection, about halfway between jaw and torso.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Neck circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Bust circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Bust, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around LowBust under the breasts, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Rib circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Waist circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Waist, following natural contours. Waists are  typically higher in back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hip circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Neck Side through Neck Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Bust arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bust Side to Bust Side across chest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>size</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation>Same as bust_arc_f.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Lowbust Side to Lowbust Side across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Rib arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Rib Side to Rib Side, across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Waist arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Waist Side across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highhip Side to Highhip Side across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Hip Side to Hip Side across Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Neck arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Bust arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Rib arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Waist arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Bust arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Rib arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Neck arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Bust arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Rib arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Waist arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_with_abdomen_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc with Abdomen, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>body_armfold_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation>Body circumference at Armfold level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure around arms and torso at Armfold level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>body_bust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation>Body circumference at Bust level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure around arms and torso at Bust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>body_torso_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation>Body circumference of full torso</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_circ_with_abdomen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation>Hip circumference, including Abdomen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_waist_flat_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Waist Front flat</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front down between breasts to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armpit_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Armpit to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armpit down to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_side_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Side, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist level, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down front to Waist level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_bustpoint_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist level, through Bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side over Bustpoint to Waist level, forming a straight line.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Highbust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Neck Front down to Highbust Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Front to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_bust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Bust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Bust Front to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust Front to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Lowbust Front down to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Rib Side to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From lowest rib at side down to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_armfold_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Armfold Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip around Armscye down to Armfold Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_bust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Bust level, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down front to Bust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Highbust level, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down front to Highbust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_center_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder center to Highbust level, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_side_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Side, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist level, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down back to Waist level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back down to Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_scapula_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist level, through Scapula</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side across Scapula down to Waist level, forming a straight line.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_highbust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Highbust Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back down to Highbust Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Back to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_bust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Bust Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back down to Bust Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Bust Back to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust Back to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Lowbust Back down to Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_armfold_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Armfold Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip around Armscye down to Armfold Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_bust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Bust level, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down back to Bust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_highbust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Highbust level, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down back to Highbust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_center_to_highbust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder center to Highbust level, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation>From mid-Shoulder down back to Highbust level, aimed through Scapula.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_highhip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Front to Highhip Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Front to Highhip Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_hip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Front to Hip Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Front to Hip Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_highhip_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Side to Highhip Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Highhip Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_highhip_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Back to Highhip Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Back down to Highhip Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_hip_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Back to Hip Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front, over tape between Breastpoints, down to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_hip_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Side to Hip Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Hip Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_side_angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope Angle from Neck Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_side_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope length from Neck Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance between Neck Side and Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_back_angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope Angle from Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_back_height</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope length from Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance between Neck Back and Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_shoulder_tip_angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope Angle from Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_across_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Across Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation>From neck back, down to level of Across Back measurement.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_back_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation>Across Back to Waist back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation>From middle of Across Back down to Waist back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_shoulder_tip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Shoulder Tip, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip to Shoulder Tip, across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_chest_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation>Across Chest</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armscye to Armscye at narrowest width across chest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armfold_to_armfold_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation>Armfold to Armfold, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_shoulder_tip_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Shoulder Tip, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_chest_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation>Across Chest, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_shoulder_tip_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Shoulder Tip, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip to Shoulder Tip, across the back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_back_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Across Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armscye to Armscye at the narrowest width of the back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armfold_to_armfold_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation>Armfold to Armfold, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armfold to Armfold across the back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_shoulder_tip_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Shoulder Tip, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_back_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Across Back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_shoulder_tip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front to Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_shoulder_tip_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back to Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint to Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_neck_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Neck Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_lowbust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Lowbust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint down to Lowbust level, following curve of bust or chest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Waist level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_bustpoint_half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Bustpoint, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_neck_side_to_waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint, Neck Side to Waist level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_shoulder_tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint to Shoulder tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_bustpoint_halter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Bustpoint Halter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint around Neck Back down to other Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_shoulder_center</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Shoulder Center</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From center of Shoulder to Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_neck_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Neck Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front to Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip diagonal to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front diagonal to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_side_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist Side, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal across front to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip diagonal to Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_b_1in_offset</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back diagonal across back to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_side_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist Side, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal across back to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_armfold_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Armfold Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal to Armfold Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_armpit_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Highbust Side, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal across front to Highbust Side (Armpit).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_bust_side_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Bust Side, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Neck Side diagonal across front to Bust Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_armfold_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Armfold Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal to Armfold Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_armpit_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Highbust Side, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal across back to Highbust Side (Armpit).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_bust_side_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Bust Side, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Neck Side diagonal across back to Bust Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Wrist, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_elbow_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Elbow, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm, measure from Shoulder Tip to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow to Wrist, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_circ_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow circumference, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation>Elbow circumference, arm is bent.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip to Wrist bone, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder tip to Elbow Tip, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_to_wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow to Wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_armpit_to_wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Armpit to Wrist, inside</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armpit to ulna Wrist bone, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_armpit_to_elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Armpit to Elbow, inside</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armpit to inner Elbow, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_to_wrist_inside</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow to Wrist, inside</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_upper_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Upper Arm circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm circumference at Armpit level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_above_elbow_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Above Elbow circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm circumference at Bicep level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Elbow circumference, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_lower_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Lower Arm circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm circumference where lower arm is widest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_wrist_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Wrist circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation>Wrist circumference.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_armfold_line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Armfold line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip down to Armpit level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Side to Wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_finger_tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Side to Finger Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armscye_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Armscye: Circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armscye_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Armscye: Length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Shoulder Tip to Armpit.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armscye_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Armscye: Width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance between Armscye Front and Armscye Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_outer_elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck side to Elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_crotch_to_floor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Crotch to floor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_waist_side_to_floor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Waist Side to floor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side along curve to Hip level then straight down to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_thigh_upper_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Thigh Upper circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_thigh_mid_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Thigh Middle circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Thigh circumference about halfway between Crotch and Knee.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_knee_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Knee circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Knee circumference with straight leg.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_knee_small_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Knee Small circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Leg circumference just below the knee.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_calf_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Calf circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Calf circumference at the largest part of lower leg.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_ankle_high_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Ankle High circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation>Ankle circumference where the indentation at the back of the ankle is the deepest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_ankle_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Ankle circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Ankle circumference where front of leg meets the top of the foot.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_knee_circ_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Knee circumference, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation>Knee circumference with leg bent.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_ankle_diag_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Ankle diagonal circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation>Ankle circumference diagonal from top of foot to bottom of heel.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_crotch_to_ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Crotch to Ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_waist_side_to_ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Waist Side to Ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_waist_side_to_knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Waist Side to Knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>crotch_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation>Crotch length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Put tape across gap between buttocks at Hip level. Measure from Waist &quot;Front down between legs and up to Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>crotch_length_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation>Crotch length, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>crotch_length_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation>Crotch length, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_side_sitting</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, side, sitting</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side around hip curve down to surface, while seated on hard surface.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_diag</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, diagonal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back around Neck Side down to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_waist_halter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist to Waist Halter, around Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist level around Neck Back to Waist level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_natural_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Natural Waist circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_natural_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Natural Waist arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Side to Side at the Natural Waist level, across the front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_natural_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Natural Waist arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_natural_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Front to Natural Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Length from Waist Front to Natural Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_natural_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Back to Natural Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Length from Waist Back to Natural Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_back_to_elbow_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Back to Elbow, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_back_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Back to Wrist, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_elbow_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Side to Elbow, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Side to Wrist, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_across_back_center_to_elbow_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Across Back Center to Elbow, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_across_back_center_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Across Back Center to Wrist, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_armscye_back_center_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Armscye Back Center to Wrist, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_bust_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Bust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back, over Shoulder, to Bust Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_armfold_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Armfold Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back over Shoulder to Armfold Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_armfold_front_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back, over Shoulder, to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back, over Shoulder, down chest to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_back_over_shoulder_to_armfold_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Back, over Shoulder, to Armfold Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Back over Shoulder to Armfold Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_back_over_shoulder_to_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Back, over Shoulder, to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_armfold_front_to_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back, to Armfold Front, to Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_back_center_to_armfold_front_to_across_back_center</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Across Back Center, circled around Shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation>From center of Across Back, over Shoulder, under Arm, and return to start.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_armfold_front_to_highbust_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back, to Armfold Front, to Highbust Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armfold_to_armfold_bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Armfold to Armfold, front, curved through Bust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armfold_to_bust_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Armfold to Bust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_b_over_shoulder_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Back, over Shoulder, to Highbust level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armscye_arc</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation>Armscye: Arc</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>dart_width_shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Dart Width: Shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>dart_width_bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Dart Width: Bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>dart_width_waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Dart Width: Waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</translation>

--- a/share/translations/measurements_en_US.ts
+++ b/share/translations/measurements_en_US.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Total</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from crown of head to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_scapula</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Scapula</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Scapula (Blade point) to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_armpit</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Armpit</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Armpit to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Waist Side to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Hip level to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_gluteal_fold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Gluteal Fold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the fold at the back of the Knee to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_calf</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Calf</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the widest point of the calf to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_ankle_high</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Ankle High</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the deepest indentation of the back of the ankle to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from point where the front leg meets the foot to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_highhip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Highhip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Waist Front to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Bustpoint to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_shoulder_tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Shoulder Tip to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Neck Front to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Neck Side to the floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_back_to_knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Back to Knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_side_to_knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Side to Knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Waist Side to the fold at the back of the knee.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_side_to_hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Side to Hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the Waist Side to the Hip level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_knee_to_ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Knee to Ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_neck_back_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Neck Back to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>height_waist_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Height: Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation>Vertical height from Waist Back to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Shoulder Tip to Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Bust Side to Bust Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Waist Side to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Hip Side to Hip Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>width_abdomen_to_hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Width: Abdomen to Hip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>indent_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Indent: Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Scapula (Blade point) to the Neck Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>indent_waist_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Indent: Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>indent_ankle_high</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Indent: Ankle High</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_palm_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Palm length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Length from Wrist line to base of middle finger.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Length from Wrist line to end of middle finger.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_palm_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Palm width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure where Palm is widest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_palm_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Palm circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference where Palm is widest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Foot: Width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure at widest part of foot.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Foot: Length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure from back of heel to end of longest toe.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Foot: Circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure circumference around widest part of foot.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_instep_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Foot: Instep circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure circumference at tallest part of instep.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure circumference at largest level of head.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Head Crown to bottom of jaw.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_depth</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Depth</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from front of forehead to back of head.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance from Head Side to Head Side, where Head is widest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_crown_to_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Crown to Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_chin_to_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Head: Chin to Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_mid_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation>Neck circumference, midsection</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference of Neck midsection, about halfway between jaw and torso.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Neck circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Bust circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Bust, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around LowBust under the breasts, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Rib circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Waist circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Waist, following natural contours. Waists are  typically higher in back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hip circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Neck Side through Neck Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Bust arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bust Side to Bust Side across chest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>size</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation>Size</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation>Same as bust_arc_f.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Lowbust Side to Lowbust Side across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Rib arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Rib Side to Rib Side, across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Waist arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Waist Side across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highhip Side to Highhip Side across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Hip Side to Hip Side across Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Neck arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Bust arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Rib arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Waist arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Bust arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Rib arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Neck arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Bust arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Rib arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Waist arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Highhip arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_with_abdomen_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation>Hip arc with Abdomen, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>body_armfold_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation>Body circumference at Armfold level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure around arms and torso at Armfold level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>body_bust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation>Body circumference at Bust level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure around arms and torso at Bust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>body_torso_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation>Body circumference of full torso</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_circ_with_abdomen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation>Hip circumference, including Abdomen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_waist_flat_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Waist Front flat</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front down between breasts to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armpit_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Armpit to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armpit down to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_side_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Side, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist level, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down front to Waist level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_bustpoint_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist level, through Bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side over Bustpoint to Waist level, forming a straight line.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Highbust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Neck Front down to Highbust Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Front to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_bust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Bust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Bust Front to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust Front to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Lowbust Front down to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Rib Side to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From lowest rib at side down to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_armfold_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Armfold Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip around Armscye down to Armfold Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_bust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Bust level, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down front to Bust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Highbust level, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down front to Highbust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_center_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder center to Highbust level, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_side_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Side, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist level, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down back to Waist level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back down to Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_scapula_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist level, through Scapula</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side across Scapula down to Waist level, forming a straight line.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_highbust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Highbust Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back down to Highbust Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Back to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_bust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Bust Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back down to Bust Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Bust Back to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Lowbust Back to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Lowbust Back down to Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_armfold_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Armfold Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip around Armscye down to Armfold Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_bust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Bust level, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down back to Bust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_highbust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Highbust level, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side straight down back to Highbust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_center_to_highbust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder center to Highbust level, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation>From mid-Shoulder down back to Highbust level, aimed through Scapula.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_highhip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Front to Highhip Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Front to Highhip Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_hip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Front to Hip Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Front to Hip Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_highhip_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Side to Highhip Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Highhip Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_highhip_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Back to Highhip Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Back down to Highhip Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_hip_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Back to Hip Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_hip_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Side to Hip Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Hip Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_side_angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope Angle from Neck Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_side_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope length from Neck Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance between Neck Side and Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_back_angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope Angle from Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_back_height</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope length from Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance between Neck Back and Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_shoulder_tip_angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Slope Angle from Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_across_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Across Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation>From neck back, down to level of Across Back measurement.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_back_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation>Across Back to Waist back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation>From middle of Across Back down to Waist back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_shoulder_tip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Shoulder Tip, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip to Shoulder Tip, across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_chest_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation>Across Chest</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armscye to Armscye at narrowest width across chest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armfold_to_armfold_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation>Armfold to Armfold, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_shoulder_tip_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Shoulder Tip, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_chest_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation>Across Chest, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_shoulder_tip_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Shoulder Tip, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip to Shoulder Tip, across the back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_back_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Across Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armscye to Armscye at the narrowest width of the back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armfold_to_armfold_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation>Armfold to Armfold, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armfold to Armfold across the back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_shoulder_tip_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Shoulder Tip, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_back_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Across Back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_shoulder_tip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front to Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_shoulder_tip_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back to Shoulder Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Bustpoint</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint to Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_neck_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Neck Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_lowbust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Lowbust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint down to Lowbust level, following curve of bust or chest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Waist level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_bustpoint_half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Bustpoint, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_neck_side_to_waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint, Neck Side to Waist level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_shoulder_tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Shoulder Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint to Shoulder tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_bustpoint_halter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Bustpoint Halter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From Bustpoint around Neck Back down to other Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_shoulder_center</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Shoulder Center</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From center of Shoulder to Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustpoint_to_neck_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Bustpoint to Neck Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front to Bustpoint.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip diagonal to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Front to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front diagonal to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_side_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist Side, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal across front to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip diagonal to Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_b_1in_offset</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back diagonal across back to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_side_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Waist Side, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal across back to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_armfold_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Armfold Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal to Armfold Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_armpit_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Highbust Side, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal across front to Highbust Side (Armpit).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_bust_side_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Bust Side, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Neck Side diagonal across front to Bust Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_armfold_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Armfold Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal to Armfold Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_armpit_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Highbust Side, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side diagonal across back to Highbust Side (Armpit).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_bust_side_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Side to Bust Side, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Neck Side diagonal across back to Bust Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Wrist, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_elbow_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Elbow, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm, measure from Shoulder Tip to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow to Wrist, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_circ_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow circumference, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation>Elbow circumference, arm is bent.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip to Wrist bone, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder tip to Elbow Tip, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_to_wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow to Wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_armpit_to_wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Armpit to Wrist, inside</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armpit to ulna Wrist bone, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_armpit_to_elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Armpit to Elbow, inside</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armpit to inner Elbow, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_to_wrist_inside</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow to Wrist, inside</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_upper_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Upper Arm circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm circumference at Armpit level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_above_elbow_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Above Elbow circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm circumference at Bicep level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elbow_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Elbow circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Elbow circumference, arm straight.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_lower_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Lower Arm circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm circumference where lower arm is widest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_wrist_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Wrist circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation>Wrist circumference.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_shoulder_tip_to_armfold_line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Shoulder Tip to Armfold line</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Shoulder Tip down to Armpit level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Side to Wrist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_finger_tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Side to Finger Tip</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armscye_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Armscye: Circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armscye_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Armscye: Length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Shoulder Tip to Armpit.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armscye_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Armscye: Width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontal distance between Armscye Front and Armscye Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_outer_elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck side to Elbow</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_crotch_to_floor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Crotch to floor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_side_sitting</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_waist_side_to_floor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front, over tape between Breastpoints, down to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Waist Side to floor</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side along curve to Hip level then straight down to floor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_thigh_upper_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Thigh Upper circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_thigh_mid_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Thigh Middle circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Thigh circumference about halfway between Crotch and Knee.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_knee_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Knee circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Knee circumference with straight leg.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_knee_small_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Knee Small circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Leg circumference just below the knee.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_calf_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Calf circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Calf circumference at the largest part of lower leg.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_ankle_high_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Ankle High circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation>Ankle circumference where the indentation at the back of the ankle is the deepest.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_ankle_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Ankle circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Ankle circumference where front of leg meets the top of the foot.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_knee_circ_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Knee circumference, bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation>Knee circumference with leg bent.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_ankle_diag_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Ankle diagonal circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation>Ankle circumference diagonal from top of foot to bottom of heel.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_crotch_to_ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Crotch to Ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_waist_side_to_ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Waist Side to Ankle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leg_waist_side_to_knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Leg: Waist Side to Knee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>crotch_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation>Crotch length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>crotch_length_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation>Crotch length, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>crotch_length_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation>Crotch length, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, side, sitting</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist Side around hip curve down to surface, while seated on hard surface.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_diag</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, diagonal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rise_length_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation>Rise length, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back around Neck Side down to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_waist_halter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist to Waist Halter, around Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Waist level around Neck Back to Waist level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_natural_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Natural Waist circumference</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_natural_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Natural Waist arc, front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Side to Side at the Natural Waist level, across the front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_natural_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Natural Waist arc, back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_natural_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Front to Natural Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Length from Waist Front to Natural Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_natural_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Waist Back to Natural Waist Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Length from Waist Back to Natural Waist Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_back_to_elbow_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Back to Elbow, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_back_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Back to Wrist, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_elbow_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Side to Elbow, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_neck_side_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Neck Side to Wrist, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_across_back_center_to_elbow_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Across Back Center to Elbow, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_across_back_center_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Across Back Center to Wrist, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_armscye_back_center_to_wrist_bent</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Armscye Back Center to Wrist, high bend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_bust_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Bust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back, over Shoulder, to Bust Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_armfold_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back to Armfold Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back over Shoulder to Armfold Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_armfold_front_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back, over Shoulder, to Waist Side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back, over Shoulder, down chest to Waist Side.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_back_over_shoulder_to_armfold_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Back, over Shoulder, to Armfold Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Back over Shoulder to Armfold Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_back_over_shoulder_to_waist_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Back, over Shoulder, to Waist Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_armfold_front_to_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back, to Armfold Front, to Neck Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_back_center_to_armfold_front_to_across_back_center</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Across Back Center, circled around Shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation>From center of Across Back, over Shoulder, under Arm, and return to start.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_armfold_front_to_highbust_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Neck Back, to Armfold Front, to Highbust Back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armfold_to_armfold_bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Armfold to Armfold, front, curved through Bust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armfold_to_bust_front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Armfold to Bust Front</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_b_over_shoulder_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation>Highbust Back, over Shoulder, to Highbust level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armscye_arc</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation>Armscye: Arc</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>dart_width_shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Dart Width: Shoulder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>dart_width_bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Dart Width: Bust</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>dart_width_waist</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Dart Width: Waist</translation>

--- a/share/translations/measurements_es_ES.ts
+++ b/share/translations/measurements_es_ES.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Total</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde la coronilla de la cabeza al suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_cuello_trasero</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Cuello Trasero</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde el cuello trasero (vertebra cervical) hasta el suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_escapula</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Escapula</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical de la escapula (punta de la cuchilla) al suelo. </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_axila</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Axila</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical de la axila al suelo. </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_cintura_lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Cintura Lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical de la cintura lateral al suelo. </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_cadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Cadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical del nivel de la cadera al piso. </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_pliegue_glúteo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: pliegue del glúteo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde el pliegue del glúteo, donde el músculo del glúteo se encuentra con la parte superior de la parte posterior del muslo, hasta el suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_rodilla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Rodilla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde el pliegue en la parte posterior de la rodilla hasta el suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_pantorrilla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Pantorrilla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde el punto más ancho de la pantorrilla hasta el suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_alto_tobillo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Alto Tobillo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde la hendidura más profunda de la parte posterior del tobillo hasta el suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_tobillo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Tobillo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde el punto donde la parte delantera de la pierna se encuentra con el pie hasta el suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_alturadelacadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Altura de la Cadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde el nivel de la altura de la cadera, donde la parte delantera del abdomen es más prominente, hasta el suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_cintura_frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Cintura Frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde la parte delantera de la cintura hasta el suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_busto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Busto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde la altura donde el busto es mas prominente hasta el suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Altura_Hombro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Hombro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde el Hombro hasta el piso</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_cuello_frente</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Cuello Frente</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde el Cuello (delantera) hasta el piso</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_lado_cuello</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Lado del cuello</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde el lateral del cuello hasta el piso.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_posterior_desde_el_cuello_a_la_rodilla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: desde Nuca hasta rodilla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde la Nuca (vértebra cervical) hasta el pliegue posterior de la rodilla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Altura_lateral_cintura_rodilla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Lateral de la cintura a la rodilla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde el costado de la cintura hasta el pliegue de la rodilla.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_lateral_de_cintura_a_cadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Lado de la cintura a la cadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical lateral desde la cintura al nivel de la cadera. </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Altura_Rodilla_Tobillo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Rodilla a Tobillo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde el pliegue de la rodilla hasta el lugar donde la parte delantera de la pierna se encuentra con el pie..</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_desde_Nuca_hasta_el_lateral_de_Cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: desde Nuca hasta el lateral de la Cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde la Nuca hasta el lateral la Cintura. (&apos;Altura: Nuca&apos; - &apos;Altura: lateral de Cintura&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ancho_hombro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Ancho: Hombro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia horizontal desde extremo de hombro a extremo de hombro.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ancho_busto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Ancho: Busto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia horizontal desde lado del busto a lado del busto.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ancho_cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Ancho: Cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia horizontal de lado de cintura a lado de cintura.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ancho_caderas</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Ancho: Cadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia horizontal de un lado de la cadera al otro lado de la cadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ancho_abdomen_a_cadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Ancho: Abdomen a cadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia horizontal de la mayor prominencia del abdomen a la mayor prominencia de la cadera.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>indent_neck_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Marcar: Parte trasera del cuello</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia horizontal desde Omóplato (punto de hoja) a la parte trasera del cuello.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>indent_waist_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Marcar: Parte trasera de la cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia horizontal entre un palo liso, puesto para tocar Cadera y Omóplato, y parte trasera de la cintura.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>indent_ankle_high</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Marcar: Tobillo Alto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>longitud_palma_mano</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation>Mano: Longitud de la palma</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Longitud de la línea de la muñeca hasta la base del dedo medio.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>longitud_mano</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Mano: Longitud</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Longitud de la línea de la muñeca hasta la punta del dedo medio.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ancho_palma_mano</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation>Mano: Ancho de la palma</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Medida donde la palma es mas ancha.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>circ_palma_mano</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Mano: Circunferencia de la palma</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Circunferencia donde la palma es mas ancha.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>circ_mano</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Mano: Circunferencia</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation>Alforza con el pulgar hacia el dedo más pequeño, juntar los dedos. Medida de la circunferencia alrededor de la parte más ancha de la mano.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ancho_pie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Pie: Ancho</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Medida en la parte más ancha del pie.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>longitud_pie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Pie: Longitud</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation>Medida desde la parte posterior del talón hasta el final del dedo más largo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>circ_pie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Pie: Circunferencia</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Medida de la circunferencia en la parte más ancha del pie.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_instep_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Pie: Circunferencia del empeine</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation>Medida de la circunferencia en la parte más ancha del arco.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Cabeza: Circunferencia</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Medida de la circunferencia en la parte más alta de la cabeza.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>head_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Cabeza: longitud</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde la coronilla de la cabeza a la base de la mandíbula.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>profundidad_de_cabeza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation>Cabeza: Profundidad</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia horizontal desde la frente hasta la parte posterior de la cabeza.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ancho_de_cabeza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Cabeza: ancho</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia horizontal desde un costado de la cabeza al otro, en el lugar que la cabeza es más ancha.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>coronilla_hasta_nuca</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Cabeza: desde la coronilla hasta la nuca</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde la Coronilla hasta la Nuca. (&apos;Altura: Total&apos; - &apos;Altura: Nuca&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>mentón_hasta_nuca</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Cabeza: desde el Mentón hasta la Nuca</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical desde el Mentón hasta la Nuca. (&apos;Altura&apos; -&apos;Altura: Nuca&apos; - ´Cabeza: Altura&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_mid_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation>Circunferencia del cuello, sección central</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation>Circunferencia de la sección central del cuello, a medio camino entre mandíbula y rorso.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circunferencia del cuello</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Circunferencia del cuello en la base del Cuello, tocando la parte trasera del Cuello, Lados del Cuello, y Parte frontal del Cuello.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circunferencia del pecho alto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation>Circunferencia en el pecho alto, siguiendo a una distancia corta entre los pliegues del brazo sobre el tórax, alto bajo las axilas.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circunferencia del busto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circunferencia alrededor del busto, paralela al suelo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circunferencia del busto bajo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circunferencia alrededor del pecho bajo, bajo los pechos, paralela al suelo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circunferencia de costilla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circunferencia alrededor de las costillas al nivel de la costilla más baja por el lado, paralela al suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circunferencia de cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circunferencia de cadera alta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation>Circunferencia alrededor de la cintura, siguiendo los contornos naturales. Las caderas son normalmente más altas en la espalda.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_Cintura_posterior</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Cintura posterior</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circunferencia alrededor de la cadera alta, donde el abultamiento del abdomen es mayor, paralela al suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circunferencia de cadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circunferencia alrededor de la cadera donde el abultamiento de la cadera es mayor, paralela al suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del cuello, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>De lado del cuello a lado del cuello a través de la parte frontal del cuello.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del busto alto, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el lado del busto alto (axila) a lado del busto alto (axila) a través del tórax.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del busto, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde lado del busto a lado del busto a través del tórax.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del busto bajo, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde lado del busto bajo a lado del busto bajo a través de la parte frontal.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de costilla, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>De lado de la costilla a lado de la costilla, a través de la parte frontal.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de la cintura, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde lado de la cintura a lado de la cintura a través de la parte frontal.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de la cadera alta, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde lado de la cadera alta a lado de la cadera alta a través de la parte frontal.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de la cadera, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde lado de la cadera a lado de la cadera a través de la parte frontal.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del cuello, parte frontal, parte media</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad del &apos;Arco del cuello, parte frontal&apos;. (&apos;Arco del cuello, parte frontal&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del busto alto, parte frontal, parte media</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad del &apos;Arco del busto alto, parte frontal&apos;. Desde la parte frontal del Busto alto hasta el lado del Busto alto. (&apos;Arco del busto alto,  parte frontal&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Bust arc, front, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad del &apos;Arco del busto, parte frontal&apos;. (&apos;Arco del busto, parte frontal&apos;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del busto bajo, parte frontal, parte media</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad del &apos;Arco del busto bajo, parte frontal&apos;.  (&apos;Arco del busto bajo, parte frontal&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de la costilla, parte frontal, parte media</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad del &apos;Arco de la costilla, parte frontal&apos;. (&apos;Arco de la costilla, parte frontal&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de la cintura, parte frontal, parte media</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad del &apos;Arco de la cintura, parte frontal&apos;. (&apos;Arco de la cintura, parte frontal&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de la cadera alta, parte frontal, parte media</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad del &apos;Arco de la cadera alta, parte media&apos;.  (&apos;Arco de la cadera alta, parte media&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_half_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de la cadera, parte frontal, parte media</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad de &apos;Arco de la cadera, parte frontal&apos;. (&apos;Arco de la cadera, parte frontal&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del cuello, parte trasera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Desde Lado del Cuello a Lado del Cuello a través de la parte trasera. (&apos;Circunferencia del cuello&apos; - &apos;Arco del cuello, parte frontal&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del busto alto, parte trasera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el Lado del busto alto a Lado del busto alto. (&apos;Circunferencia del busto alto&apos; - &apos;Arco del busto alto, parte frontal&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del busto, parte trasera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el Lado del busto a Lado del busto a través de la parte trasera. (&apos;Circunferencia del busto&apos; - &apos;Arco del busto, parte frontal&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del busto bajo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Desde Lado del busto bajo a Lado del busto bajo a través de la parte trasera.  (&apos;Circunferencia del busto bajo&apos; - &apos;Arco del busto alto, parte frontal&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de la costilla, parte trasera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Desde Lado de la Costilla hasta Lado de la Costilla a través de la parte trasera. (&apos;Circunferencia de la costilla&apos; - &apos;Arco de la costilla, parte frontal&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de la cintura, parte trasera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Desde Lado de la Cintura a Lado de la Cintura a través de la parte trasera. (&apos;Circunferencia de la cintura&apos; - &apos;Arco de la cintura, parte frontal&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de la cadera alta, parte trasera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Desde Lado de la cadera alta a Lado de la cadera alta a través de la parte trasera. (&apos;Circunferencia de la cadera alta&apos; - &apos;Arco de la cadera alta, parte frontal&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de la cadera, parte trasera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Desde Lado de la cadera a Lado de la Cadera a través de la parte trasera. (&apos;Circunferencia de la cadera&apos; - &apos;Arco de la cadera, parte frontal&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del cuello, parte trasera, parte media</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad de &apos;Arco del cuello, parte trasera&apos;. (&apos;Arco del cuello, parte trasera&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del busto alto, parte trasera, parte media</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad del &apos;Arco del busto alto, parte trasera&apos;. Desde parte trasera del busto alto hasta el lado del busto alto. (&apos;Arco del busto alto, parte trasera&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del busto, parte trasera, parte media</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad del &apos;Arco del busto, parte trasera&apos;. (&apos;Arco del busto, parte trasera&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arco del busto bajo, parte trasera, parte media</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad del &apos;Arco del busto bajo, parte trasera&apos;. (&apos;Arco del busto bajo, parte trasera&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Rib arc, back, half</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad del &apos;Arco de la costilla, parte trasera&apos;. (&apos;Arco de la costilla, parte trasera&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de la cintura, parte trasera, parte media</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad de &apos;Arco de la cintura, parte trasera&apos;. (&apos;Arco de la cintura, parte trasera&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highhip_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de la cadera alta, parte trasera, parte media</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad de &apos;Arco de la cadera alta, parte trasera&apos;. Desde parte trasera de la cadera alta hasta el lado del busto alto. (&apos;Arco de la cadera alta, parte trasera&apos;/ 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_arc_half_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de la cadera, parte trasera, parte media</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Mitad de &apos;Arco de la cadera, parte trasera&apos;. (&apos;Arco de la cadera, parte trasera&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_with_abdomen_arc_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation>Arco de cadera con Abdomen, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>body_armfold_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation>Circunferencia del cuerpo al nivel del pliegue del brazo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation>Medir alrededor de los brazos y el torso al nivel del pliegue del brazo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>body_bust_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation>Circunferencia del cuerpo al nivel del busto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Medir alrededor de los brazos y el torso al nivel del busto.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>body_torso_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation>Circunferencia del cuerpo del torso completo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation>Circunferencia alrededor del torso desde la mitad del hombro alrededor de la entrepierna y vuelta a mitad del hombro.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hip_circ_with_abdomen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation>Circunferencia de la cadera, incluyendo el Abdomen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation>Medida a nivel de la Cadera, incluyendo la profundidad del Abdomen. (Arco de la cadera, parte trasera + Arco de la cadera con abdomen, parte frontal).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Parte frontal del cuello hasta parte frontal de la cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_waist_flat_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation>Parte frontal del cuello a parte frontal de la cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde parte frontal del cuello por entre los pechos hasta la parte frontal de la cintura.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armpit_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la axila hasta el lado de la cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la Axila hasta el lado de la cintura.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_side_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el extremo del hombro hasta el lado de la cintura, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el extremo del hombro, curvando alrededor de la parte frontal de la sisa del brazo, después bajando hasta el lado de la cintura.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el lado del cuello hasta el nivel de la cintura, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el lado del cuello hasta la parte frontal del nivel de la cintura.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_bustpoint_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Desde lado del cuello hasta el nivel de la cintura, a través del busto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde lado del cuello sobre el busto hasta el nivel de la cintura, formando una línea recta.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte frontal del cuello hasta la parte frontal del busto alto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la parte frontal del cuello hasta la parte frontal del busto alto.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte frontal del busto alto hasta la parte frontal de la cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_front_to_bust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte frontal del cuello hasta la parte frontal del busto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte frontal del busto hasta la parte frontal de la cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la parte frontal del busto hasta el nivel de la cintura. (&apos;Parte frontal del cuello hasta parte frontal de la cintura&apos; - &apos;Parte frontal del cuello hasta parte frontal del busto&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_to_waist_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte frontal del busto bajo hasta la parte frontal de la cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la parte frontal del busto bajo hasta la parte frontal de la cintura.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_to_waist_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el lado de la costilla hasta el lado de la cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el lado de la costilla más baja hasta el lado de la cintura.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_armfold_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el extremo del hombro hasta la parte frontal del pliegue del brazo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el extremo del hombro alrededor de la sisa hasta la parte frontal del pliegue del brazo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_bust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el lado del cuello hasta el nivel del busto, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Recto desde el lado del cuello hasta la parte frontal del nivel del busto.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el lado del cuello hasta el nivel del busto alto, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el lado del cuello hasta la parte frontal del nivel del busto alto.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_center_to_highbust_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el centro del hombro hasta el nivel del busto alto, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la mitad del hombro por delante hasta el nivel del busto alto, dirigido a la cima del pecho.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_waist_side_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el extremo del hombro hasta el ladode la cintura, parte trasera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el extremo del hombro, curvando alrededor de la parte trasera de la axila, después bajar hasta el lado de la cintura.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el ladodel cuello hasta el nivel de la cintura, parte trasera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el lado del cuello recto hasta el nivel de la cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte trasera del cuello hasta la parte trasera de la cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la parte trasera del cuello hasta la parte trasera de la cintura.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_waist_scapula_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el lado del cuello hasta el nivel de la cintura, a través del omóplato</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el lado del cuello a través del omóplato hasta el nivel de la cintura, formando una línea recta.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_highbust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte trasera del cuello hasta la parte trasera del busto alto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la parte trasera del cuello hasta la parte trasera del busto alto.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>highbust_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte trasera del busto alto hasta la parte trasera de la cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la parte trasera del busto alto hasta la parte trasera de la cintura. (&apos;Desde la parte trasera del cuello hasta la parte trasera de la cintura&apos; - &apos;Desde la parte trasera del cuello hasta la parte trasera del busto alto&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_bust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte trasera del cuello hasta la parte trasera del busto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la parte trasera del cuello hasta la parte trasera del busto.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bust_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte trasera del busto hasta la parte trasera de la cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la parte trasera del busto hasta el nivel de la cintura. (&apos;Desde la parte trasera del cuello hasta la parte trasera de la cintura&apos; - &apos;Desde la parte trasera del cuello hasta la parte trasera del busto&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lowbust_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte trasera del busto bajo hasta la parte trasera de la cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la parte trasera del busto bajo hasta la parte trasera de la cintura.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_armfold_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el extremo del hombro hasta la parte trasera del pliegue del brazo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el extremo del hombro alrededor de la sisa hasta la parte trasera del pliegue del brazo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_bust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el lado del cuello hasta el nivel del busto, parte trasera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el lado del cuello recto hasta el nivel del busto.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_side_to_highbust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el lado del cuello hasta el nivel del busto alto, parte trasera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el lado del cuello recto hasta el nivel del busto alto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_center_to_highbust_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el centro del hombro hasta el nivel del busto alto, parte trasera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la mitad del hombro hasta el nivel del busto alto, a través del omóplato.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_highhip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte frontal de la cintura hasta la parte frontal de la cadera alta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la parte frontal de la cintura hasta la parte frontal de la cadera alta.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_hip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte frontal de la cintura hasta la parte frontal de la cadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la parte frontal de la cintura hasta la parte frontal de la cadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_highhip_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el lado de la cintura hasta el lado de la cadera alta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el lado de la cintura hasta el lado de la cadera alta.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_highhip_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte trasera de la cintura hasta la parte trasera de la cadera alta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la parte trasera de la cintura hasta la parte trasera de la cadera alta.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_hip_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte trasera de la cintura hasta la parte trasera de la cadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>waist_to_hip_side</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el lado de la cintura hasta el lado de la cadera</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el lado de la cintura hasta el lado de la cadera.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_side_angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el ángulo de inclinación del hombro hasta el lado del cuello</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el ángulo formado por línea desde el lado del cuello hasta el final del hombro y desde la línea del lado del cuello paralelo al suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_side_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la longitud de la inclinación del hombro hasta el lado del cuello</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical entre el lado del cuello y el final del hombro.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_back_angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Ángulo de inclinación del hombro desde la parte trasera del cuello</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el ángulo formado por la línea desde la parte trasera del cuello hasta el final del hombro y la línea formada por la parte trasera del cuello paralela al suelo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_neck_back_height</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Longitud de la inclinación del hombro desde la parte trasera del cuello</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Distancia vertical entre el lado del cuello y el final del hombro.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_slope_shoulder_tip_angle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el ángulo de inclinación del hombro hasta el final del hombro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Ángulo formado por la línea desde el lado del cuello hasta el final del hombro y la línea vertical del final del hombro.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>neck_back_to_across_back</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Desde la parte trasera del cuello a través de la espalda</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la parte trasera del cuello a través de la medida del la espalda.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_back_to_waist_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation>A través de la espalda hasta la parte trasera de la cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la mitad de la espalda hasta la parte trasera de la cintura.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>longitud_hombro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation>Longitud del hombro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde el lado del cuello hasta lo alto del hombro.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>shoulder_tip_to_shoulder_tip_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde lo alto del hombro hasta lo alto del hombro, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde lo alto del hombro hasta lo alto del hombro, a través de la parte frontal.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>across_chest_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation>A través del tórax</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Desde la sisa hasta la sisa en el ancho más estrecho a través del tórax.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armfold_to_armfold_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation>Desde el brazo hasta el brazo, parte frontal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>separación_pechos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>longitud_entrepierna</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>

--- a/share/translations/measurements_fi_FI.ts
+++ b/share/translations/measurements_fi_FI.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Yhteensä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys pään latvusta lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_niska_selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Kaula takana</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys niskan selästä (kaulannikama) lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_lapaluu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: lapaluu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys lapaluusta (terän kärjestä) lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_kainalo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: kainalo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys kainalosta lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_vyötärön_sivupuoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Vyötärön puoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys vyötärön puolelta lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_lonkka</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Lantio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuuntainen etäisyys lantiosta lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_pakarapoimu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Pakarataitto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys pakarapoimusta, jossa pakaralihas kohtaa reiden takaosan, lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_polvi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Polvi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuuntainen etäisyys polven takana olevasta taiteesta lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pituus_pohje</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: pohje</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys pohkeen leveimmästä kohdasta lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_nilkka_korkea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Nilkka korkea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuuntainen etäisyys nilkan takaosan syvimmästä syvennyksestä lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_nilkka</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Nilkka</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys kohdasta, jossa etujalka kohtaa jalan, lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_korkealantio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Korkea lantio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys korkeasta lantiosta, jossa etuvatsa on näkyvin, lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_vyötärön_etu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Vyötärö edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys vyötärön etuosasta lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_rintapiste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Rintakehä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys rintakuvasta lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_olkapää_kärki</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Olkapää</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys olkapäästä lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_kaulan_etupuoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Kaula edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys kaulan etuosasta lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_kaulan_sivupuoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Kaulan puolella</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuuntainen etäisyys kaulan puolelta lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_kaulan_selkä_polveen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Niska selästä polveen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys niskan selästä (kaulannikama) polven takaosan poimuon.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_vyötärön_puolelta_polveen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Vyötäröltä polveen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys vyötärön puolelta polven takaosan taitteeseen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_vyötärön_sivulta_lantioon</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Vyötäröltä lantioon</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuuntainen etäisyys vyötärön puolelta lantion tasolle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_polvesta_nilkkaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Polvesta nilkkaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuuntainen etäisyys polven takaosassa olevasta poimusta pisteeseen, jossa etujalka kohtaa jalan yläosan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_kaulan_selkä_vyötärön_puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Takaa niskassa, vyötärön puolelta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys kaulasta selästä vyötärön puolelle. (&apos;Korkeus: Kaula Selkä&apos; - &apos;Korkeus: Vyötäröpuoli&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation>Pystykorkeus vyötäröstä lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leveys_olkapää</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Leveys: Olkapäät</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Vaakasuora etäisyys olkapäästä olkapäähän.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leveys_rintakuva</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Leveys: Rinta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Vaakasuora etäisyys rinnan puolelta rinnan puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leveys_vyötärö</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Leveys: Vyötärö</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Vaakasuora etäisyys vyötärön puolelta vyötärön puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leveys_lantio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Leveys: Lantio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Vaakasuora etäisyys lonkkapuolelta lantion puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>leveys_vatsa_lantioon</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Leveys: Vatsasta lantioon</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation>Vaakasuora etäisyys suurimmasta vatsan ulkonemasta suurimpaan lantion ulkonemaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>syvennys_niska_taakse</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Sisennys: Kaula takana</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Vaakasuora etäisyys lapaluusta (terän kärjestä) niskaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>syvennys_vyötäröllä_takaisin</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Sisennys: Vyötärö takana</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Vaakasuora etäisyys litteän tikun, joka on asetettu koskettamaan lantiota ja lapaluuta, ja vyötärön selkänojan välillä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>sisennys_nilkka_korkea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Sisennys: Nilkka korkea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kämmenen_pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation>Käsi: Kämmenen pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Pituus ranteesta keskisormen tyveen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käden_pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Käsi: pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Pituus ranteesta keskisormen päähän.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kämmenen_leveys</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation>Käsi: Kämmenen leveys</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Mittaa missä kämmen on levein.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kämmen_ympäyrysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Käsi: Kämmenen ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Ympärysmitta, jossa kämmen on levein.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käden_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Käsi: Ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation>Työnnä peukalo pienintä sormea kohti, tuo sormet lähelle toisiaan. Mittaa ympärysmitta käden leveimmästä osasta.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalka_leveys</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Jalka: Leveys</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Mittaa jalan leveimmästä kohdasta.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalan_pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Jalan pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation>Mittaa kantapään takaa pisimmän varpaan loppuun.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalan_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jalkapää: Ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Mittaa ympärysmitta jalan leveimmästä osasta.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalka_jalkaterän_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jalkapää: Jalkapään ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation>Mittaa ympärysmitta jalkapohjan korkeimmasta kohdasta.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pään_ympäryysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Pään ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Mittaa ympärysmitta pään suurimmalta tasolta.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pään_pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Pää: Pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys pään kruunusta leuan pohjaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pään_syvyys</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation>Pää: Syvyys</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Vaakasuora etäisyys otsan etuosasta pään takaosaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pään_leveys</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Pää: Leveys</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Vaakasuora etäisyys pään puolelta pään puolelle, jossa pää on levein.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>päälaesta_selkään</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>päälaelta kaulaan ja selkään</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys kruunusta niskaan. (&apos;Korkeus: Kokonaiskorkeus - &apos;Korkeus: Kaula Selkä &apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pää_leuka_niskaan_takaisin</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Pää: Leuasta kaulaan takaisin</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuuntainen etäisyys leuasta niskaan. (&quot;Korkeus&quot; - &quot;Korkeus: Kaula Selkä&quot; - &quot;Pää: Pituus&quot;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaulan_keskeltä_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan ympärysmitta, keskiosa</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan keskiosan ympärysmitta, noin leuan ja vartalon puolivälissä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaulan_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan ympärysmitta niskan tyvessä, koskettaa niskan takaosaa, kaulan sivuja ja kaulan etuosaa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkea_rintakehän_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Korkea rintakehän ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation>Ympärysmitta korkea rinnan kohdalla, seuraa lyhyintä etäisyyttä käsivarsien välillä rinnassa, korkea kainaloiden alla.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakehä_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Rintakehän ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Ympärysmitta rinnan ympärillä, yhdensuuntainen lattian kanssa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>alarintakaaren_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Matala rintakehän ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Ympärysmitta LowBustin ympärillä rintojen alla, yhdensuuntainen lattian kanssa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kylkien_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Kylkiluiden ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Ympärysmitta kylkiluiden ympärillä alimman kylkiluun tasolla, yhdensuuntainen lattian kanssa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötärön_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Vyötärönympärys</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkea_lantio_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Korkea lantion ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötärönympärys luonnollisia muotoja noudattaen. Vyötärö on yleensä korkeampi takaa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkeus_vyötärön_selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Korkeus: Vyötärö Selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation>Vaakasuora Etäisyys litteän, kohtisuoraan kantapäätä vastaan asetetun sauvan ja nilkan suurimman sisennyksen välillä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Ympärysmitta Highhipin ympärillä, jossa vatsan ulkonema on suurin, yhdensuuntainen lattian kanssa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lonkan_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Lantion ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Ympärysmitta lonkan ympärillä, missä lonkan ulkonema on suurin, yhdensuuntainen lattian kanssa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaulan_kaari_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan kaari, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta kaulan puolelle kaulan etuosan kautta.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkea_rintakuva_kaari_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Korkea rinnan kaari, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Korkeasta rinnan puolelta (kanalosta) korkealle rinnan puolelle (kanalosta) rinnassa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakuva_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Rinnan kaari, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Rinnan puolelta rinnan puolelle rinnan yli.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>koko</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation>Koko</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation>Sama kuin rintakuva_kaari_f.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>alhainen_kaari_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Matala kaari, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Matalarintaisesta puolelle alimmaiseen etupuolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kylkiluiden_kaari_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Kylkiluiden kaari, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Kylkiluusta puolelta kylkiluulle Sivulle, poikki edessä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötärön_kaari_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Vyötärön kaari, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötäröpuolelta vyötärön puolelle edestä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korke_lonkka_kaari_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Korkea kaari, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Lakan puolelta korkean lonkan puolelle edestä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lonkkakaari_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Lantiokaari, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Lantiopuolelta lantion puolelle edestä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_kaari_puolikas_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan kaari, edessä, puolikas</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &apos;Kaulan kaaresta, edessä&apos;. (&apos;Niskakaari, edessä&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkea_rintakuva_kaari_puoli_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Korkea rinnan kaari, edestä, puoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &quot;korkea rintakuva, edessä&quot;. Korkeasta rintakuvasta edestä korkean rintakuvan puolelle. (&quot;korkea rintakuva, edessä&quot; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakuva_puoli_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Rinnan kaari, edessä, puoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &apos;rintakaaresta, edessä&apos;. (&apos;Rintakaare, edessä&apos;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>alhainen_kaari_puoli_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Matalarin kaari, edessä, puoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &apos;Matala kaaresta, edessä. (&apos;Matala kaari, edessä&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kylkiluiden_kaari_puoli_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Kylkiluidenekaari, edessä, puolikas</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &quot;kylkiluukaaresta, edessä&quot;. (&apos;kylkiluiden kaari, edessä&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötärön_kaari_puoli_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Vyötärökaare, edessä, puolikas</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &apos;vyötärön kaaresta, edessä&apos;. (&apos;Vyötärökaare, edessä&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkea_lonkka_kaari_puoli_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Korkea lonkkakaari, edessä, puoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &apos;korkeasta kaaresta, edessä&apos;. (&apos;Korkea kaari, edessä&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lonkkakaari_puoli_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Lonkkakaari, edessä, puolikas</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &apos;lonkkakaaresta, edessä&apos;. (&apos;lonkkakaari, edessä&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaulakaari_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan kaari, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta kaulan puolelle selän poikki. (&apos;Kaulan ympärysmitta&apos; - &apos;Kaulan kaari, edessä&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkearinteinen_kaari_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Korkea kaari, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Korkeasta rinnan puolelta korkealle rintakehän puolelle selän poikki. (&apos;korkea rinnan ympärysmitta&apos; - &quot;korkea rinnan kaari, edessä&quot;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakuva_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Rinnan kaari, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Rintapuolen puolelta takapuolen puolelle. (&apos;Rintakehän ympärysmitta&apos; - &apos;Rintakaare, edessä&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>alhainen_kaari_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Matala kaari, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Matalarin puolelta selän poikki. (&apos;matala rintakehän ympärysmitta&apos; - &apos;Matalin kaari, edessä&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kylkiluiden_kaari_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Kylkiluiden kaarre selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Kylkiluusta puolelta selän poikki. (&apos;kylkiluiden ympärysmitta&apos; - &apos;kylkiluun kaari, edessä&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötärökaari_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Vyötärönympärys, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötäröltä vyötärön puolelle selkäpuolelle. (&apos;Vyötärönympärys&apos; - &apos;Vyötärökaare, edessä&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkea_kaari_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Korkea kaari, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Korkealta lantion puolelta korkealle lantion puolelle selän yli. (&quot;Korkea lantion ympärysmitta&quot; - &quot;Korkea lantion kaari, edessä&quot;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lonkkakaari_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Lonkkakaari, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Lantiopuolelta lantion puolelle selän poikki. (&apos;lonkan ympärysmitta&apos; - &apos;lonkkakaari, edessä&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_kaari_puolikas_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan kaari, selkä, puoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &apos;Niskakaari, selkä&apos;. (&apos;Niskakaari, selkä&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkearinteinen_kaari_puolikas_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Korkearinta kaari, selkä, puoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &quot;korkea rintakuva, selkä&quot;. Korkeasta rintakehästä takaa korkealle rinnan puolelle. (&apos;korkea rintakuva, selkä&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakehän_kaari_puolikas_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Rinnan kaari, selkä, puoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet rintakaaresta, takaosa&apos;. (&apos;Rintakaare, takaosa&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>alarintakaaren_puolisko_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Matalarin kaari, selkä, puoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &quot;Matala rintakuva, selkä&quot;. (&apos;Matala rintakuva, selkä&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kylkiluu_puolikas_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Kylkiluiden kaari, selkä, puolikas</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &apos;rivan kaaresta, selästä&apos;. (&apos;Ruokaari, takaosa&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötärön_kaari_puolikas_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Vyötärön  kaari, selkä, puoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &apos;vyötärön kaari, selkä&apos;. (&apos;Vyötärönympärys, selkä&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkean_lantion_kaari_puolikas_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Korkea lantion kaari, selkä, puoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &quot;Korkea lonkkakaari, selkä&quot;. Korkeasta lonkasta takaisin korkean rinnan puolelle. (&quot;Korkea lonkkakaari, selkä&quot;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lonkkakaari_puolikas_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Lonkkakaari, selkä, puoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &apos;lonkkakaari, selkä&apos;. (&apos;lonkkakaari, selkä&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lonkka_vatsan_kaaren_kanssa</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation>Lonkkakaaressa vatsa, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vartalon_käsivarre_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation>Vartalon ympärysmitta käsivarsien tasossa</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation>Mittaa käsivarsien ja vartalon ympäriltä käsivarsien tasolta.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kehon_rintakuva_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation>Kehon ympärysmitta rinnan tasolla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Mittaa käsivarsien ja vartalon ympäriltä rinnan tasolla.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vartalo_vartalo_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation>Koko vartalon ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation>Ympärysmitta vartalon puolivälistä olkapäiden ympäriltä takaisin olkapäiden puoliväliin.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lonkan_ympyrä_vatsalla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation>Lantion ympärysmitta, mukaan lukien vatsa</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation>Mittaus lantion tasolla, mukaan lukien vatsan syvyys. (Lankkakaari, selkä + lonkkakaari vatsalla, edessä).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_edessä_vyötäröön_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula edestä vyötärölle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_edessä_vyötärölle_tasainen_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula edestä vyötärön edestä tasainen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaula-edusta alas rintojen välistä vyötärölle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kainalosta_vyötärön_puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Kainalosta vyötärön puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Kainalosta alas vyötärön puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_vyötärölle_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapää vyötärön puolelle, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Olkapäästä kaartuu käsivarren ympärille, sitten alas vyötärön puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_puolelta_vyötäröön_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula sivulta vyötärön tasolle, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta suoraan edestä vyötärön tasolle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_puolelta_vyötärön_rintakohtaan_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan puolelta vyötärön tasolle, rinnan läpi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta Bustpointin yli vyötärön tasolle muodostaen suoran linjan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_edestä_korkeaan_rintakehän_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula edestä korkealle rinnalle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Pääntie edestä korkealle rinnalle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkea_rintakehä_vyötärölle_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>korkea rintakehä edestä vyötärölle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_edestä_rintakehään_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula edestä rinnan eteen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakehä_vyötärölle_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Rinnasta edestä vyötärölle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Rinnasta edestä vyötärön tasolle. (&quot;Kaulan edestä vyötärölle&quot; - &quot;Kaulan edestä rinnan eteen&quot;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>alhaalta_vyötärölle_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Matalarinta edestä vyötärölle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Matalasta rinnasta edestä alas vyötärölle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötäröstä_kyljen_sivulle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>kylkiluiden puolelta vyötärön puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Alimmasta kyljestä alas vyötärölle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_kädenpää_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapää kädensijaan eteen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Olkapäästä käsivarsivyön ympärillä käsivarsinauhan eteen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_puolelta_rintakehään_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula Sivulta rinnan tasolle, edestä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta suoraan edestä rinnan tasolle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaulan_puoli_korkeaan_rintakuvaan_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan puolelta korkealle rinnan tasolle, edestä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta suoraan alas edestä korkealle rinnan tasolle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_keskuksesta_korkeaan_rintakuvaan_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Hartioiden keskeltä korkealle rinnan tasolle, edestä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Hartioiden keskiosasta alas edestä korkea rinnan tasoon, suunnattu rintakuvaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_vyötärölle_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapää vyötärön puolelle, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Olkapäästä kaartuva käsivarsivyön ympärille, sitten alas vyötärön puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>niskasta_vyötärölle_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula sivulta vyötärön tasolle, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta suoraan alas takaisin vyötärön tasolle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_selkä_vyötärölle_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula takaa vyötärölle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulasta selästä alas vyötärölle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_puolelta_vyötärölle_lapaluun_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan puolelta vyötärön tasolle, lapaluun läpi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta lapaluun poikki alas vyötärön tasolle muodostaen suoran linjan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>niska_selkä_korkea_rinnalle_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula takaa korkean rintakehän selän</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulasta selästä korkearintaiseen selkään.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkea_rintakehä_vyötärölle_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Korkea rintakehä takaa vyötärölle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Highbust-selästä alas vyötärölle. (&apos;Niska selkä vyötärölle&apos; - &apos;niska selkä korkearintoiseen selkään&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_selkä_rintakehään_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula selästä rintakehään</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulasta selästä alas rintaselkään.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakehä_vyötärölle_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Rinta takaa vyötärölle takaisin</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Rinnasta takaisin vyötärön tasolle. (&apos;Kaulan selkä vyötärölle&apos; - &apos;Kaula selkä rinnan selkään&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>alhaalta_vyötärölle_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Matala selkä vyötärölle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Matalasta rinnasta alas vyötärölle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_käden_tappiin_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapään kärki käsivarret selkään</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Olkapäästä käsivarsivyön ympärillä käsivarsinauhan selkään.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_puolelta_rintakehään_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula Sivulta rinnan tasolle, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta suoraan alas takaisin rintatasolle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaulan_puolelta_korkealle_rintakehään_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan puolelta korkealle rinnan tasolle, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta suoraan alas takaisin korkealle rinnan tasolle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_keskuksesta_korkeaan_rintakehään_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Hartioiden keskeltä korkea rinnan tasolle, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation>Hartioiden puolivälistä alas takaisin korkeaan rinnan tasoon, suunnattu lapaluun läpi.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötäröstä_korkeaan_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Vyötärö edestä korkeaan lantioon</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötäröstä korkealle lantiolle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötäröstä_lantioon_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Vyötärö edestä lantioon</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötäröstä lantion etuosaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötäröstä_korkealle_puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Vyötäröltä korkean lantion puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötärön puolelta korkean lantion puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötäröstä_korkealle_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Vyötärö takaa korkeaan lantioon</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötäröstä alas korkeahippiin.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötäröstä_lantioon_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation>yötärö takaa lantion selkään</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötäröstä_lantion_puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Vyötäröltä lantion puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötäröltä lantion puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_kaltevuus_kaulan_sivukulma</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapään kaltevuuskulma kaulan puolelta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Kulma, jonka muodostaa linja kaulan puolelta olkapäähän ja kaulan puolelta lattian suuntaisesti.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_kaltevuus_kaulan_puolen_pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapään kaltevuuden pituus kaulan puolelta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuuntainen etäisyys kaulan puolen ja olkapään välillä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_kaltevuus_kaula_selkäkulma</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapään kaltevuuskulma niskasta takaa</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Kulman muodostaa linja niskasta olkapäähän ja kaulan selästä lattian suuntaisesti.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_kaltevuus_kaula_selän_korkeus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapään kaltevuuden pituus niskasta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan selän ja olkapään välinen pystysuora etäisyys.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_kaltevuus_olkapää_kärkikulma</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapään kaltevuuskulma olkapään kärjestä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Kulman muodostaa linja kaulan puolelta olkapäähän ja pystyviiva olkapäähän.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_selästä_ristikkäin</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Niska selkä vastakkain</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulasta selästä alas selän poikkimitan tasoon.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>poikki_selästä_vyötärölle_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation>Selästä vyötärön taakse</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation>Keskiosasta selästä alas vyötärölle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hartioiden_pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapäiden pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta olkapäähän.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapäästä_olkapän_kärkeen_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapäästä olkapäähän, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Olkapäästä olkapäähän, edessä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>poikki_rinta_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation>Rinnan poikki</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Käsivarresta käsivarsivyhteeseen kapeimmalla rinnan leveydellä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsipanta_käsivarteen_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation>Käsinojallinen käsivarsipannu, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Käsinojasta käsinojaan, lyhin etäisyys käsivarsien välillä, ei yhdensuuntainen lattian kanssa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapäästä_olkapäähän_kärkeen_puolikas_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapäästä olkapäähän, edestä, puoliksi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet&apos; Olkapäästä olkapäähän, edessä&apos;. (&apos;Olkapäästä olkapäähän, edessä&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakehän_poikki_puolikas_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation>Rinnan poikki, puoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &apos;rinnan poikki&apos;. (&quot;rintaan poikki&quot; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_kärki_olkapäähän_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapäästä olkapäähän, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>Olkapäästä olkapäähän, selän poikki.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>poikki_selkä_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Takana</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation>Käsivarresta käsivarsivyyhteeseen selän kapeimmalla leveydellä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsinojasta_käsivarresta_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation>Kädensidos käsivarsipanteeseen, takana</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>Käsivarresta selän poikki.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_kärkeen_olkapäähän_puolikas_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapäästä olkapäähän, selkä, puoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &apos;olkapäästä olkapäähän, selkä&apos;. (&apos;Olkapäästä olkapäähän, selkä&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>poikki_takapuolen_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Takana puolet</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &apos;taaksepäin&apos;. (&apos;taaksepäin&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_edestä_olkapään_kärkeen_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula edestä olkapäähän</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan edestä olkapäähän.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_selkä_olkapäähän_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Niska selästä olkapäähän</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulasta selästä olkapäähän.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaulan_leveys</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan leveys</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation>Mittaa &apos;jalkojen&apos; sulkemattomasta kaulakorusta tai ketjusta, joka on levitetty kaulan ympärille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rnnasta_rintaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Rnnasta rintaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Rintapisteestä rintakuvaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakuva_niskan_puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Rintakehästä niskaan sivulta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta rintakuvaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakuvasta_alimmalle_tasolle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation>Rinnan kohdasta matalarintaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Rintakuvasta alaspäin matalaan rinnan tasoon, rintakehän tai rintakehän käyrän mukaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakehän_vyötärölle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>Rintakehä vyötärön tasolla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation>Rinnan kohdasta suoraan alas vyötärön tasolle, muodostaen suoran viivan (ei kaareva vartaloa pitkin).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakuva_pisteestä_rintapisteeseen_puolikas</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation>Rintakuva pisteestä rintakuvaan, puoliksi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Puolet &apos;rintakuvasta pisteestä rintakuvaan&apos;. (&apos;rintakuvasta rintakuvapisteeseen&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakehän_kohta_kaula_puolelta_vyötäröön</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>Rinnankohta, kaula puolelta vyötärön tasolle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta rintakuvaan, sitten suoraan alas vyötärön tasolle. (&apos;Kaulan puoli rintakohtaan&apos; + &apos;rintakohta vyötärön tasolle&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakuva_pisteestä_olkapäähän</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Rintakuva olkapäähän</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Rintapisteestä olkapäähän.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakehä_vyötärölle_etupuoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Rintakehän kohta vyötärön etupuolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation>Rinnan kohdasta vyötärön etupuolelle, suorassa linjassa, ei noudata vartalon käyriä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>niskalenkki_rintakuva_pisteestä_rintakuvaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation>Niskalenkkitoppi rinnasta rintakuvan kohdalle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Rintakohdasta kaulan ympärillä takaisin alas toiseen rintakuvaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakuva_pisteen_olkapään_keskukseen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation>Rintakehän kohta olkapäätä kohti keskustaa</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Olkapään keskustasta rintakuvaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rintakehä_kohti_kaulaa_edestä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Rintakehän kohta kaulan eteen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan edestä rintakohtaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_vyötärön_etupuolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapää vyötärön eteen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Olkapäästä lävistäjä vyötärön eteen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_edessä_vyötärön_puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula edestä vyötärön puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan edestä diagonaalista vyötärön puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_puolelta_vyötärön_puolelle_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan puolelta vyötärön puolelle, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta lävistäjä edestä vyötärön puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_vyötärölle_selkään</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapää vyötärön taakse</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Olkapäästä lävistäjä vyötärön selkään.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>olkapää_vyötärölle_b_25mm_ulospäin</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation>Olkapää vyötärön selkään, 1 tuuman (2,54 cm) siirtymä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation>Merkitse 1 tuuma (2,54 cm) ulospäin vyötäröstä Takaosa vyötärön tasolla. Mittaa olkapään diagonaaliseen merkkiin.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_selkä_vyötärön_puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula takaa vyötärön puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulasta selästä lävistäjä selän poikki vyötärön puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_puolelta_vyötärön_puolelle_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula sivulta vyötärön puolelle, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta lävistäjä takaisin vyötärön puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_puoli_käsivarteen_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan puolelta käsivarret edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta diagonaalista käsivarren etupuolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>niskan_puolelta_kainaloon_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan puolelta korkealle rinnan puolelle, edestä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta lävistäjä edestä korkealle rinnan puolelle (kainalo).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaulan_puolelta_rintakehän_puolelle_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan puolelta rinnan puolelle, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolella lävistäjä edestä rinnan puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_puolelta_käsivarteen_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan puolelta käsivarsinauhan taakse</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta diagonaalista käsivarsinauhan takaosaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_puolella_kainaloon_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan puolelta korkea rinnan puolelle, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta lävistäjä takaisin korkean rinnan puolelle (kainalo).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_puolelta_rintakehän_puolelle_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Kaulan puolelta rinnan puolelle, takaa</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolella lävistäjä takaisin rinnan puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarren_olkapää_ranteeseen_taivutettu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Olkapäästä ranteeseen, taivutettu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Taivuta käsivartta, mittaa olkapään kärjestä kyynärpäästä säteittäiseen ranneluun.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarren_olkapään_kärki_kyynärpäähän</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Olkapäästä kyynärpäähän, taivutettu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Taivuta käsivartta, mittaa olkapäästä kyynärpäähän.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_kyynärpää_ranteeseen_taivutettu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Kädet: Kyynärpäästä ranteeseen, koukussa</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Kyynärpää ranteeseen. (Käsi: Olkapää ranteeseen, taivutettu - Käsivarsi: Olkapää kyynärpäähän, taivutettu).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_kyynärpään_ympärysmitta_taivutettu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Kädet: Kyynärpään ympärysmitta, taivutettu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation>Kyynärpään ympärysmitta, käsivarsi koukussa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarren_olkapään_ranteeseen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Olkapää ranteeseen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Olkapäästä ranteeseen, käsi suorana.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_olkapää_kyynärpäähän</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Olkapäästä kyynärpäähän</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Olkapäästä kyynärpäähän, käsi suorana.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_kyynärpää_ranteeseen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Kyynärpää ranteeseen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Kyynärpäästä ranteeseen, käsi suorana. (Käsi: Olkapää ranteeseen - Käsivarsi: Olkapää kyynärpäähän).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_kainalosta_ranteeseen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Kainalosta ranteeseen, sisällä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Kainalosta kyynärluun ranteeseen, käsi suorana.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarresta_kyynärpäähän</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarret: Kainalosta kyynärpäähän, sisäpuolella</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Kainalosta sisäkyynärpäähän, käsi suorana.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_kyynärpää_ranteeseen_sisälle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Kyynärpää ranteeseen, sisällä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Kyynärpään sisäpuolelta ranteeseen. (&apos; Käsivarsi: Kainalosta ranteeseen, sisäpuoli&apos; - &apos; Käsivarsi: Kainalosta kyynärpäähän, sisäpuoli&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarren_ylempi_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Olkavarren ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>Käsivarren ympärysmitta kainalon tasolla.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_kyynärpään_yläpuolella_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Kyynärpään ympärysmitan yläpuolella</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation>Käsivarren ympärysmitta hauispään tasolla.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_kyynärpäästä_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Kyynärpään ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Kyynärpään ympärysmitta, käsi suorana.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarren_alempi_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Alavarren ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Käsivarren ympärysmitta, jossa käsivarren alaosa on levein.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_ranne_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Ranteen ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation>Ranteen ympärysmitta.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarren_olkapään_kärki_käsivarren_linjaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Olkapäästä käsivarren taittolinjaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>Olkapäästä kainalotasolle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_kaulan_puolelta_ranteeseen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Kaulan puolelta ranteeseen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta ranteeseen. (&apos;hartioiden pituus&apos; + &apos;käsivarsi: olkapäästä ranteeseen&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarren_kaula_puolelta_sormenpäähän</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Kaulan puolelta sormenpäähän</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulasta Käsivarsi alaspäin keskisormen kärkeen. (&apos;Olkapään pituus&apos; + Käsivarsi: Olkapäästä ranteeseen&apos; + &apos;Käsi: Pituus&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_ynpärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation>Anna käsivarren roikkua sivuilla. Mittaa käsivarsivyön ympärysmitta olkapään ja kainalon kautta.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuuntainen etäisyys olkapään kärjestä kainaloon.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsivyön_leveys</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Leveys</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Vaakasuora etäisyys käsivarren etuosan ja takaosan välillä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarren_kaulan_puolelta_ulompaan_kyynärpäähän</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Kädet: Kaulan puolelta kyynärpäähän</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan puolelta olkapään yli alas kyynärpäähän. (Olkapäiden pituus + käsivarsi: Olkapäästä kyynärpäähän).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalka_haara_lattiaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Jalka: Haara lattiaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Seiso jalat lähellä toisiaan. Mittaa haarojen tasolta (koskettaa vartaloa, ei ylimääräistä tilaa) alas lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötärön puolelta kaarretta pitkin lantion tasolle ja sitten suoraan alas polven tasolle. (&apos;jalka: vyötärö sivulta lattiaan&apos; - &apos;polven korkeus&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Aseta teippi pakaroiden välisen raon yli lantion tasolla. Mittaa vyötärön edestä alas jalkojen välistä ja ylhäältä vyötärön taakse.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation>Aseta teippi pakaroiden välisen raon yli lantion tasolla. Mittaa vyötärön takaa haaran puoliväliin, joko emättimestä tai kivesten ja peräaukon välistä).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nousu_pituus_puolella_istuminen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuuntainen etäisyys vyötärön puolelta alas haaran tasolle. Käytä kaavaa (korkeus: vyötärön puoli - jalka: haara lattiaan).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>Tämä tieto on vedetty kuviokaavioista joissakin kuviontekojärjestelmissä, esim. Winifred P. Aldrichin &quot;Metric Pattern Cutting&quot;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalka_vyötärö_puolelta_lattiaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Jalat: Vyötäröltä lattiaa vasten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötärön puolelta käyrää pitkin lantion tasolle ja sitten suoraan alas lattiaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalka_reiden_ylempi_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jalka: Reisi yläympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation>Reiden ympärysmitta reiden yläosan täydellisimmässä osassa lähellä haaraa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalka_reiden_keskiosa</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jalka: Reiden keskiympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Reiden ympärysmitta noin haaran ja polven puolivälissä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalka_polvi_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jalat: Polven ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Polven ympärysmitta suoralla jalalla.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalka_polvi_pieni_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jalat: Polven pieni ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Jalkojen ympärysmitta juuri polven alapuolella.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jpohkeen_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jalka: Pohkeen ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Pohkeen ympärysmitta säären suurimmassa osassa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalka_nilkka_korkea_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jalka: Korkea nilkan ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation>Nilkan ympärysmitta, jossa nilkan takana oleva syvennys on syvin.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalka_nilkka_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jalka: Nilkan ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Nilkan ympärysmitta, jossa jalan etuosa kohtaa jalan yläosan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalka_polvi_ympärysmitta_koukussa</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Jalat: Polven ympärysmitta, taivutettu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation>Polven ympärysmitta jalka koukussa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>säären_alaosan_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jalka: Nilkan diagonaalinen ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation>Nilkan ympärysmitta lävistäjä jalan yläosasta kantapään alaosaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalka_haara_nilkkaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Jalka: Haaroista nilkkaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Haaroista nilkkaan. (&apos;jalka: haarasta lattiaan&apos; - &apos;korkeus: nilkka&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalka_vyötärön_puolelta_nilkkaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Jalka: Vyötäröltä nilkkaan asti</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötärön puolelta nilkkaan. (&apos;jalka: vyötärö sivulta lattiaan&apos; - &apos;korkeus: nilkka&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jalka_vyötärön_puolelta_polveen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Jalka: Vyötäröltä polveen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>haara_pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation>Haarojen pituus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>haara_pituus_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation>Haarojen pituus, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>haara_pituus_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation>Haarojen pituus, edestä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötärön edestä emättimen alkuun tai kivesten loppuun. (&apos;Haarapituus&apos; - &apos;Haarapituus, selkä&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation>Nousupituus, sivu, istuin</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötäröltä lantion ympäriltä alas pintaan kovalla alustalla istuen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuora etäisyys vyötäröstä haaran tasoon. (&quot;Korkeus: vyötärö takana&quot; - &quot;jalka: haarasta lattiaan&quot;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Pystysuuntainen etäisyys vyötärön etuosasta haaratasoon. (&apos;Korkeus: vyötärö edessä&apos; - &apos;jalka: haarasta lattiaan&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nousu_pituus_sivulta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation>Nousupituus, sivu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nousu_pituus_diagonalinen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Taivuta jäykkää paperia vatsan etuosan ympärille, teippaa sivuilla. Mittaa lantion puolelta lantion puolelle paperin päällä edestä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulan edestä, teipin yli rintakohtien välissä, alas vyötärölle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Korkeasta rinnasta vyötärölle. Käytä teippiä siltaamaan rintakuvapisteiden välinen rako. (&quot;Kaulan edestä vyötärölle&quot; - &quot;Kaulan edestä korkeaan rinnan etuosaan&quot;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulasta alas rinnan etuosaan. Vaatii teippiä peittämään rintakuvapisteiden välisen raon.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötäröstä selästä lantioon. Vaatii teipin peittämään pakaroiden välisen raon.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation>Nousupituus, diagonaali (lävistäjä)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation>Mittaa vyötärön puolelta vinosti lahkeen yläosaan sidottuun nauhaan, joka asettuu kovalle alustalle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nousu_pituus_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation>Nousupituus, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nousu_pituus_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation>Nousupituus, edestä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_selkä_vyötärön_etupuolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula takaa vyötärön eteen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulasta takaa niskan ympäriltä alas vyötärön eteen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötäröstä_vyötäröön_lenkki</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Vyötäröstä_vyötärölle_lenkki_kaulan_ympärillä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Vyötäröltä kaulan ympäriltä Takaisin vyötärön tasolle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötärön_luonnollinen_ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Luonnollinen vyötärön ympärysmitta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation>Vartalon ympärysmitta miesten luonnollisella puolella Vatsan vino sisennys, jos vinoa sisennystä ei löydy, niin juuri napatason alapuolella.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötäröllä_luonnollinen_kaari_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Luonnollinen vyötärökaare, edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation>Sivulta toiselle luonnollisella vyötärötasolla, edessä.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötärö_luonnollinen_kaari_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Luonnollinen vyötärökaare, selkä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation>Sivulta toiselle luonnollisella vyötärön tasolla, selän poikki. Laske muodossa ( Luonnollinen vyötärön ympärysmitta - Luonnollinen vyötärön kaari (edessä) ).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötärö_luonnolliseen_vyötärön_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Vyötärö edestä luonnolliseen vyötärölle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Pituus vyötärön edestä luonnolliseen vyötärön eteen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vyötärö_luonnolliseen_vyötäröön_b</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Vyötärö takaisin luonnolliseen vyötärölle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Pituus vyötäröstä luonnolliseen selkänojaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_kaula_selkä_kyynärpäähän</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Kädet: Niska selästä kyynärpäähän, korkea mutka</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Taivuta käsivartta kyynärpää ulospäin, käsi edessä. Mittaa kaulasta kyynärpäähän.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_kaula_selkä_ranteeseen_taivutettu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Kädet: Kaula selkä ranteeseen, korkea kulma</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Taivuta käsivartta kyynärpää ulospäin, käsi edessä. Mittaa kaulasta kyynärpään kärkeen ranteen luuhun.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_kaula_puolelta_kyynärpäähän_taivutettu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Kädet: Kaula sivulta kyynärpäähän, korkea kulma</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Taivuta käsivartta kyynärpää ulospäin, käsi edessä. Mittaa kaulan puolelta kyynärpäähän.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_kaulan_puoleisesti_ranteeseen_taivutettu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Kaula Sivulta ranteeseen, korkea kulma</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Taivuta käsivartta kyynärpää ulospäin, käsi edessä. Mittaa niskan puolelta kyynärpään kärkeen ranteen luuhun.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_selän_poikki_keskeltä_kyynärpäähän_taivutettuna</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Selän poikki keskeltä kyynärpäähän, korkea mutka</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Taivuta käsivartta kyynärpää ulospäin, käsi edessä. Mittaa selän keskiosasta kyynärpään kärkeen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_takana_keskeltä_ranteeseen_taivutettuna</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Takaosan poikki keskeltä ranteeseen, korkea taivutus</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Taivuta käsivartta kyynärpää ulospäin, käsi edessä. Mittaa selän keskiosasta kyynärpään kärkeen ranteen luuhun.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_takaa_keskeltä_ranteeseen_taivutettu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: Käsivarsi takaosa keskeltä ranteeseen, korkea mutka</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Taivuta käsivartta kyynärpää ulospäin, käsi edessä. Mittaa käsivarresta takaisin kyynärpäähän.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_selästä_rintaa_etupuoli</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula takaa rinnasta eteen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulasta takaa, olkapäästä rinnan etupuolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>niska_selkä_käsivarren_etupuolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula takaosasta käsinojaan eteen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulasta selästä olkapäiden yli käsivarsien eteen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>niska_selästä_käsivarren_edestä_vyötärön_puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula takana, olkapään yli, vyötärön puolelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulasta selästä, olkapäiden yli, rinnasta alas vyötärön puolelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkea_rintakehä_takana_olkapäästä_käsivarteen_taitettuna_edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Korkearinta takaosa, olkapään yli, käsivarsinauhan eteen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Korkearintaisesta takaosasta olkapäästä käsivarren eteen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkearinta_takaa_olkapäästä_vyötäröön_edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Korkearinta selkä, olkapään yli, vyötärön eteen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Korkearintaisesta takaa, olkapäiden yli koskettaen kaulan puolta, vyötärön eteen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_selästä_käsivarren_edestä_kaulan_selkään</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula takana, käsinojassa edessä, niskassa takana</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulasta takaa, olkapäästä käsivarren eteen, käsivarren alle ja takaisin alkuun.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>poikki_selän_keskeltä_käsinojaan_edest_poikki_takaosan_keskelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Selän poikki keskellä, kierretty olkapään ympäri</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation>Keskiosasta selän poikki, olkapään yli, käsivarren alta ja palaa alkuun.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kaula_selästä_käsivarren_edestä_korkeaan_rintakehän_selkään</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Kaula takana, käsinojassa edessä, korkea rinnassa takana</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Kaulasta Selästä olkapäiden yli käsivarsien eteen, käsivarren alta korkearintaiseen selkään.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarret_käsivarresta_rintakuvaan</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Käsinojat käsivarresta, edessä, kaareva rinnan etuosan läpi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Mittaa kaaressa käsivarsipanosta vasemmasta etuosasta rinnan etuosan kaarevaan takaosaan käsivarsinojan oikeaan etuosaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarsi_rintakehän_edessä</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Käsinojat rinnan eteen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation>Mittaa käsivarren edestä rintakehän etupuolelle, lyhin etäisyys näiden välillä, mahdollisimman suorana.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>korkea_rintakuva_b_olkapäästä_korkearinta_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation>Korkea rintakehä Selkä, olkapään yli, korkea rinnan tasolle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Korkeasta rintakuvasta Selästä, olkapään yli, tähtää sitten rintakuvan kohdalle ja lopeta mittaus korkealla rinnankorkeudella.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>käsivarren_kaari</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation>Käsivarsi: kaari</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Rinnan poikki olkapään yli olevasta käsivarresta selän poikki.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>muotolaskoksen_leveys_olkapää</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Muotolaskoksen  leveys: Olkapää</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>Tämä tieto on vedetty kuviokaavioista joissakin kuviontekojärjestelmissä, esim. Winifred P. Aldrichin &quot;metrinen kuvioleikkaus&quot;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>muotolaskoksen_leveä_rintakuva</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Mutolaskoksen leveys: Rintakuva</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>muotolaskoksen_leveys_vyötärö</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Muotolaskoksen leveys: Vyötärö</translation>

--- a/share/translations/measurements_fr_FR.ts
+++ b/share/translations/measurements_fr_FR.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Totale</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du haut de la tête au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_nuque</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Nuque</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale de la nuque (vertèbre cervicale) au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_omoplate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Omoplate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance verticale de l&apos;omoplate au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_aisselle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Aisselle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale de l&apos;aisselle au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_taille_côté</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Taille côté</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du côté de la taille au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_hanche</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Hanche</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale de la hanche au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_sous_fesses</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Sous fesses</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance verticale du pli glutéal (où le muscle glutéal rencontre le haut de l&apos;arrière de la cuisse) jusqu&apos;au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_genou</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Genou</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du pli derrière le genou au sol</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_mollet</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Mollet</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du plus large du mollet au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_cheville_haute</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Haut cheville</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance verticale du point le plus rentré de la cheville jusqu&apos;au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_cheville</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Cheville</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du point où le devant de la jambe rencontre le pied au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_hanchehaute</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Petites hanches</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale des petites hanches, là où le ventre est le plus proéminent, au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_taille_avant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Taille devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du devant de la taille au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_poitrine</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Poitrine</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du point de poitrine au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_bout_epaule</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Bout d&apos;épaule</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du bout de l&apos;épaule au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_cou_devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Cou devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du devant du cou au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_cou_cote</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Cou côté</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du côté du cou au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_nuque_au_genou</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Nuque au genou</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale de la nuque (vertèbre cervicale) au pli derrière le genou.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_cote_taille_au_genou</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Côté taille au genou</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du côté de la taille au pli derrière le genou.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_cote_taille_aux_hanches</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Côté taille aux hanches</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du côté de la taille aux hanches.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_genou_a_cheville</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Genou à cheville</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du pli derrière le genou au point où le devant de la jambe rencontre le pied.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_nuque_au_cote_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur: Nuque au côté taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale de la nuque au côté de la taille. (&apos;Hauteur: Nuque&apos; - &apos;Hauteur: Taille côté&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>haut_taille_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur taille dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>largeur_epaule</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Largeur: Epaule </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur horizontale d&apos;un bout de l&apos;épaule à l&apos;autre.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>largeur_buste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Largeur: Buste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur horizontale d&apos;un côté du buste à l&apos;autre.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>largeur_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Largeur: Taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur horizontale d&apos;un côté de la taille à l&apos;autre.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>largeur_hanches</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Largeur: Hanche</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur horizontale d&apos;un côté des hanches à l&apos;autre.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Largeur_aplomb_ventre_hanches</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Largeur: Aplomb du ventre et hanches</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance horizontale entre le sommet du ventre et le sommet des fesses</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>creux_nuque</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Creux de la nuque</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance horizontale entre le sommet des homoplates et le creux de la nuque.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>creux_lombaire</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Creux des lombaires</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance horizontale entre une ligne imaginaire passant par le sommet des homoplates et le creux lombaire (cambrure)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>creux_talon</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Creux talon d&apos;achille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>main_longueur_paume</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation>Main: Longueur paume</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur du poignet à la base du majeur.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>main_longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Main: Longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur du poignet au bout du majeur.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>main_largeur_paume</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation>Main: Largeur paume</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Mesurer là où la paume est la plus large.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>main_circ_paume</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Main: Circonférence paume</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence là où la paume est la plus large.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>main_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Main: Circonférence</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation>Mettre le pouce vers le plus petit doigt, garder les doigts serrés. Mesurer la circonférence au plus large de la main.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Largeur_pied</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Pied: Largeur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Mesurer la partie la plus large du pied.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pied_longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Pied: Longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation>Mesurer du derrière du talon au bout du plus grand orteil.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pied_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Pied: Circonférence</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Mesurer la circonférence au plus large du pied.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tour_coup_de_pied</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation>tour_de_cou_de_pied</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation>Mesure du tour au plus creux du cou-de-pied</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tete_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Tête: Circonférence</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Mesurer la circonférence au plus large de la tête.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tete_longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Tête: Longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance verticale depuis le sommet du crâne jusqu&apos;à la base de la mâchoire.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tete_profondeur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation>Tête: Profondeur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance horizontale depuis le visage jusqu&apos;à l&apos;arrière de la tête</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tete_largeur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Tête : Largeur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance horizontale d&apos;un côté à l&apos;autre de la tête, au plus large.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tete_haut_a_nuque</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Tête: Du haut à la nuque</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du sommet du crâne à la nuque. (&apos;Hauteur: Totale&apos; - &apos;Hauteur: Nuque&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tete_menton_a_nuque</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Tête: Du menton à la nuque</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur verticale du menton à la nuque. (&apos;Hauteur&apos; - &apos;Hauteur: Nuque&apos; - &apos;Tête: Longueur&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>cou_circ_milieu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation>Circonférence du cou, au milieu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence du cou, à la moitié entre la machoire et le torse.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>cou_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circonférence du cou</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence du cou à la base, en passant par le point de la nuque, de côtés et de devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tour_surpoitrinaire</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Tour surpoitrinaire</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation>Tour au dessus de la poitrine, passant entre les deux plis de bras et sous les aisselles.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>poitrine_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Tour de poitrine</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence du buste, parallèle au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tour_souspoitrinaire</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Tour sous-poitrinaire</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Tour de la cage thoracique sous les seins, parallèle au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tour_cage</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Tour cage thoracique</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Tour de la cage thoracique au niveau des cotes flottantes, parallèle au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Tour de taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence de la taille, en suivant les lignes du corps. En général la taille est plus haute dans le dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>petites_hanches_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Tour des petites hanches</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence des petites hanches, là où l&apos;abdomen est le plus fort, parallèle au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hanches_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Tour de hanches</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence des hanches, où elles sont le plus larges, parallèle au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Demi encolure devant, d&apos;un coté à l&apos;autre.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_tour_surpoitrinaire</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>arc_sur_poitrinaire</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>De chaque pli du bras par la carrure devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>poitrine_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Ligne de poitrine, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>De chaque coté de la poitrine par la carrure devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation>Taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>sous_poitrine_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Sous-poitrine, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>D&apos;un coté à l&apos;autre, sous la poitrine</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>cage_devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-cage thoracique, devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>D&apos;un coté à l&apos;autre de la cage thoracique, devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_taille_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-taille, devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>D&apos;un coté à l&apos;autre de la taille, dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_bassin_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-bassin, devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>D&apos;un coté à l&apos;autre du bassin, devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_hanche_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-hanches, devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation>D&apos;un coté à l&apos;autres des hanches, devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_cou_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-cou, devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié de demi-cou (&apos;Demi-cou, devant&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>quart_tour_surpoitrinaire</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>demi_arc_surpoitrinaire</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié du demi tout sur-poitrinaire devant. Du point de sur-poitrine devant à point de sur-poitrine latéral (&apos;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>quart_tour_poitrine</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Arc de sur-poitrine, devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié d&apos;&apos;arc de poitrine, devant.&apos; (&apos;arc de poitrine&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_arc_sous_mammaire</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-arc sous mammaire, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié de demi-arc sous-mammaire, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>quart_tou_thorax</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Moitié de l&apos;arc thoracique, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié de &apos;Demi-arc thoracique, devant&apos;. (&apos;Demi-arc thoracique, devant&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>quart_tour_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-tour de taille, devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié de demi-tour de taille, devant. (&apos;demi-tour de taille, devant.&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>quart_tour_bassin</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Moitié de demi-tour de bassin, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié de &apos;demi-tour de bassin, devant&apos;. (&apos;Moitié de demi-tour de bassin, devant&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>quart_tour_hanches</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>moitié du demi-tour de hanche, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié du &apos;demi-tour de hanches&apos;. (&apos;Demi-tour de hanches, devant&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_encolure_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-encolure, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>D&apos;un point d&apos;encolure à l&apos;autre en passant par le dos (&apos;Encolure&apos; - demi-encolure, devant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_tour_surpoitrinaire_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-tour sur-poitrinaire, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Du point de sur-poitrine devant à point de sur-poitrine latéral par le dos (&apos;Tour sur-poitrinaire&apos; - &apos;arc sur-poitrinaire, devant&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_poitrine_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-tour de poitrine, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>D&apos;un coté à l&apos;autre de la poitrine, par la carrure dos (&apos;Tour de poitrine&apos; - &apos;Demi-tour de poirtrine, devant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_sous_mammaire_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-arc sous-mammaire, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Segment sous-mammaire d&apos;un coté à l&apos;autre, passant par le dos (&apos;Tour sous-mammaire&apos; - &apos;Demi-tour sous-mammaire, devant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_thorax_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-thorax, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>D&apos;un coté à l&apos;autre de la cage thoracique, dos. (&apos;Tour thorax&apos; - &apos;Demi-thorax, devant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_taille_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-taille, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>D&apos;un coté à l&apos;autre de la taille par le dos (&apos;Tour de taille&apos; - &apos;Demi-taille, devant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_bassin_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Demi tour de bassin, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>D&apos;un coté à l&apos;autre du bassin par le dos. (&apos;Tour de bassin&apos; - &apos;Demi_tour de bassin, devant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_hanches_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Demi tour de hanches, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>D&apos;un coté à l&apos;autres des hanches par le dos. (&apos;Tour de hanches&apos; - &apos;Demi tour de hanches, devant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_arc_cou_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Moitié de demi-encolure, dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié de &apos;demi-ecolure, dos&apos;. (&apos;Demi-encolure, dos&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>quart_tour_surpoitrinaire_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Moitié d&apos;arc sur-poitrinaire, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié del&apos;arc sur-poitrinaire dos. Du point de sur-poitrine devant à point de sur-poitrine latéral (&apos;</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>quart_tour_poitrine_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-arc de poitrine, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié d&apos;&apos;arc de poitrine, dos.&apos; (&apos;Arc de poitrine, devant&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_arc_sous_mammaire_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-arc sous-mammaire, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié de &apos;Arc sous-mammaire, dos&apos; (&apos;Arc sous-mammaire, dos&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>quart_tour_thorax_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-arc thoracique, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié de &apos;Arc thoracique, dos&apos;. (&apos;Arc thoracique, dos&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>quart_tour_taille_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Moitié du demi-tour de taille, dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié de d&quot;emi-tour de taille, dos&quot;. (&apos;demi-tour de taille, dos.&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>quart_tour_bassin_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Moitié de demi-tour de bassin, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié de &apos;demi-tour de bassin, dos&apos;. (&apos;Moitié de demi-tour de bassin, dos&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>quart_tour_hanches_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Moitié du demi-tour de hanche, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié du &apos;demi-tour de hanches, dos&apos;. (&apos;Demi-tour de hanches, dos&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hanche_avec_ventre_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation>Segment de hanche, devant passant par les fesses.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tour_epaule</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation>Tour des épaules au niveau de la pliure du bras</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation>Mesure du torse en incluant les bras au niveau de la pliure du bras.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tour_torse</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation>Tour du corps au niveau de la poirtrine</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Mesure prise autour des bras et du torse au niveau des seins.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Tour_torse_vertical</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation>Tour de corps à la verticale</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation>Tour de corps passant par le milieu de l&apos;épaule et l&apos;entrejambe.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tour_hanche_avec_ventre</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation>Tour de hanches, incluant le ventre</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation>Mesure du tour de hanches intégrant la profondeur de ventre (&apos;Demi-hanches, dos&apos; + &apos;Demi-hanches avec ventre, devant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_taille_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Distance entre l&apos;encolure et la taille , devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_taille_plat_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation>Distance entre l&apos;encolure et la taille à plat, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>De l&apos;encolure devant à la taille devant, en passant entre les seins.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>aisselle_taille_latéral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Aisselle à la taille en latéral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>De sous l&apos;aisselle à la taille en latéral.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>epaule_taille_lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Point d&apos;épaule à la taille, latéral, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Du point d&apos;épaule, en contournant l&apos;emmanchure par devant, descendant à la taille en latéral.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_lateral_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure latéral à la taille, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Du point d&apos;encolure latéral à la taille devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_lateral_taille_par_pointe_sein</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Point d&apos;encolure latéral à la taille par la pointe de sein</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>Du point d&apos;encolure latéral, passant par la pointe de sein, jusqu&apos;à la taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_sur_pointrine_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure devant à ligne sur-poitrinaire, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Point d&apos;encolure au milieu devant à la ligne de sur-poitrine, vertical.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>sur_poitrine_taille_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>ligne de sur-poitrine devant à ligne de taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_poitrine_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure devant à ligne  de poitrine, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>poitrine_taille_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Ligne de poitrine devant à taille devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Distance de la ligne de poitrine devant à la taille. (&apos;Distance entre l&apos;encolure et la taille , devant&apos; - &apos;Encolure devant à ligne  de poitrine, devant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>sous_mammaire_taille_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Ligne sous-mammaire devant à taille devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance de la ligne sous-mammaire devant à la taille devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>thorax_taille_lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Distance latérale entre le thorax et la taille </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>De la ligne de thorax passant par la dernière cote flottante et la taille, en latéral.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>emmanchure_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Pointe d&apos;épaule à pli du bras</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Mesure de l&apos;emmanchure de la pointe d&apos;épaule au point de pli du bras.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_cote_poitrine</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Du point d&apos;encolure latéral a la ligne de poitrine</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance du point d&apos;encolure latéral à la ligne de poitrine, devant, vertical.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_cote_sur_poitrine_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Du point d&apos;encolure latéral à la ligne de sur-poirtrine, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance du point d&apos;encolure latéral à la ligne de sur-poitrine, devant, vertical.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>centre_epaule_sur_poitrine_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>de centre épaule à sur-poitrine, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance du centre de l&apos;épaule devant à la ligne de sur-poitrine, à l&apos;opposé de la pointe de sein.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>epaule_taille_cote_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Du point d&apos;épaule à la taille en latéral, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance du point d&apos;épaule, passant par l&apos;emmanchure dos, vers la taille en latéral.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_cote_taille_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure latéral à la taille, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Du point d&apos;encolure latéral à la taille dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_dos_taille_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure dos à la taille dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance du point d&apos;encolure dos à la ligne de taille dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_cote_taille_homoplate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Point d&apos;encolure latéral à la taille par l&apos;homoplate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance du point d&apos;encolure latéral, passant par lhomoplate, jusqu&apos;à la taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_dos_sur_poitrine_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure dos à sur-poitrine dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance du point d&apos;encolure dos à la ligne de sur poitrine, dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>sur_poitrine_taille_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Sur-poitrine dos à taille dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Distance de la ligne de sur-poitrine dos à la taille dos (&apos;Encolure dos à taille dos&apos; - &apos;Encolure dos à sur-poitrine dos&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_poitrine_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure dos à la poitrine dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance du point d&apos;encolure dos à la ligne de poitrine dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>poitrine_taille_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>poitrine dos à taille dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Distance de la ligne de poitrine, dos à la ligne de poitrine, dos (&apos;Encolure dos à taille dos&apos; - &apos;Encolure dos àpoitrine dos&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>sous_mammaire_taille_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Sous-mammaire à taille, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance de la ligne sous-mammaire, dos à la ligne de taille, dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>emmanchure_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Point d&apos;épaule à pli du bras, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Mesure de l&apos;emmanchure du point d&apos;épaule au point de pli du bras, dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_cote_poitrine_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure latéral a poitrine, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance du point d&apos;encolure latéral à la ligne de poitrine, dos, vertical.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_cote_sur_poitrine_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Du point d&apos;encolure latéral à la ligne de sur-poirtrine, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance du point d&apos;encolure latéral à la ligne de sur-poitrine, dos, vertical.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>centre_epaule_sur_poitrine_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>de centre épaule à sur-poitrine, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance du centre de l&apos;épaule dos à la ligne de sur-poitrine, en passant par l&apos;homoplate.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_bassin_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Taille devant à bassin devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance de la ligne de taille devant à la ligne d ebassin bassin devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_hanches_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Taille devant à hanches devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance de la ligne de taille devant à la ligne de hanches devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_bassin_cote</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation>taille latéral à sur-poitrine latéral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance de la ligne de taille latéral à la ligne de sur-poitrine latéral.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_bassin_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Taille dos à bassin dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance de la ligne de taille dans le dos à la ligne de bassin dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_hanches_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Distance de la ligne de taille dans le dos à la ligne de hanches dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_hanches_cote</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Taille au hanches en lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance de la ligne de taille à la ligne de hanches, en latéral.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pente_epaule_encolure_cote</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Pente d&apos;épaule à l&apos;encolure laterale</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Angle formé par la ligne qui passe par le point d&apos;encolure latéral et le point d&apos;épaule, et la ligne verticale passant par le point d&apos;épaule.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>long_pente_epaule_encolure_cote</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur pente d&apos;épaule à l&apos;encolure laterale</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance verticale entre la base latérale du cou jusqu&apos;à l’extrémité de l&apos;épaule.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pente_epaule_encolure_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur pente d&apos;épaule à l&apos;encolure laterale</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Angle formé par la ligne qui passe par le point d&apos;encolure dos et le point d&apos;épaule, et la ligne passant par le point d&apos;encolure, parallèle au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_pente_epaule_encolure_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur pente d&apos;épaule à l&apos;encolure dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance entre la nuque et l&apos;extrémité de l&apos;épaule.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pente_epaule</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Pente d&apos;épaule au point d&apos;épaule.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>L&apos;angle formé par la ligne qui passe par la base latérale du cou et l&apos;extrémité de l&apos;épaule, et la ligne verticale passant par l&apos;extrémité de l&apos;épaule.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_carrure_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure dos à la carrure dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation>mesure du point d&apos;encolure dos à la carrure dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>carrure_dos_taille_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation>Carrure dos à la taille dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance du milieu de la carrure dos à la ligne de taille en vertical</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>épaule_longueur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation>Longueur d&apos;épaule</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>De la base latérale du cou jusqu&apos;à l&apos;extrémité de l&apos;épaule.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bout_epaule_a_bout_epaule_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation>D&apos;un bout de l&apos;épaule à l&apos;autre, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur d&apos;un bout de l&apos;épaule à l&apos;autre, en passant par le devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>carrure_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation>Carrure devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Largeur d&apos;un coté à l&apos;autre des emmanchure, à lendroit le plus étroit.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>entre_plis_bras</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation>D&apos;un coté à l&apos;autre des pli du bras, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>La plus courte distance, d&apos;un coté à l&apos;autre des plis du bras, devant, non parallèle au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demie_distance_entre_les_deux_points_dépaule_devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>demie_distance_entre_les_deux_points_dépaule_devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié de la distance entre les deux points d&apos;épaule, devant (&apos;point d&apos;épaule à point d&apos;épaule&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_carrure_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation>Demie carrure, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié de la ligne de carrure, devant. (&apos;carrure devant&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>entre_epaule_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation>D&apos;un bout de l&apos;épaule à l&apos;autre, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur d&apos;un bout de l&apos;épaule à l&apos;autre, en passant par le dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>carrure_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Carrure dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation>Largeur d&apos;un coté à l&apos;autre des emmanchures, à l&apos;endroit le plus étroit, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>entre_plis_bras_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation>Du pli du bras à l&apos;autre, dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance du pli du bars dos à l&apos;autre, le long de la carrure.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_entre_epaules_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Demie distance entre les deux points d&apos;épaule, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié de la distance entre les deux points d&apos;épaule, devant (&apos;point d&apos;épaule à point d&apos;épaule&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_carrure_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Demie-carrure dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié de la carrure dos (&apos;carrure dos&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_epaule_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Du point d&apos;encolure devant jusqu&apos;au point d&apos;épaule.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Du point d&apos;encolure devant jusqu&apos;au point d&apos;épaule.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_epaule_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Du point d&apos;encolure dos jusqu&apos;au point d&apos;épaule.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance du point d&apos;encolure dos jusqu&apos;au point d&apos;épaule.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>largeur_encolure</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation>Largeur d&apos;encolure</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation>Mesure entre les pendants verticaux d&apos;un collier ouvert sur le devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>point_de_poitrine_a_point_de_poitrine</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>D&apos;une pointe à l&apos;autre</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance entre les pointes de sein</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pointe_sein_encolure_lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>De la pointe de sein à l&apos;encolure, latéral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>De point d&apos;encolure latéral à la pointe de sein.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pointe_sein_sous_mammaire</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation>De la pointe de sein à ligne sous-mammaire</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Mesure de la courbe allant de la pointe de sein à la ligne sous-mammaire.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pointe_sein_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>De la pointe de sein à la taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation>Distance allant de la pointe de sein vers la ligne de taille, en ligne droite (sans suivre le corps)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_entre_seins</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation>Demi-écart entre pointes de sein</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Moitié &apos;D&apos;une pointe de sein à l&apos;autre&apos; (&apos;D&apos;une pointe de sein à l&apos;autre&apos; / 2&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pointe_sein_encolure_cote_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>Pointe de sein, encolure latéral à la taille </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>De l&apos;encolure latéral à la taille en passant par la pointe de sein. (&apos;De la pointe de sein à l&apos;encolure, latéral&apos; + &apos;De la pointe de sein à la taille&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pointe_de_sein_pointe_epaule</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>De la pointe de sein au point d&apos;épaule</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation>De la pointe de sein à la pointe épaule</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pointe_sein_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Pointe de sein a la taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation>De la pointe de sein jusqu&apos;à la taille, en ligne droite, sans suivre les courbes du corps.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>entre_seins_encolure_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation>Pointe de sein à pointe de sein par encolure</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Pointe de sein passant par le bas de l&apos;Encolure Dos à l&apos;autre Pointe de sein</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Pointe_sein_au_milieu_epaule</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation>Pointe de sein au Milieu épaule</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Du milieu Epaule à la Pointe de sein</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pointe_epaule_a_taille_devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Pointe d&apos;épaule à la Taille devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Diagonale partant de la Pointe d&apos;épaule à la taille devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_devant_a_taille_cote</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure devant à la Taille côté</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Diagonale partant de l&apos;encolure jusqu&apos;à la Taille côté</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_cote_a_taille_cote</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure côté à la Taille côté, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Diagonale partant de l&apos;Encolure côté arrivant à la Taille côté en passant par le devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pointe_epaule_a_taille_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Pointe d&apos;épaule à la Taille dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Diagonale partant de la Pointe épaule arrivant à la Taille Dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pointe_epaule_a_taille_d_1in_ajuste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation>Pointe d&apos;épaule à la Taille Dos, avec 1in (2.54cm) de décalage</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation>En partant de la Taille Dos, pointer 1in (2.54cm) de décalage par rapport au niveau de la Taille. Mesurer à partir de la pointe d&apos;épaule à cette marque en diagonale.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_dos_a_taille_cote</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure Dos à la Taille Côté</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Diagonale partant de l&apos;Encolure Dos passant par le dos jusqu&apos;à la Taille Côté.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_cote_a_taile_cote_d</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure Côté à la Taille Côté, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Diagonale partant de l&apos;Encolure Côté passant par le dos jusqu&apos;à la Taille Côté.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>coté_cou_au_pli_de_bras_devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Ecolure coté au pli de bras devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>De l&apos;Encolure Côté jusqu&apos;au niveau Haute de l&apos;Aisselle, mesurer en diagonale.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_cote_a_aisselle_dvt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure Côté à l&apos;aisselle côté, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation>Diragonale partant de l&apos;Encolure Côté, passant sur le devant jusqu&apos;à l&apos;aisselle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_cote_a_carrure_cote_dvt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure Côté à la Carrure Côté, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Diagonale partant de l&apos;Encolure Côté à la Carrure Côté en passant sur le devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_cote_au_pli_coude_d</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure côté au Bas de l&apos;Aisselle Dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Diagonale partant de l&apos;Encolure Côté au Bas de l&apos;Aisselle Dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_cote_a_aisselle_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure Côté jusque sous l&apos;Aisselle, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation>Diagonale partant de l&apos;Encolure Côté jusqu&apos;au plus haut du Buste côté (sous Aisselle) en passant par le dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_cote_au_buste_cote_d</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure Côté au Buste Côté, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Mesurer en diagonale de l&apos;Encolure Côté jusqu&apos;au commencement du Buste Côté dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pointe_epaule_au_poignet_casse</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Pointe d&apos;épaule au Poignet, plié</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bras en équerre, mesurer de la Pointe d&apos;épaule jusqu&apos;à l&apos;os du Poignet en passant par le coude.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>pointe_epaule_au_coude_plie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Pointe épaule au Coude, plié</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bras en équerre, mesurer de la Pointe épaule jusqu&apos;à l&apos;articulation du Coude.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>coude_au_poignet_plie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Coude au Poignet, plié</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Articulation Coude au Poignet. (&apos;Bras: Pointe épaule au poignet, plié&apos; - &apos;Bras: Pointe épaule au Coude, plié&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>coude_circ_plie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Circonférence du Coude, plié</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation>Bras en équerre, mesurer le Tour du Coude.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_pointe_epaule_au_poignet</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Pointe épaule au Poignet</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Pointe d&apos;épaule à l&apos;os du Poignet, bras tendu.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_pointe_epaule_au_coude</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Pointe épaule au Coude</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Pointe d&apos;épaule à l&apos;Os du Coude, bras tendu.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_coude_au_poignet</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Coude au Poignet</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Du Coude au Poignet, bras tendu. (&apos;Bras: Pointe épaule au Poignet&apos; - &apos;Bras: Pointe épaule au Coude&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>aisselle_au_poignet</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Bras : Aisselle au Poignet, par l&apos;intérieur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>De l&apos;Aisselle au l&apos;os du poignet fixant le cubitus, bras tendu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_aisselle_au_coude</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Aisselle au Coude, par l&apos;intérieur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>De l&apos;Aisselle au creux du Coude, bras tendu.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_coude_au_poignet_interieur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Coude au Poignet, intérieur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>De l&apos;intérieur du Coude au Poignet. (&apos;Bras: Aisselle au Poignet, intérieur&apos; - &apos;Bras : Aisselle au coude, intérieur&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_haut_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: circonférence de la partie Supérieur du Bras</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence du Bras au niveau de l&apos;Aisselle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_au_dessus_coude_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Circonférence au-dessus du Coude</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence du Bras au niveau du Biceps</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_coude_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Circonférence du Coude</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence du Coude, bras tendu.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_bas_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Circonférence de l&apos;Avant-Bras</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence de l&apos;avant-Bras où il est le plus fort.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_poignet_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Circonférence du Poignet</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence du Poignet.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_pointe_epaule_a_ligne_basse_aisselle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Pointe d&apos;Épaule à la ligne basse de l&apos;Aisselle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>Partir de la Pointe d&apos;Épaule et descendre jusqu&apos;au niveau d&apos;Aisselle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_encolure_cote_au_poignet</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Encolure Côté au Poignet</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>De l&apos;Encolure Côté jusqu&apos;au Poignet. (&apos;Longueur Épaule&apos; + &apos;Bras: Pointe d&apos;Épaule au Poignet&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_encolure_cote_au_extremite_doigt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Encolure Côté à l&apos;Extrémité Doigt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>De l&apos;Encolure côté descendre par le bras jusqu&apos;à l&apos;extrémité du majeur. (&apos;Longueur Épaule&apos; + &apos;Bras: Pointe Épaule au poignet&apos; + &apos;Main: Longueur&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tour_d&apos;emmanchure</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Tour d&apos;emmanchure</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation>Les bras le long du corps. Mesurer le tour d&apos;emmanchure de l&apos;épaule en passant par l&apos;aisselle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_d&apos;emmanchure</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation>emmanchure : Hauteur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance entre l&apos;épaule et l&apos;aisselle </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>largeur_d&apos;emmanchure</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation>emmanchure : largeur</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distance entre l&apos;emmanchure devant et l&apos;emmanchure dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>longueur_du_bras_de_l&apos;encolure_à_l&apos;extérieure_du_coude</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Longueur de bras : de l&apos;encolure à l&apos;exterieur du coude</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation>De l&apos;encolure coté jusqu&apos;a l&apos;exterieur du coude. ( Y compris la logueur d&apos;épaule )</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jambe_entrejambe_au_sol</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Jambe: hauteur d&apos;entrejambe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Les jambes serrés. Mesurer de l&apos;entrejambe jusqu&apos;aux sol ( A ras du corps )</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_jambe_cote_au_sol</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Jambe: du Côté de la Taille au sol</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Partir du Côté de la Taille en passant par la courbe de la Hanche et finir droit jusqu&apos;au sol.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jambe_cuisse_haut_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jambe: circonférence Haut de Cuisse</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence de la Cuisse au plus haut de la cuisse proche de la Fourche.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jambe_cuisse_milieu_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>J</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence de la Cuisse à mi-distance entre la Fourche et le Genou.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jambe_genou_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jambe: circonférence Genou</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence du genou avec la jambe droite.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jambe_genou_petit_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jambe: Petite circonférence du Genou</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence de la Jambe juste en dessous du Genou.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jambe_mollet_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jambe: circonférence Mollet</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence du mollet au plus large.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jambe_cheville_haut_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jambe: circonférence du Haut de la Cheville</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence de la Cheville où cette dernière est au plus creux sur l&apos;arrière.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jambe_cheville_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jambe: circonférence Cheville</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence Cheville à l&apos;endroit où la jambe rencontre le haut du pied.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jambe_genou_circ_plié</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Jambe: circonférence Genou, plié</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence du Genou avec la jambe pliée.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jambe_cheville_diag_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Jambe: Circonférence Cheville en diagonale</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence de la Cheville mesurée en diagonale à partir du devant de la cheville, jusqu&apos;à la partie basse du Talon.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jambe_fourche_a_cheville</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Jambe: Fourche à la Cheville</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>A partir de la fourche jusqu&apos;à la Cheville. (&apos;Jambe: Fourche jusqu&apos;au Sol&apos; - &apos;Hauteur: Cheville&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jambe_taille_cote_a_cheville</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Jambe: Taille Côté à la Cheville</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>A partir de la Taille Côté jusqu&apos;à la cheville. (&apos;Jambe: Taille Côté jusqu&apos;au Sol&apos; - &apos;Hauteur: Cheville&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>jambe_taille_cote_au_genou</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Jambe: Taille Côté au Genou</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Du Côté de la Taille le long de la courbe de la Hanche et jusqu&apos;au genou. (&apos;Jambe : Coté de la Taille jusqu&apos;au genou&apos; - &apos;Genou&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>longueur_entrejambe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation>Longueur de l&apos;entrejambe</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished">longueur_entrejambe_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation>Longueur Entrejambe, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>entrejambe_longueur_dvt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation>Longueur Entrejambe, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>A partir de la Taille Devant, jusqu&apos;au début du vagin ou à la fin des testicules. (&apos;longueur Entrejambe&apos; - &apos;longueur Entrejambe, dos&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hauteur_montant_cote_assis</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation>Hauteur Montant, côté, assis</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation>Du Côté de la Taille le long de la courbe des hanches jusqu&apos;à la surface, en étant assis sur une surface dure</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Distance verticale à partir de la Taille Dos jusqu&apos;au niveau de Fourche. (&apos;Hauteur: Taille Dos&apos; - &apos;Jambe: Fourche jusqu&apos;au Sol&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Distance verticale à partir de la Taille Devant jusqu&apos;au niveau de Fourche. (&apos;Hauteur: Taille Devant&apos; - &apos;Jambe: Fourche jusqu&apos;au Sol&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>montant_longueur_cote</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation>Longueur Montant, côté</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>montant_longueur_diag</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation>Longueur Montant, diagonale</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation>Mesurer en diagonale à partir de la Taille Côté jusqu&apos;à une ficelle marquant le niveau du début de la jambe, en position assise sur une surface dure.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>montant_longueur_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation>Longueur Montant, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>montant_longueur_dvt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation>Longueur Montant, devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation>Distance verticale à partir du Côté de la Taille jusqu&apos;au niveau de la Fourche. (&apos;Hauteur: Taille Côté&apos; - &apos;Jambe: Fourche jusqu&apos;au Sol&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_dos_a_taille_devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure Dos jusqu&apos;à la Taille Devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>A partir de l&apos;Encolure Dos, en passant par l&apos;encolure côté, rejoindre la Taille Devant (milieu).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_à_taille_opposee</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Taille à Taille Opposée, en passant par l&apos;Encolure Dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>A partir du niveau de Taille, monter verticalement jusqu&apos;à l&apos;encolure, passer par l&apos;Encolure Dos et redescendre jusqu&apos;au niveau de Taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_naturelle_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circonférence Taille naturelle</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonférence du tronc au commencement de l&apos;Échancrure des Obliques Abdominales naturelles masculin, si l&apos;Échancrure de l&apos;oblique ne peut être trouvée alors mesurer juste en dessous du niveau du Nombril.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>demi_taille_naturel_dev</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Demi tour de taille naturel, devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation>De coté à coté au niveau de la taille naturelle, sur le devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_naturelle_arc_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Arc Taille Naturelle, dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation>Au niveau de la Taille Naturelle, mesurer du côté jusqu&apos;à l&apos;autre en passant par le dos. Vérifier en calculant (Circonférence Taille Naturelle - Arc Taille Naturel (devant) ).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_a_taille_naturelle_dvt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Taille Devant à Taille Naturelle Devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur à partir de la Taille Devant jusqu&apos;à la Taille Naturelle Devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_a_taille_naturelle_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Taille Dos à la Taille Naturelle Dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Longueur partant de la Taille Dos allant à la Taille Naturelle Dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_encolure_dos_au_coude_plie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Encolure Dos au Coude, complètement plié</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Plier le Bras avec le Coude vers l&apos;extérieur, main vers le devant. Mesurer de l&apos;Encolure Dos jusqu&apos;à la Pointe du Coude.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_encolure_dos_au_poignet_plie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Encolure Dos au Poignet, complètement plié</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bras Plié avec le Coude vers l&apos;extérieur, main vers le buste. Mesurer de l&apos;Encolure Dos jusqu&apos;à la Pointe du Coude pour arriver à l&apos;Os du Poignet.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_encolure_cote_au_coude_plie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Encolure Côté au Coude, complètement plié</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bras Plié avec le Coude vers l&apos;extérieur, main vers le buste. Mesurer de l&apos;Encolure Côté à la Pointe du Coude.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_encolure_cote_poignet_plie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Encolure Côté au Poignet, complètement plié</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bras Plié avec le Coude vers l&apos;extérieur, main vers le buste. Mesurer à partir de l&apos;Encolure Côté jusqu&apos;à la Pointe du Coude et rejoindre l&apos;Os du Poignet.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_sur_milieu_dos_au_coude_plie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Sur le Milieu Dos jusqu&apos;au Coude, complètement plié</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bras Plié avec le Coude vers l&apos;extérieur, main vers le buste. Mesurer à partir du Milieu Dos jusqu&apos;à la Pointe du Coude.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_sur_milieu_dos_au_poignet_plie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Centrer sur le Milieu Dos au Poignet, complètement plié</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Bras Plié avec le Coude vers l&apos;extérieur, main vers le buste. Mesurer à partir un Milieu Dos jusqu&apos;à la Pointe du Coude et rejoindre l&apos;Os du Poignet.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bras_emmanchure_centre_dos_au_poignet_plie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Bras: Centre de l&apos;Emmanchure Dos au Poignet, complètement plié</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Bras Plié avec le Coude vers l&apos;extérieur, main vers le buste. Mesurer à partir de l&apos;Emmanchure Dos jusqu&apos;à l&apos;Os du Coude.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_dos_au_buste_devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure Dos au Buste Devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>A partir de l&apos;Encolure Dos, passer sur l&apos;Épaule, pour arriver au Buste Devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_dos_aiselle_devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure Dos jusqu&apos;en bas de l&apos;Aisselle Devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>A partir de l&apos;Encolure Dos passer par l&apos;Épaule et arriver au bas de l&apos;Aisselle Devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>encolure_dos_a_emmanchure_devant_a_taille_cote</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Encolure Dos, passant dessus l&apos;Épaule, arriver à la Taille Côté</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Partir de l&apos;Encolure Dos, passer par l&apos;Épaule, descendre le long de la poitrine jusqu&apos;à la Taille Côté.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>milieu_buste_dos_sur_épaule_arriver_bas_aisselle_devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Du haut buste dos, en passant sur l&apos;épaule, arriver à l&apos;aisselle devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>A partir du milieu du buste dans le dos, passer par l&apos;Épaule et arriver au bas de l&apos;Aisselle Devant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>milieu_buste_dos_passer_épaule_arriver_taille_devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Milieu buste dos, passer épaule, arriver taille devant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>À partir du dos haut, sur l&apos;épaule touchant le côté du cou, à la taille avant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>cou_dos_aisselle_devant_cou_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Cou dos, aisselle devant, cou dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation>Du cou dos, en passant sur l&apos;épaule à l&apos;aisselle devant, passer sous le bras et retourner au point de départ.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>centre_milieu_dos_aisselle_devant_centre_milieu_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Au milieu du dos, entouré autour de l&apos;épaule</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation>Du centre du milieu dos, en passant par dessus l&apos;épaule, puis sous le bras, et revenir au début.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>cou_dos_aisselle_devant_haut_buste_dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Cou dos, par aisselle devant, à haut du buste dos</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Du cou dans le dos, par dessus l&apos;épaule jusqu&apos;à l&apos;aisselle devant, en passant sous le bras jusqu&apos;en haut du buste dans le dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Bras croisés devant la poitrine </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>emmanchure_arc</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation>Emmanchure: Arc</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation>A partir de l&apos;Emmanchure Corps Devant au niveau de la poitrine passer par la Pointe Épaule jusqu&apos;au milieu de l&apos;Emmanchure Dos.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>larg_pince_epaule</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Largeur de pince d&apos;épaule</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>Cette information provient de tableaux de certains systèmes de patronage, ex: Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>larg_pince_poitrine</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Largeur de pince de poitrine</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>larg_pince_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Largeur de pince</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>Cette information provient de tableaux de certains systèmes de patronage, ex: Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</translation>

--- a/share/translations/measurements_he_IL.ts
+++ b/share/translations/measurements_he_IL.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>

--- a/share/translations/measurements_id_ID.ts
+++ b/share/translations/measurements_id_ID.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>panjang_bahu</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>

--- a/share/translations/measurements_it_IT.ts
+++ b/share/translations/measurements_it_IT.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Total</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dalla parte superiore della testa al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_collo_dietro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Collo Dietro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale da Collo Dietro (vertebra cervicale) al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_scapola</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Scapola</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dalla Scapola (punto più esterno della scapola) al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_ascella</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Ascella</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dall&apos;Ascella al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_vita_fianco</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Vita Fianco</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dal Fianco Vita al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_anca</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Anca</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dal livello Anca al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_piega_gluteo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Piega Gluteo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dalla piega del Gluteo, dove il muscolo del Gluteo incontra la parte superiore della coscia dietro, al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_ginocchio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Ginocchio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dalla piega dietro il ginocchio al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_polpaccio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Polpaccio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dal punto più ampio del polpaccio al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_caviglia_alto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Caviglia Alta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dal rientro più profondo della parte posteriore della caviglia al pavimento .</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_caviglia</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Caviglia</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dal punto dove la gamba di fronte incontra il piede al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_ancasuperiore</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Anca superiore</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dal livello superiore Anca, dove l&apos;addome anteriore è più sporgente, al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_vita_davanti</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Vita Davanti</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dalla Vita Davanti al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_seno</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Seno</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dal Seno al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_spalla_punta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Punta Spalla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dalla Punta della Spalla al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_collo_fronte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Collo Fronte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dal Collo Davanti al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_lato_collo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Lato Collo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dal Lato Collo al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_collo_dietro_al_ginocchio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Collo Dietro al Ginocchio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dal Collo Dietro (vertebra cervicale) alla piega dietro del ginocchio.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_lato_vita_al_ginocchio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Lato Vita al Ginocchio</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dal Lato Vita alla piega dietro al ginocchio.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_lato_vita_al_fianco</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Lato Vita al Fianco</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dal Lato Vita al Livello Fianco.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_ginocchio_ad_anca</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Ginocchio all&apos;Anca</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dalla piega dietro del ginocchio al punto dove la parte frontale della gamba incontra la parte superiore del piede.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_collo_dietro_al_lato_vita</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Collo Dietro al Lato Vita</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dal Collo Dietro al Lato Vita. (&apos;Altezza:Collo Dietro&apos;-&apos;Altezza:Lato Vita&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>larghezza_spalla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Larghezza: Spalla</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza orizzontale da una Punta della Spalla all&apos;altra Punta della Spalla.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>larghezza_busto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Larghezza: Busto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza orizzontale da Fianco a Fianco del Busto. </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>larghezza_vita</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Larghezza: Vita</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza orizzontale da Fianco a Fianco della Vita.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>larghezza_anca</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Larghezza: Anca</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza orizzontale dal Fianco a Fianco dell&apos;Anca.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>larghezza_ventre_a_anca</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Larghezza:Ventre ad Anca</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza orizzontale dal punto più esterno dell&apos;addome fino al punto più prominente dei fianchi.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tacca_collo_dietro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Tacca: Collo Dietro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza orizzontale tra Scapola (punto più esterno) al Collo Dietro.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tacca_vita_dietro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Tacca: Vita Dietro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza orizzontale tra un bastoncino piatto, posto a toccare anca e scapola, e vita posteriore.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>tacca_caviglia_alta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Tacca: Caviglia Alta</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lunghezza_palmo_mano</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation>Mano: lunghezza palmo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Lunghezza dalla linea del polso alla base del dito medio.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lunghezza_mano</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Mano: Lunghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Lunghezza dalla linea del Polso alla fine del dito medio.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>larghezza_palmo_mano</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation>Mano: larghezza Palmo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Misura dove il palmo è più largo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>circonferenza_palmo_mano</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Mano: circonferenza Palmo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonferenza dove il palmo è più largo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>circ_mano</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Mano: Circonferenza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation>Piega il pollice verso il dito più piccolo, avvicina le dita. Misura la circonferenza attorno alla parte più larga della mano.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>larghezza_piede</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Piede: Larghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Misura della parte più larga del piede.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lunghezza_piede</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Piede: Lunghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation>Misura dal retro del tallone alla fine del dito del piede più lungo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>circ_piede</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Piede: Circonferenza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Misura circonferenza attorno alla parte del piede più larga.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>collodel_piede_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Piede: collo del piede circonferenza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation>Misura circonferenza alla parte più alta del collo del piede.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>testa_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Testa: Circonferenza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Misura circonferenza al punto più largo della testa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lunghezza_testa</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Testa: Lunghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dalla parte più alta della testa al fondo della mascella.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>testa_profondità</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation>Testa: Profondità</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza orizzontale dalla fronte al retro della testa.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>testa_larghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Testa: Larghezza</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza orizzontale da lato a lato della testa, dove è più larga.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>sommità_testa_al_collo_dietro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Testa: Sommità al Collo Dietro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dalla Sommità della testa al Collo Dietro. (&apos;Altezza: Totale&apos; - &apos;Altezza: Collo Dietro&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>testa_mento_al_collo_dietro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Testa: Mento al Collo Dietro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Distanza verticale dal Mento al Collo Dietro. (&apos;Altezza&apos; - &apos;Altezza: Collo Dietro&apos; - &apos;Testa: Lunghezza&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>collo_medio_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation>Circonferenza Collo, sezione di mezzo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonferenza della parte media del collo, circa a metà strada tra la mascella e il tronco.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>collo_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circonferenza collo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonferenza collo alla base del Collo, toccando Dietro il Collo, i Lati del Collo e Parte Anteriore del Collo.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>torace_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circonferenza torace</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonferenza del torace, seguendo la distanza più corta tra le braccia incrociate sul petto, la parte superiore sotto le ascelle.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>busto_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circonferenza busto</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonferenza attorno al busto, parallelo al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>basso_torace_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circonferenza basso torace</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonferenza del basso torace sotto il seno, parallela al pavimento</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>costola_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circonferenza costola</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonferenza attorno alle costole, all&apos;altezza della costola più bassa laterale, parallelo al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>vita_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circonferenza vita</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>fiancoalto_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circonferenza parte alta delle anche</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonferenza attorno alle anche, seguendo il contorno naturale. Le anche di solito sono più alte dietro.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altezza_vita_dietro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Altezza: Anca Posteriore</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonferenza attorno alle Anche, dove l&apos;Addome sporge maggiormente, parallelo al pavimento.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>anche_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circonferenza anche</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circonferenza fianchi nel punto dove i fianchi sono più larghi, parallela al pavimento</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>

--- a/share/translations/measurements_nl_NL.ts
+++ b/share/translations/measurements_nl_NL.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Totaal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand van kruin tot vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_nek_achterkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Nek Achterkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand van rugnek(nekwervel) naar vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_schouderblad</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Schouderblad</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf de schouderbladpunt naar de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_oksel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Oksel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf oksel naar de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_zijkant_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Zijkant Taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf de zijkant van de taille naar de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_heup</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Heup</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf de heup naar de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_bilspier_ronding</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Bilspier Ronding</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf de bilspierronding, waar de spier Gluteus samenkomt met de bovenkant van het dijbeen, naar de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_knie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Knie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf knieholte tot aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_kuit</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Kuit</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf het breedste gedeelte van de kuit tot aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_enkel_hoog</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Enkel Hoog</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf het diepste gedeelte achter de achillespees tot aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_enkel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Enkel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf het punt waar de voorkant van het been overgaat in de voet, tot aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_hogeheup</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Hoge heup</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf het hogere gedeelte van de heup, waar de buik het meest prominent is, tot aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_voorkant_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Taille Voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf de voorkant van de taille tot aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_bustepunt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Bustepunt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf Bustepunt tot aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_schouderpunt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Schouder Punt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf het puntje van de schouder tot aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_keelkuiltje</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Keelkuiltje</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf het kuiltje onderaan de keel tot aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_zijkant_nek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Zijkant Nek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf de zijkant van de nek tot aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_rug_nek_tot_knie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Rugnek tot knie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf de rugzijde van de nek(nekwervel) tot aan vouw van de achterkant van de knie.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_taille_zij_naar_knie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Taille zij naar knie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf zijkant taille tot aan de vouw van de achterkant van de knie.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_taille_zij_naar_heup</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: zijkant Taille naar Heup</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf de zijkant van de taille tot aan heuphoogte.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_knie_tot_enkel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Knie tot enkel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf de vouw van de achterkant van de knie tot aan het punt waar de voorkant van het been en bovenkant van de voet in elkaar overgaan.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_rug_nek_tot_zij_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Rug nek tot zijkant taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf rugzijde van de nek tot aan zijkant van de taille.(&apos;Hoogte: Rugnek&apos; - &apos;Hoogte: Zijkant taille&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation>Verticale afstand van Taille achter tot de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>breedte_schouder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Breedte: Schouder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale afstand van schouderpunt tot schouderpunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>breedte_buste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Breedte: Buste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale afstand van zijkantbuste tot zijkantbuste.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>breedte_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Breedte: Taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale afstand vanaf zijkant taile tot aan zijkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>breedte_heup</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Breedte: Heup</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale afstand vanaf zijkant heup tot aan zijkant heup.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>breedte_buik_naar_heup</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Wijdte: Buik tot heup</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale afstand van het dikste deel van de buik tot aan dikste deel van de heup.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>inham_nek_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Inham: rug nek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale afstand van het schouderblad( blad punt) tot aan de rugzijde van de nek.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>inham_taille_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Inham: Rug taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale afstand op een platte lat welke tegen de heup, schouderblad en taille aan de rugzijde geplaatst is.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>inham_enkel_hoog</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Inham: Enkel hoog</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_palm_lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Palm lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Lengte vanaf midden pols tot aan basis van de middelvinger.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Lengte vanaf midden pols tot aan het einde van de middelvinger.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_palm_breedte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Palm breedte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Meten waar de palm het breedst is.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_palm_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hand : Palm omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Omtrek waar de palm van de hand het breedst is.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hand: Omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation>Plooi de duim naar de pink, houd de vingers strak tegen elkaar. Meet de omtrek rond het breedste deel van de hand.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>voet_breedte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Voet: Breedte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Meten over het breedste gedeelte van de voet.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>voet_lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Voet: Lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation>Meten vanaf de achterkant van de hiel tot aan het einde van de langste teen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>voet_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Voet: Omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Meet de omtrek rond het breedste deel van de voet.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>voet_wreef_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Voet: omtrek wreef</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation>Meet de omtrek op het hoogste deel van de wreef.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoofd_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hoofd: Omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Meet de omtrek van het hoofd waar die het wijdst is.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoofd_lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Hoofd: Lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf hoofdkruin tot aan de onderkant van de kaak.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoofd_diepte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation>Hoofd: Diepte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale afstand van voorhoofd tot aan de achterkant van het hoofd.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoofd_breedte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Hoofd: Breedte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale afstand van zijkant hoofd tot aan zijkant van het hoofd, waar het hoofd het breedst is.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoofd_kruin_naar_rug_nek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Hoofd: Kruin naar rug nek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf Kruin naar de rugzijde van de nek. (&apos;Hoogte: Total&apos; - &apos;Hoogte: Rug nek&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoofd_kin_naar_nek_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Hoofd: Kin naar rug nek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand van kin naar rugzijde van de nek.(&apos;Hoogte&apos; -  &apos;Hoogte: Rug Nek&apos; - &apos;Hoofd: Lengte&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_midden_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation>Nek omtrek, midden gedeelte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation>Omtrek vanaf het middengedeelte van de nek, tot ongeveer halverwege kaak en torso.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Nek Omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Nek omtrek aan de basis van de nek, langs rugzijde van de nek, zijkant nek en voorkant van de nek.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hogebuste_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hoge buste omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation>Omtrek van het hoge gedeelte van de borstkas, langs de kortste afstand over de hoge borst, hoog onder de oksels.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>borst_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Borst Omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Omtrek rondom de borst, parallel aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lageborst_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Lage borst omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Omtrek rondom het lage gedeelte van de borst onder de borsten, parallel aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ribbenkast_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Ribbenkast omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Omtrek van de ribbenkast op het laagste gedeelte van de ribbenkast aan de zijkant, parallel aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Taille omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hogeheup_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Hogeheup omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation>Omtrek rond de taille, de natuurlijke contouren volgend. Tailles zijn vrijwel altijd hoger op de rug.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hoogte_taille_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Hoogte: Taille Rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale afstand op een platte lat welke loodrecht tegen de hiel en de grootste inham van de enkel geplaatst is.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Omtrek rond de Hogeheup, waar buik het meest vooruitsteekt, parallel aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>heup_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Heup Omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Omtrek rond Heup waar Heupbolling het meest uitsteekt, parallel aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_ronding_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Nek ronding, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek tot aan andere zijkant nek via voorkant hals.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hogeborst_ronding_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Hogeborst ronding, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Van hoge borst zijde( oksel) tot andere hoge borst zijkant ( oksel) via borstkas.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>buste_ronding_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Buste ronding, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant buste naar zijkant buste via borstkas.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>maat</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation>Maat</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation>Zelfde als buste_ronding_voorkant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lage_buste_ronding_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Lage busteronding, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van lagebustezijkant naar lagebustezijkant via voorkant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_ronding_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Ribronding, Voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van Ribzijkant naar Ribzijkant, via voorkant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_ronding_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Taille ronding, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant taille naar zijkant taille via voorkant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hogeheup_ronding_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Hogeheup ronding, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van Hogeheup zijkant tot aan hogeheup zijkant via voorkant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>heup_ronding_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Heupronding, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant heup naar zijkant heup via voorkant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_ronding_helft_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Nekronding, voorkant, helft</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Nekronding, voorkant&apos;. (&apos;Nek ronding, voorkant&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hogeborst_ronding_helft_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hogeborstronding, voorkant, helft</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;hogeborstronding, voorkant&apos;. Van hogeborst voorkant naar hogeborst zijkant. (Hogeborst ronding, voorkant&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>buste_ronding_helft_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Busteronding, voorkant, helft</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Busteronding, voorkant&apos;. ( Busteronding, voorkant&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lagebuste_ronding_helft_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Lagebusteronding, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Lagebusteronding, voorkant&apos;. (&apos;Lagebusteronding, voorkant&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_ronding_helft_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Ribronding, voorkant, helft</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Ribronding, voorkant&apos;. (&apos;Ribronding, voorkant&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_ronding_helft_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Tailleronding, voorkant, helft</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Tailleronding, voorkant&apos;. (&apos;Tailleronding, voorkant&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hogeheup_ronding_helft_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Hogeheupronding, voorkant, helft</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;hogeheupronding, voorkant&apos;. (&apos;Hogeheupronding, voorkant&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>heup_ronding_helft_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Heupronding, voorkant, helft</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Heupronding, voorkant&apos;. (&apos;Heupronding, voorkant&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Nekronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek naar zijkant nek via rug. (&apos;Nek omtrek&apos; - &apos;Nekronding, voorkant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hogebuste_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Hogebusteronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant hogebuste naar zijkant hogebuste via rug. (&apos;Hogebuste omtrek&apos; - &apos;Hogebusteronding, voorkant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>buste_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Busteronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant buste naar zijkant buste via rug. (&apos;Buste omtrek&apos; - &apos;Busteronding, voorkant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lagebuste_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Lagebusteronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant lagebuste naar zijkant lagebuste via rug. (&apos;Lagebuste omtrek&apos; - &apos;Lagebusteronding, voorkant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Ribronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant rib naar zijkant rib via rug. (&apos;Rib omtrek&apos; - &apos;Ribronding, voorkant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Tailleronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van taillezijde naar taillezijde via rug. (&apos;Taille omtrek&apos; - &apos;Taille ronding, voorkant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hogeheup_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Hogeheup ronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van hogeheupzijde naar hogeheupzijde via rug. (&apos;Hogeheup omtrek&quot; - &apos;Hogeheup ronding, voorkant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>heup_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Heup ronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van heupzijde naar heup zijde via rug. (&apos;Heup omtrek&apos; - &apos;Heup ronding, voorkant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>halve_nek_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Halve nekronding rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Nek ronding, rug&apos;. (&apos;Nekronding, rug&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>halve_hogebuste_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Helft hogebust ronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Hogebust ronding, rug&apos;. Van hogebust rug naar hogebust zij. (&apos;Hogebust ronding, rug&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>halve_buste_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Halve busteronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;busteronding, rug&apos;. (&apos;Busteronding, rug&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>halve_lagebuste_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Halve lagbusteronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Lagebusteronding, rug&apos;. (&apos;Lagebusteronding, rug&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>halve_rib_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Halve ribronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Ribronding, rug&apos;. (&apos;Ribronding, rug&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>halve_taille_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Halve tailleronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Tailleronding, rug&apos;. (&apos;Tailleronding, rug&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>halve_hogeheup_ronding_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Halve hogeheupronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Hogeheupronding, rug&apos;. Van hogeheup rug naar hogebuste zijde. (&apos;Hogeheupronding, rug&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>halve_heup_ronding</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Halve heupronding, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Heupronding, rug&apos;. (&apos;Heupronding, rug&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>heup_met_onderbuik_ronding_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation>Heupronding met onderbuik, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>romp_armplooi_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation>Romp omtrek op de hoogte van de armplooi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation>Meten rond armen en torso ter hoogte van de armplooi.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>romp_buste_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation>Romp omtrek ter hoogte van de buste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Meten rond armen en torso ter hoogte van de buste.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>romp_torso_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation>Romp omtrek van volledige torso</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation>Omtrek rond torso van midden schouder via kruis en weer terug naar midden schouder.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>heup_omtrek_met_onderbuik</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation>Heup omtrek, inclusief onderbuik</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation>Meten ter hoogte van de heup, inclusief het uitsteken van de onderbuik.( Heup ronding, rug + heup ronding met onderbuik, voorkant).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_voorkant_naar_taille_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Nek voorkant naar taille voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_naar_taille_vlak_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation>Voorkant nek naar voorkant taille, vlak gemeten</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van voorkant nek naar beneden tussen borsten naar voorkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>oksel_naar_zijkant_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Oksel naar zijkant Taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Van oksel naar beneden naar zijkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouderpunt_naar_zijkant_taille_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Schouderpunt naar zijkant taille, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Van schouderpunt, om de voorkant armplooi gedraaid, daarna naar beneden naar zijkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijkant_naar_taille_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Zijkant nek naar taille, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek direct naar beneden tot voorkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijkant_naar_taille_bustepunt_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Zijkant nek naar taillehoogte, via bustepunt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek over bustepunt naar taille, een rechte lijn vormend.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_voorkant_naar_hogebuste_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Voorkant nek naar voorkant hogebuste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Voorkant nek naar beneden naar voorkant hogebuste.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hogebuste_naar_taille_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Voorkant hogebuste naar voorkant taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>voorkant_nek_naar_buste_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Voorkant nek naar voorkant buste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>buste_naar_taille_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Voorkant buste naar voorkant taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van voorkant buste naar beneden naar taille. (&apos;voorkant nek naar voorkant taille&apos; - &apos;Voorkant nek naar voorkant buste&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lagebuste_naar_taille_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Voorkant lagebuste naar voorkant taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van voorkant lagebuste naar beneden naar voorkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rib_naar_zijkant_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Zijkant rib naar zijkant taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Van onderste rib aan zijkant naar beneden naar zijkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouder_punt_naar_armplooi_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Schouderpunt naar voorkant armplooi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van schouderpunt tot voorkant armplooi over lijn armsgat.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijkant_tot_borst_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Zijkant nek tot borstlijn, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Zijkant nek tot borstlijn, voorkant en recht naar beneden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijkant_tot_bovenborst_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Zijkant nek tot bovenborstlijn, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Zijkant nek tot bovenborstlijn, voorkant en recht naar beneden.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouder_midden_tot_hogeborst_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Midden van schouder tot hogeborstlijn, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Van midden schouder tot hogeborstlijn, richting borstpunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouderpunt_tot_taille_zijkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Schouderpunt tot zijkant taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Van schouderpunt, rondom armsgat rug, tot aan zijkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijkant_tot_taille_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Zijkant nek tot taille, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek direct naar beneden achterkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_rug_naar_taille_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Nek rug naar taille rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Van Nek rug naar taille rug.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijde_naar_taille_schouderblad_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Nek zijde naar taille, over schouderblad</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>Van nekzijde schouderblad kruisend naar beneden naar taille, een rechte lijn vormend.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_rug_naar_hogebuste_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Nek rug naar hogebuste rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Van nek rug naar beneden naar hogebuste rug.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hogebuste_naar_taille_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Hogebuste rug naar taille rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van hogebuste rug naar beneden naar taille rug.(&apos;Nek rug naar taille rug&apos; - &apos;Nek rug naar hogebust rug&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_rug_naar_buste_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Nek rug naar buste rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Van nek rug naar buste rug.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>buste_naar_taille_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Buste rug naar taille rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van hogebuste rug naar taille rug. (&apos;Nek rug naar taille rug&apos; - &apos;Nek rug naar hogebust rug&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lagebuste_naar_taille_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Lagebuste rug naar taille rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Van lagebuste rug naar taille rug.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouderpunt_naar_armplooi_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Schouderpunt naar armplooi rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Van schouderpunt rond armsgat naar armplooi rug.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijde_naar_buste_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Nek zijde naar buste rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Van nek zijde direct naar rug buste niveau.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijde_naar_hogebuste_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Nek zijde naar hogebuste niveau, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Van nek zijde direct naar rug hogebuste niveau.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouder_midden_naar_hogebuste_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Schouder midden naar hogebuste, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation>Van mid-schouder naar hogebuste niveau, over schouderblad.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_naar_hogeheup_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Voorkant taille naar voorkant hogeheup</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van voorkant taille naar voorkant hogeheup.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_naar_heup_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Voorkant taille naar voorkant heup</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van voorkant heup naar voorkant heup.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_naar_hogeheup_zijde</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Taillezijde naar hogeheup zijde</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Van taille zijde naar hogeheup zijde.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_naar_hogeheup_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Taille rug naar hogeheup rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Van Taille rug naar hogeheup rug.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_naar_heup_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Taille rug naar Heup rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_naar_heup_zijde</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Taille zijde naar heup zijde</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Van taille zijde naar heup zijde.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouder_helling_nek_zijde_hoek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Hoek van Schouderhelling aan nekzijde</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Hoek gevormd door de lijn van nek zijde naar schouderpunt en lijn van nek zijde parallel aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouder_helling_nek_zijde_lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Schouder helling lengte van nek zijde</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand tussen nek zijde en schouderpunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouder_helling_nek_rug_hoek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Schouder helling hoek aan nek rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Hoek gevormd door de lijn van nek rug naar schouderpunt en lijn van nek rug parallel aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouder_helling_nek_rug_hoogte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Schouder helling lengte aan nek rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand tussen nek rug en schouder punt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouder_helling_schouder_punt_hoek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Schouder helling hoek aan schouder punt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Hoek gevormd door de lijn van nek zijde naar schouderpunt en verticale lijn op schouder punt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_rug_naar_rugbreedtelijn</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Nek rug verticaal naar de lijn van rugbreedte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation>Van nek rug, verticaal naar de lijn waarover rugbreedte wordt gemeten.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>rugbreedte_lijn_naar_taille_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation>Rugbreedtelijn naar taille rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation>Van het midden van de lijn waarover rugbreedte wordt gemeten verticaal naar taille rug.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouder_lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation>Schouder lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Van nek zijde naar schouder punt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouder_punt_naar_schouder_punt_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation>Schouderpunt naar schouderpunt, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van schouderpunt naar schouderpunt, langs voorkant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>breedte_borst_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation>Breedte borst</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Van armsgat naar armsgat op de smalste breedte over borst.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armplooi_naar_armplooi_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation>Armplooi naar armplooi, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Van armplooi naar Armplooi, kortste afstand tussen armplooien, niet paralell aan de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouder_punt_naar_schouder_punt_helft_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Schouder punt naar schouder punt, voorkant, helft</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van schouderpunt naar schouderpunt, voorkant. (&apos;Schouderpunt naar schouderpunt, voorkant&apos; /2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>breedte_borst_helft_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation>Breedte borst, helft</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Breedte borst&apos;. (&apos;Breedte borst&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouder_punt_naar_schouder_punt_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation>Schouderpunt naar schouderpunt, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>Van schouderpunt naar schouderpunt, over de rug.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>breedte_rug_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Breedte Rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation>Van armsgat naar armsgat op de smalste breedte van de rug.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armplooi_naar_armplooi_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation>Armplooi naar armplooi, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>Van armplooi naar armplooi over de rug.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouder_punt_naar_schouder_punt_helft_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Schouderpunt naar schouderpunt, rug, helft</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Schouderpunt naar schouderpunt, rug.&apos; (&apos;Schouderpunt naar schouderpunt, rug&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>breedte_rug_helft_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Breedte rug, helft</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;breedte rug&apos;. (&apos;Breedte rug&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_voorkant_naar_schouder_punt_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Nek voorkant naar schouderpunt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Van voorkant nek(hals) naar schouderpunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_rug_schouder_punt_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Nek rug naar schouderpunt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Van nek rug naar schouderpunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_breedte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation>Nek breedte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation>Meten tussen de uiteinden van een niet-afgesloten halsband of ketting gedrapeerd rond de nek.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustepunt_naar_bustepunt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Bustepunt naar bustepunt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Van bustepunt naar bustepunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustepunt_naar_nek_zijkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Bustepunt naar zijkant nek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek naar bustepunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustepunt_naar_lagebuste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation>Bustepunt naar lage buste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Van bustepunt verticaal naarlage buste, de ronding volgend van de buste of borstkas.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustepunt_naar_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>Bustepunt naar taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation>Van bustepunt recht naar beneden tot tailleniveau, een rechte lijn vormend (niet gebogen langs het lichaam).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustepunt_naar_bustepunt_helft</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation>Bustepunt naar bustepunt, helft</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Helft van &apos;Bustepunt naar bustepunt&apos;. (&apos;Bustepunt naar bustepunt&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustepunt_nek_zijkant_naar_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>Bustepunt, zijkant nek naar taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van de zijkant van de nek naar Bustepunt, dan recht naar beneden tot niveau taille. (&apos;Zijkant nek naar bustepunt&apos; + &apos;Bustepunt naar taille&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustepunt_naar_schouder_punt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Bustepunt naar schouderpunt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Van bustepunt naar schouderpunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustepunt_naar_taille_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Bustepunt naar voorkant taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation>Van bustepunt naar voorkant taille, in een rechte lijn, niet de de rondingen van het lichaam volgend.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustepunt_naar_bustepunt_halter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation>Bustepunt naar bustepunt halterlijn</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Van bustepunt rond de nek terug naar beneden naar het andere bustepunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustepunt_naar_schouder_midden</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation>Bustepunt naar het midden van de schouder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Van midden van de schouder naar bustepunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>bustepunt_naar_nek_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Bustepunt naar voorkant nek (hals)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Van voorkant nek (hals) naar bustepunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouder_punt_naar_taille_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Schouderpunt naar voorkant taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van schouderpunt diagonaal naar voorkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_voorkant_naar_taille_zijkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Hals naar zijkant taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Van voorkant hals diagonaal naar zijkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijkant_naar_taille_zijkant_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Nek zijkant naar zijkant taille, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek diagonaal via voorkant naar zijkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouderpunt_naar_taille_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Schouderpunt naar taille op de rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Van schouderpunt diagonaal naar taille op de rug.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>schouderpunt_naar_taille_rug_1in_offset</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation>Schouderpunt naar taille rug, met 1in (2.54cm) offset</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation>Markeer 1 inch (2.54cm) naar buiten van taille rug op de taillelijn. Meet van het schouderpunt diagonaal naar markeerpunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_rug_naar_taille_zijkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Nek rug naar zijkant taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Van nek rug diagonaal over rug naar zijkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijkant_naar_taille_zijkant_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Zijkant nek naar zijkant taille, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek diagonaal via rug naar zjikant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijkant_naar_armplooi_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Zijkant nek naar voorkant armplooi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek diagonaal naar voorkant armplooi.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijkant_naar_oksel_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Zijkant nek naar zijkant hoge buste, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek diagonaal via voorkant naar zijkant hoge buste(oksel).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijkant_naar_buste_zijkant_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Zijkant nek naar zijkant buste, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Zijkant nek diagonaal via voorkant naar zijkant buste.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijkant_naar_armplooi_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Zjikant nek naar rugkant armplooi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek diagonaal naar rugkant armplooi.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijkant_naar_oksel_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Zijkant nek naar zijkant hoge buste, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek diagonaal via rugkant naar zijkant hoge buste(oksel).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_zijkant_naar_buste_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Zijkant nek naar zijkant buste, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Zijkant nek diagonaal via rug naar zijkant buste.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_schouderpunt_naar_pols_gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: schouderpunt naar pols, gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Gebogen arm, meet van schouderpunt via elleboog naar radiale polsbot.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_schouderpunt_naar_elleboog_gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: schouderpunt naar elleboog, gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Gebogen arm, meten van schouderpunt naar elleboogpunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elleboog_naar_pols_gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: elleboog naar pols, gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Elleboogpunt naar pols. (&apos;Arm: schouderpunt naar pols, gebogen&apos; - &apos;Arm: schouderpunt naar elleboog, gebogen&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elleboog_omtrek_gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: Omtrek elleboog, gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation>Omtrek elleboog, arm is gebogen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_schouderpunt_naar_pols</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: schouder punt naar pols</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Van schouderpunt naar polsbotje, gestrekte arm.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_schouderpunt_naar_ellebooog</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: schouderpunt naar elleboog</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Van schouderpunt naar elleboogpunt, met gestrekte arm.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elleboog_naar_pols</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: elleboog naar pols</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van elleboog naar pols, met gestrekte arm. (&apos;Arm: schouderpunt naar pols&apos; _ &apos;Arm: schouderpunt naar elleboog&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_oksel_naar_pols</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: oksel naar pols, binnenkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Van oksel tot ellepijpbot van de pols, met gestrekte arm.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_oksel_naar_elleboog</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: oksel naar elleboog, binnenkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Van oksel naar binnenkant elleboog, met gestrekte arm.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elleboog_naar_pols_binnenkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: elleboog naar pols, binnenkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van binnenkant elleboog naar pols. (&apos;Arm: oksel naar pols, binnenkant&apos; - &apos;Arm: oksel naar elleboog, binnenkant&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_bovenarm_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: omtrek bovenarm</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm omtrek ter hoogte van de oksel.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_boven_elleboog_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: omtrek boven elleboog</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm omtrek op de biceps.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_elleboog_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: elleboog omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Omtrek elleboog, met gestrekte arm.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_onderarm_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: omtrek onderarm</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Arm omtrek waar onderarm het wijdst is.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_pols_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: pols omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation>Polsomtrek.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_schouder_punt_naar_armplooi_ljin</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: schouderpunt naar armplooilijn</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>Van schouderpunt naar beneden tot het niveau van de oksel.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_nek_zijkant_naar_pols</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: zijkant nek naar pols</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek naar pols. (&apos;Schouderlengte&apos; + &apos;Arm: schouderpunt naar oksel&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_nek_zijkant_naar_vingertop</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: zijkant nek naar vingertop</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek naar beneden via de arm tot top van de middelvinger. (&apos;Schouderlengte&apos; + &apos;Arm: schouderpunt naar pols&apos; + &apos;Hand: lengte&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armsgat_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Armsgat: omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation>Laat de arm langs je zijde hangen. Meet de omtrek van de armsgat via schouderpunt en oksel.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armsgat_lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Armsgat: lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf schouderpunt tot oksel.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armsgat_breedte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Armsgat: breedte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Horizontale afstand tussen voorkant armsgat en rugkant armsgat.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_nek_zijkant_naar_buitenkant_elleboog</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: zijkant nek tot elleboog</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant nek over de schouderpunt tot elleboog. (Schouderlengte + Arm: schouderpunt tot elleboog).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>been_kruis_naar_vloer</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Been: kruis naar vloer</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Zet je voeten tegen elkaar. Meet vanaf het kruis (op het lichaam, zonder extra ruimte) tot de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Vanaf zijkant taille via ronding naar heup en dan recht naar beneden tot het niveau van de knie. (&apos;Been: zijkant taille naar vloer&apos; - &apos;Kniehoogte&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Breng tape aan over bilspleet ter hoogte van de heup. Meet van taille voorkant tussen de benen tot taille rug.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation>Breng tape aan over bilspleet ter hoogte van de heup. Meet van taille rug naar het midden van het kruis, ter hoogte van de vagina of tussen de testikels en de anus.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>zit_hoogte_zijkant_zittend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf zijkant taille naar beneden naar kruis hoogte. Gebruik formule (Hoogte: zijkant taille - Been: Kruis naar vloer).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>Deze informatie komt uit patroontabellen van verschillende patroontekensystemen, bv. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>been_taille_zijkant_vloer</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Buig stijf karton rond de voorkant van de buik, maak aan de zijkant vast met tape. Meet van zijkant heup naar zijkant heup over het karton langs de voorkant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van voorkant hals, over tape tussen bustepunten, naar voorkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van voorkant hogebuste naar voorkant taille, over tape die overbrugt tussen bustepunten.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation>Van voorkant hals naar voorkant buste. Overbrug met tape tussen bustepunten.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation>Van taille rug naar heup rug. Gebruik tape om te overbruggen over bilspleet.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Been: zijkant taille naar vloer</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant taille via ronding naar heup en dan recht naar beneden naar de vloer.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>been_dij_boven_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Been: omtrek bovenbeen (dij)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation>Dij omtrek om het dikste gedeelte van het bovenbeen vlakbij het kruis.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>been_dij_midden_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Been: midden dij omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Dij omtrek ongeveer halverwege tussen kruis en knie.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>been_knie_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Been: knie omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Knie omtrek met gestrekt been.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>been_knie_smal_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Been: omtrek smalste gedeelte van de knie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Been omtrek net onder de knie.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>been_kuit_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Been: kuit omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Kuit omtrek op het breedste gedeelte van het onderbeen.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>been_enkel_hoog_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Been: hoge enkel omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation>Enkel omtrek waar de inham aan de achterkant het diepst is.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>been_enkel_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Been: enkel omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Enkel omtrek waarde voorkant van het been overgaat in de wreef van de voet.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>been_knie_omtrek_gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Been: knie omtrek, gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation>Knie omtrek met gebogen been.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>been_enkel_diagonaal_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Been: enkel diagonale omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation>Diagonale enkel omtrek van wreef tot onderkant hiel.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>been_kruis_naar_enkel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Been: kruis naar enkel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van kruis naar enkel. (&apos;Been: kruis naar vloer&apos; - &apos;Hoogte: enkel&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>been_taille_zijkant_naar_enkel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Been: zijkant taille naar enkel</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant taille naar enkel. (&apos;Been: zijkant taille naar vloer&apos; - &apos;Hoogte: enkel&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>been_taille_zijkant_naar_knie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Been: zijkant taille naar knie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kruis_lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation>Kruis lengte</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kruis_lengte_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation>Kruislengte, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>kuis_lengte_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation>Kruislengte, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Van voorkant taille naar begin van de vagina of eind testikels. (&apos;Kruislengte&apos; - &apos;Kruislengte, rug).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation>Zithoogte, zijkant, zittend</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant taille via heup ronding naar beneden naar oppervlakte, zittend op een harde rechte ondergrond.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf taille rug naar kruishoogte. (&apos;Hoogte: taille rug&apos; - &apos;Been: kruis naar vloer&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Verticale afstand vanaf voorkant taille naar kruishoogte. (&apos;Hoogte: voorkant taille&apos; - &apos;Been: kruis naar vloer&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>zithoogte_lengte_zijkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation>Zithoogte, zijkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>zithoogte_lengte_diagonaal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation>Zithoogte, diagonaal</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation>Meet vanaf zijkant taille diagonaal naar een lint vastgebonden aan het begin van een been, zittend op een harde rechte ondergrond.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>zithoogte_lengte_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation>Zithoogte, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>zithoogte_lengte_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation>Zithoogte, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_rug_naar_taille_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Nek rug naar voorkant taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van rugnek via zijkant nek naar beneden naar voorkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_naar_taille_halter</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Taille naar taille halter, via rugnek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Vanaf taille niveau via rugnek naar taille niveau.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_natuurlijke_omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Natuurlijke taille omtrek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation>Torso omtrek ter hoogte van &apos;s mans natuurlijke schuine buikspierenrondingen, wanneer schuine buikspierrondingen er niet zijn dan net onder de navel.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_natuurlijke_boog_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Natuurlijke taille boog, voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant naar zijkant op natuurlijke taillelijn, via de voorkant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_natuurlijke_boog_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Natuurlijke taille boog, rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation>Van zijkant naar zijkant op natuurlijke taillelijn, via de rug. Bereken als ( Natuurlijke taille omtrek - Natuurlijke taille boog (voorkant) ).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_naar_natuurlijke_taille_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Voorkant taille naar natuurlijke voorkant taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Lengte van voorkant taille naar voorkant natuurlijke taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>taille_naar_natuurlijke_taille_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Taille rugkant naar rugkant natuurlijke taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Lengte van rugkant taille naar rugkant natuurlijke taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_nek_rug_naar_elleboog_gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: rugnek naar elleboog, hoog gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Gebogen arm met elleboog omhoog, hand aan de voorkant. Meet vanaf rugnek naar elleboogpunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_nek_rug_naar_pols_gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: rugnek naar pols, hoog gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Gebogen arm met elleboog omhoog, hand aan de voorkant. meet vanaf rugnek naar elleboogpunt door naar polsbotje.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_nek_zijkant_naar_elleboog_gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: zijkant nek naar elleboog, hoog gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Gebogen arm met elleboog omhoog, hand aan de voorkant. Meet vanaf zijkant rug naar elleboogpunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_nek_zijkant_naar_pols_gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: zijkant nek naar pols, hoog gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Gebogen arm met elleboog omhoog, hand aan de voorkant. Meet vanaf zijkant nek naar elleboogpunt naar polsbotje.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_midden_rugbreedtelijn_naar_elleboog_gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: midden rugbreedtelijn naar elleboog, hoog gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Gebogen arm met elleboog omhoog, hand aan de voorkant. Meet vanaf midden van de rug naar elleboogpunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_midden_rugbreedtelijn_naar_pols_gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: midden rugbreedtelijn naar pols. hoog gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation>Gebogen arm met elleboog omhoog, hand aan de voorkant. Meet vanaf het midden van de rug naar elleboogpunt naar polsbotje.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>arm_armsgat_rug_midden_naar_pols_gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation>Arm: armsgat rug midden naar pols, hoog gebogen</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Gebogen arm met elleboog omhoog, hand aan de voorkant. Meet vanaf armsgat rugkant naar elleboogpunt.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_rug_naar_buste_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Rugnek naar voorkant buste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van rugnek, over schouder, naar voorkant buste.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_rug_naar_armplooi_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Rugnek naar voorkant armplooi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van rugnek over schouder naar voorkant armplooi.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_rug_naar_armplooi_voorkant_naar_taille_zijkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Rugnek, over schouder, naar zijkant taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Van rug nek, over schouder, naar beneden over borstkas naar zijkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hogebuste_rug_over_schouder_naar_armplooi_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Rugkant hogebuste, over schouder, naar voorkant armplooi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van rugkant hogebuste over schouder naar voorkant armplooi.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hogebuste_rug_over_schouder_naar_taille_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Hogebuste rugkant, over schouder, naar voorkant taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Van rugkant hogebuste, over schouder de nekzijde rakend, naar voorkant taille.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_rug_naar_armplooi_voorkant_naar_nek_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Rugnek, naar voorkant armplooi, naar rugnek</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation>Van rugnek, over schouder naar voorkant armplooi, onder arm en terug naar het begin.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>midden_rugbreedtelijn_naar_armplooi_voorkant_naar_midden_rugbreedtelijn</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Midden rugbreedtelijn, cirkelend rond schouder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation>Van midden van de lijn waarover rugbreedte wordt gemeten, over schouder, onder arm, en terug naar het begin.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>nek_rug_naar_armplooi_voorkant_naar_hogebuste_rug</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Rugnek, naar voorkant armplooi, naar rugkant hogebuste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Van rugnek over schouder naar voorkant armplooi, onder arm naar rugkant hogebuste.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armplooi_naar_armplooi_buste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Armplooi naar armplooi, voorkant, gekromd langs voorkant buste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Meet in een boog van armplooi linker voorkant via voorkant buste gekromd naar boven naar armplooi rechter voorkant.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armplooi_naar_buste_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Armplooi naar voorkant buste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation>Meet van voorkant armplooi naar voorkant buste, kortste afstand tussen de twee, zo gestrekt mogelijk.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hogebuste_rug_over_schouder_naar_hogebuste_voorkant</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation>Hogebuste rugkant, over schouder, naar hogebuste level</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Van rugkant hogebuste, over schouder, dan richting bustepunt, stop meting ter hoogte van hogebuste level.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>armsgat_boog</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation>Armsgat: boog</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Van armsgat op borstbreedtelijn over schouderpunt naar armsgat op rugbreedtelijn.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>figuurnaad_breedte_schouder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Figuurnaadbreedte: schouder</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation>Deze informatie komt uit patroontabellen van verschillende patroontekensystemen, bv. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>figuurnaad_breedte_buste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Figuurnaadbreedte: buste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>figuurnaad_breedte_taille</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Figuurnaadbreedte: taille</translation>

--- a/share/translations/measurements_pt_BR.ts
+++ b/share/translations/measurements_pt_BR.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Total</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distância vertical do topo da cabeça ao chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Altura_pescoço_costas</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Pescoço Costas</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distância vertical entre percoço costas (vértebra cervical) e o chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Altura_escápula</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Escápula</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distância vertical entre a Escápula (ponto saliente) ao chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_axila</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Axila</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distância vertical entre a axila e o chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_lateral_cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Lateral da cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distância vertical entre a lateral da cintura e o chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_quadril</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Quadril</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distância vertical do quadril ao chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_grande_quadril</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Grande Quadril</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>distância vertical da dobra do quadril, região onde os glúteos encontram a parte superior das costas da coxa, até o chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_joelho</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Joelho.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distância vertical da dobra traseira do joelho ao chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_panturrilha</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Panturrilha</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distância vertical entre a maior circunferência da panturrilha e o chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_superior_tornozelo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Topo do Tornozelo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_tornozelo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Tornozelo</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distância vertical do ponto onde a parte frontal da perna encontra o pé , até o chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_pequeno_quadril</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Pequeno Quadril</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distância vertical entre o pequeno quadril, onde a parte frontal do abdomem é mais proeminente, até o chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_frontal_cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Frontal da Cintura</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distância vertical entre a parte frontal da cintura e o chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_bico_peito</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Bico do Peito</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distância vertical entre o bico do peito e o chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_ponta_do_ombro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Ponta do Ombro</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>DistÂncia vertical entre a ponta do ombro e o chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>altura_frontal_pescoço</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Altura: Frontal do Pescoço</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distância vertical entre a parte frontal do pescoço e o chão.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>

--- a/share/translations/measurements_ro_RO.ts
+++ b/share/translations/measurements_ro_RO.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțimea</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation>Înăltime: Totală</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța pe verticală de la creștetul capului la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înâlțime_gât_spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Gât Spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la Ceafă (vertebra cervicală) la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_omoplat</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Omoplat</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la omoplat (punctul placii omoplatului) la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_subraț</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Subraț</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la subraț la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_talie_lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Talie Lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la Talia Laterală la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_șold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Șold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la Șold la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_fald_fesă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Fald Fesă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la faldul fesei, unde mușchiul fesei întâlnește partea de sus a spatelui coapsei pâna la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_genunchi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Genunchi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la partea din spate a genunchiului la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_gambă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Gambă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la cel mai gros punct al gambei la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_înălțime_gleznă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Înălțime Gleznă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanta verticala de la cea mai mare adâncitură din spatele gleznei la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_gleznă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Gleznă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la punctul unde partea frontală a piciorului se întâlnește cu laba piciorului până la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_șold_înalt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Șold Înalt</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la nivelul Șoldului Înalt, unde parte de abdomen din față este cea mai proeminentă, până la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_talie_față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Talie Față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la talie în față până la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_punct_piept</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Punctul Pieptului</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la Punctul Pieptului până la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_vîrf_umăr</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Vîrf Umăr</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la vîrful umărului la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_gât_față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Gât Față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la Gât Față la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_laterală_gât</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime:  Laterală Gât</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la laterala gâtului la podea.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_spate_gât_la_genunchi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Spate Gât pâna la Genunchi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la Spatele Gătului (vertebre cervicale) până la faldul din partea din spate a genunchiului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_talie_laterală_la_genunchi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Talie Laterală la Genunchi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală a Taliei Laterale la faldul din partea din spate a genunchiului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_talie_laterală_la_șold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Talie Laterală la Șold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la Talia Laterală până la nivelul Șoldului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_genunchi_la_gleznă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Genunchi la Gleznă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanta verticala de la faldul din partea din spate a genunchiului până la punctul unde piciorul din față întâlnește partea de sus a labei piciorului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>înălțime_spate_gât_la_talia_laterală</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Înălțime: Spate Gât la Talia Laterală</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la Gât la Talie. (&apos;Înălțime: Gât&apos; - &apos;Înălțime: Talie&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lățime_umăr</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Lățime: Umăr</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța orizontală de la extremitate umăr la extremitate umăr.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lățime_piept</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Lățime: Piept</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța orizontală din partea stângă la Piept în partea dreaptă la Piept.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lățime_talie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Lățime: Talie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța orizontală dintr-o parte în cealaltă a Taliei.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lățime_șold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Lățime: Șold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța orizontală de la Șold la Șold.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>lățime_abdomen_la_șold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Lățime: Abdomen la Șold</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța orizontală de la cea mai mare proeminență a abdomenului la cea mai mare proeminență a șoldului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>marcare_gât_spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Marcare: Gât Spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța orizontală de la Omoplat (punctul placa omoplat) la spatele gâtului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>marcare_talie_spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Marcare: Talie Spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța orizontală dintre un băț drept, plasat să atingă Șoldul și Omoplatiul și Talia la spate.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>marcare_înălțime_gleznă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Marcare: înălțime Gleznă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>mâna_lungime_palmă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation>Mâna: lungime Palmă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Lungimea de la linia de încheietura a mâinii până la baza degetului mijlociu.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>mână_lungime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Mână: Lungime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Lungimea de la linia de încheietura a măinii până la vârful degetului mijlociu.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>mâna_lățime_palma</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation>Mâna: lățime Palma</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Măsura Palmei unde este cea mai lată.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>mâna_circ_palmă</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Mâna: Circumferința Palmei</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumferința Palmei în cel mai lat loc.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>mâna_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Mână: Circumferința</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation>Îndreaptă degetul mare spre degetul mic, adu degetele aproape împreună. Măsura circumferinta in jurul celei mai mare parți ale mâinii.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>labă_picior_lățime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Labă Picior: Lățime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Măsura celei mai mari parți a labei piciorului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>labă_picior_lungime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Labă Picior: Lungime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation>Măsură de la spatele călcâiului până la vârful celui mai lung deget de la picior.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>labă_picior_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Labă Picior: Circumferință</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Măsura circumferinței in jurul celei mai mari parți a labei piciorului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>labă_picior_înalțime_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Labă Picior: Înălțime Circumferință</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation>Măsura Circumferinței celei mai înalte parți a scobiturii gleznei.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>cap_circumferință</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Cap: Circumerință</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Măsura cele mai mari Circumferințe a capului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>cap_lungime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Cap: Lungime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la creștetul capului până la partea de jos a maxilarului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>cap_adâncime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation>Cap: Adâncime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța orizontală de la frunte la ceafă.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>cap_lățime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Cap: Lățime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța orizontală (lățimea) a capului dintr-o parte in cealaltă în partea cea mai largă.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>cap_creștet_spate_gât</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Cap: Creștet până la Spatele Gâtului</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la Creștet la spatele gâtului. (&apos;Înălțime: Total&apos; - &apos;Înălțime: Spate Gât&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>cap_bărbie_la_spate_gât</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Cap: Bărbie la Spate Gât</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală de la bărbie până la spatele gâtului. (&apos;Înălțime&apos; - &apos;Înălțime: Spate Gât&apos; - &apos;Cap: Lungime&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_mijloc_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation>Gât la mijloc, circumferința</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumferința Gâtului la mijloc, aproximativ jumatatea distanței intre maxilar și bust.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Circumferința Gât</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumferința Gâtului la baza gâtului, atingând spatele gâtului, lateralele gâtului și partea din față a gâtului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_superior_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Piept superior Circumferință</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumferinta Pieptului Superior, se măsoară distanța cea mai scurtă pe sub brațe peste piept, pe la subsuori.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Piept circumferință</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumferința peste piept, paralel cu podeaua.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_inferior_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Piept inferior circumferința</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumferința pe sub piept, paralel cu podeaua.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>torace_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Torace circumferința</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumferința peste torace în partea cea mai inferioara a coastelor,  paralel cu podeaua.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>talie_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Talie circumferința</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>șold_înalt_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Șold înalt circumferința</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumferința în jurul taliei, urmând conturul natural al taliei. Talia la spate este de obicei mai înaltă.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumferinta în jurul Șoldului înalt, unde proeminența Abdomenului este cea mai mare, paralel cu podeaua.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>șold_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Șold circumferința</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumferința în jurul Șoldului unde proeminența Șoldului este cea mai mare, paralel cu podeaua.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_curbură_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Gât curbura, în față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation> Dintr-o parte laterală a gâtului in cealaltă parte laterală prin față.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_superior_curbură_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Piept superior curbură, prin față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>De la subraț peste Pieptul Superior la subraț.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_curbură_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Piept curbura, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>De la subraț peste Piept la subraț.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_inferior_curbură_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Piept inferior curbură, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>De la subraț peste Pieptul inferior (pe sub piept) la subraț.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>torace_curbură_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Torace curbură, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Dintr-o parte a toracelui in cealalta parte prin față.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>talia_curbură_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Talia curbură, prin față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Dintr-o parte a Taliei in cealaltă parte prin față.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>șold_înalt_curbură_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Șold înalt, curbură, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Dintr-o parte a Șoldului înalt in cealaltă parte, prin față.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>șold_curbură_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Șold curbură, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Dintr-o parte a Șoldului in cealaltă parte, prin față.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_curbură_jumătate_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Gât curbură, jumătate, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate de masura a curburii Gâtului, prin față. (&apos;Gât curbură, față&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_superior_curbură_jumătate_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Piept superior curbură, jumătate, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate de masură a &apos;Piept superior curbură, față&apos;. De la Pieptul superior față la Piept superior lateral. (&apos;Piept superior curbură, față&apos; / 2)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_curbură_jumătate_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Piept curbură, jumătate, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Piept curbură, față&apos;. (&apos;Piept curbură, față&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_inferior_curbură_jumătate_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Piept inferior, curbură, jumătate, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Piept inferior curbură, față&apos;. (&apos;Piept inferior curbură, față&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>torace_curbură_jumătate_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Torace curbură, jumătate, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Torace curbură, față&apos;. (&apos;Torace curbură, față&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>talie_curbură_jumătate_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Talie curbură, jumătate, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Talie curbură, față&apos;. (&apos;Talie curbură, față / 2&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>șold_înalt_jumătate_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Șold înalt, curbură, jumătate, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Șold înalt curbură, față&apos;. (&apos;Șold înalt curbură, față&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>șold_curbură_jumătate_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Șold curbură, jumătate, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Șold curbură, față&apos;. (&apos;Șold curbură, față&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_curbură_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Gât curbură, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Dintr-o parte a gâtului in cealaltă parte prin spate. (&apos;Gât circumferință&apos; - &apos;Gât curbură, față&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_superior_curbură_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Piept superior curbură, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Dintr-o parte in cealalta a Pieptului Superior pe la spate. (&apos;Piept superior circumferința&apos; - &apos;Piept superior curbură, față&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_curbură_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Piept curbură, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Dintr-o parte in cealaltă a Pieptului prin spate. (&apos;Piept circumferință&apos; - &apos;Piept curbură, față&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_inferior_curbură_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Piept inferior curbură, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Dintr-o parte in cealaltă a Pieptului inferior prin spate. (&apos;Piept inferior circumferință&apos; - &apos;Piept inferior curbură, față&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>torace_curbură_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Torace curbură, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Dintr-o parte in cealaltă a Toracelui prin spate. (&apos;Torace circumferință&apos; - &apos;Torace curbură, față&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>talie_curbură_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Talie curbură, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Dintr-o parte in cealaltă a Taliei prin spate. (&apos;Talie circumferință&apos; - &apos;Talie curbură, față&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>șold_înalt_curbură_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Șold înalt, curbură, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Dintr-o parte in cealaltă a Șoldului înalt prin spate. (&apos;Șold înalt circumferință&apos; - &apos;Șold înalt curbură, față&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>șold_curbură_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Șold curbură, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Dintr-o parte in cealaltă a Șoldului prin spate. (&apos;Șold circumferință&apos; - &apos;Șold curbură, față&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_curbură_jumătate_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Găt curbură, jumătate, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Gât curbură, spate&apos;. (&apos;Gât curbură, spate&apos; / 2)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_superior_curbură_jumătate_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Piept superior curbură, jumătate, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Piept superior curbură, spate&apos;. (&apos;Piept superior curbură, spate&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_curbură_jumătate_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Piept curbură, jumătate, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Piept curbură, spate&apos;. (&apos;Piept curbură, spate&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_inferior_curbură_jumătate_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Piept inferior curbură, jumătate, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Piept inferior curbură, spate&apos;. (&apos;Piept inferior curbură, spate&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>torace_curbură_jumătate_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Torace curbură, jumătate, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Torace curbură, spate&apos;. (&apos;Torace curbură, spate&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>talie_curbură_jumătate_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Talie curbură, jumătate, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Talie curbură, spate&apos;. (&apos;Talie curbură, spate&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>șold_înalt_curbură_jumătate_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Șold înalt curbură, jumătate, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Șold înalt curbură, spate&apos;. De la Șold înalt spate pâna la Piept înalt lateral (&apos;Șold înalt curbură, spate&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>șold_curbură_jumătate_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Șold curbură, jumătate, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Șold curbură, spate&apos;. (Șold curbură, spate&apos;&apos; / 2)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>șold_curbură_cu_abdomen_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation>Șold curbură cu Abdomenul, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>corp_îndoitura_mâinii_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation>Circumferința Corpului la nivelul îndoiturii mâinii (nivelul cotului)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation>Măsură în jurul brațelor și a trunchiului la nivelul îndoiturii măinilor.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>corp_piept_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation>Circumferința corpului la nivelul Pieptului</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>Măsura în jurul brațelor și a trunchiului la nivelul pieptului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>corp_trunchi_circ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation>Circumferința corpului unde trunchiul este cel mai mare</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation>Circumferința în jurul trunchiului de la mijlocul umărului în jos printre picioare înapoi până la mijlocul umărului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_anterior_la_talie_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Gât anterior până la talie anterior</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_anterior_la_talie_întins_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation>Gât anterior la talie anterior întins</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>De la gât în ​​jos prin față între sâni la talie față.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>subraț_la_talie_lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>De la subraț la talie laterală</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Subraț până la talie lateral.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_vârf_la_talie_lateral_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr vârf la talie lateral, prin față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>De la vârful umărului, curbat în jurul răscroiturii mâinii prin față în jos până la talie lateral.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_lateral_la_talie_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Gât lateral până la nivelul taliei, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>De la gât direct în ​​jos prin față până la nivelul taliei.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_lateral_la_talie_prin_punct_piept_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Gâtul lateral la nivelul taliei, prin punctul Pieptului</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>găt_anterior_la_piept_superior_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Gât anterior la Piept superior față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Gât anterior în jos până la Piept superior față.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_superior_la_talie_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Piept superior față la Talie față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_față_la_piept_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Gât față la Piept față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_la_talie_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Piept față la Talie față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>De la Piept față în jos la nivelul Taliei. (&apos;Gât față la Talie față&apos; - &apos;Gât față la Piept față&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_inferior_la_talie_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Piept inferior față la Talie față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Piept inferior față în jos la Talie față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>torace_la_talie_lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Torace lateral la Talie lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>De la cel mai jos punct al Toracelui lateral în jos la Talie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_vârf_la_mâna_îndoitură_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr vârf la Mâna îndoitura față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Vârful Umarului pe lângă răscroitura brațului în jos la îndoitura Mânei față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_lateral_la_piept_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Gât lateral la piept, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>De la gât lateral în ​​jos prin față direct la nivelul Pieptului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_lateral_la_piept_superior_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Gât lateral la nivel piept superior, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>De la gât lateral în ​​jos față direct la nivelul Pieptului superior.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_mijloc_la_piept_superior_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr mijloc la nivel Piept superior, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>De la mijlocul umărului în jos prin față de nivelul Pieptului superior, se vizează punctul Pieptului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_vârf_la_talie_lateral_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr vârf la talie lateral, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>De la vârful umărului, curbat în jurul răscroiturii brațului prin spate, apoi în jos la talie lateral.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_lateral_la_talie_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Gât lateral la talie, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>De la gât lateral drept în jos prin spate la talie.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_spate_la_talie_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Gât spate la Talie spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Gât spate în ​​jos la Talie spate.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_lateral_la_talie_peste_omoplat</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Gât lateral la Talie, peste Omoplat</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Gât lateral peste Omoplat până la nivelul Taliei, formând o linie dreaptă.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_spate_la_piept_superior_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Gât spate la Piept superior Spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Gât spate la Piept superior Spate.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_superior_la_talie_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Piept superior Spate la Talie Spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>De la Piept superior spate la Talie spate. (&apos;Gât spate la Talie spate&apos; - &apos;Gât spate la Piept superior spate&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_spate_la_piept_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Gât spate la Piept spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Gât spate în jos la Piept spate.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_la_talie_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Piept spate la Talie spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>De la Piept spate în jos la nivelul Taliei. (&apos;Gât spate la Talie spate&apos; - &apos;Gât spate la Piept spate&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_inferior_la_talie_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Piept inferior spate la Talie spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Piept inferior spate în jos la Talie spate.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_vârf_la_mână_îndoiturâ_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr vârf la Mână îndoitura spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>De la vârful Umărului pe lânga răscroitura brațului în jos la îndoitura Mâinii spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_lateral_la_piept_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Gât lateral la nivel Piept, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation>De la gât lateral drept în jos la nivelul Pieptului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_lateral_la_piept_superior_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Gât lateral la nivel piept superior, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation>De la gât lateral direct în ​​jos prin spate la nivelul Pieptului superior.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_centru_la_piept_superior_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr centru la nivel Piept superior, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation>De la mijlocul Umărului în jos prin spate de nivelul Pieptului superior, peste Omoplat.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>talie_la_șold_înalt_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Talie față la Șold înalt față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Talie față la Șold înalt față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>talie_la_șold_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Talie față la Șold față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Talie față la Șold față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>talie_la_șold_înalt_lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Talie lateral la Șold înalt lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Talie lateral la Șold înalt lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>talie_la_șold_înalt_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Talie spate la Șold înalt spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Talie spate la Șold înalt spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>talie_la_șold_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation>Talie spate la Șold spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>talie_la_șold_lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation>Talie lateral la Șold lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Talie lateral la Șold lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_gât_lateral_înclinare_unghi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr la Gât înclinare unghi lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Unghiul format de linia de la Gât lateral la vârful Umărului și linia de la Gât lateral paralel cu podeaua.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_lungime_înclinare_gât_lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr lungime înclinare de la Gâr lateral </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală între Gât lateral și vârful Umărului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_înclinare_unghi_gât_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr înclinare unghi de la Gât spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Unghiul format de linia de la gât spate la vârful umărului și linia de la gât spate paralel cu podeaua.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_înclinare_gât_înalțime_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr lungime înclinare de la Gât Spate </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Distanța verticală între Gât spate și vârful Umărului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_înclinare_umăr_vârf_unghi</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr Unghi Înclinare de la Umăr Vârf</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Unghi format de linia de la Gât lateral la Umăr Vârf si linia  verticală la Umăr Vârf</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_spate_la_peste_spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Gât Spate la Peste Spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Gât spate, în jos la nivelul măsurii Peste Spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>spate_peste_la_talie_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation>Peste Spate la Talie Spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation>De la mijlocul măsurii Peste Spate în jos la Talie Spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_lungime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr lungime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Umăr lateral la Umăr Vârf</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_vârf_la_umăr_vârf_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr Vârf la Umăr Vârf, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Umăr Vârf la Umăr Vârf, prin față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_peste_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation>Piept peste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>De la subraț la subraț, prin cea mai scurtă lățime </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>mână_răscroitură_la_mână_răscroitură_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation>Mână răscroitură la Mână răscroitură față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>De la îndoitura Mâinii la îndoitura Mâinii, cea mai scurtă distanță între îndoiturile Mâinilor, nefiind paralel cu podeaua. </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_vârf_la_umăr_vârf_jumătate_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr Vârf la Umăr Vârf, jumătate, față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Umăr Vârf la Umăr Vârf, față&apos;. (&apos;Umăr Vârf la Umăr Vârf, față&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_peste_jumătate_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation>Piept Peste, jumătate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Piept Peste&apos;. (&apos;Piept Peste&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_vârf_la_umăr_vârf_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr Vârf la Umăr Vârf, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Umăr Vârf la Umăr Vârf, peste Spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>spate_peste_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation>Spate Peste</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation>De la subraț la subraț prin cea mai scurta lațime la spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>mână_îndoitură_la_mână_îndoitură_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation>Mână îndoitură la Mână îndoitură, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>De la îndoitura Mâinii la îndoitura Mâinii peste spate.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>umăr_vârf_la_umăr_vârf_jumătate_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Umăr Vârf la Umăr Vârf, jumătate, spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Umăr Vârf la Umăr Vârf, spate&apos;. (&apos;Umăr Vârf la Umăr Vârf, spate&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>spate_peste_jumătate_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation>Spate Peste, jumătate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Jumătate din &apos;Spate Peste&apos;. (&apos;Spate Peste&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_față_la_umăr_vârf_f</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Gâr Față la Umăr Vârf</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Gâr Față la Umăr Vârf.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_spate_la_umăr_vârf_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Gât Spate la Umăr Vârf</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Gât Spate la Umăr Vârf</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_lațime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation>Gât Lățime</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation>Se măsoară lățimea între părțile atârnânde a unui șnur atârnat după gât.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Piept vârf la Piept vârf</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Piept vârf la Piept vârf</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Piept vârf la Gât lateral</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Gât lateral la Piept Vârf.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_vârf_la_piept_inferior</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation>Piept vârf la Piept Inferior</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation>De la Piept vârf în jos la nivel Piept inferior, urmând curba pieptului.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>piept_vârf_la_talie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation>Piept vârf la nivel Talie</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation>De la Piept vârf drept în jos la nivelul Taliei, formând o linie dreaptă (nu o linie curbata după corp).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Gât lateral la Mână îndoitură față</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>De la laterala Gâtului pe diagonală la îndoitura Mâinii prin față.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>gât_lateral_la_mână_îndoitură_s</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation>Gât lateral la Mână îndoitură spate</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation>De la laterala Gâtului pe diagonală la îndoitura Mâinii spate.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>

--- a/share/translations/measurements_ru_RU.ts
+++ b/share/translations/measurements_ru_RU.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Высота</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation>Рост</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальное расстояние от темени до пола.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>высота_шеи_сзади</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Высота точки основания шеи сзади</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №10. Расстояние по вертикали от пола до точки основания шеи сзади.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Влоп</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Высота лопаточной точки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №87. Расстояние по вертикали от пола до лопаточной точки.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Взу</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation>Высота заднего угла подмышечной впадины</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №11. Расстояние по вертикали от пола до заднего угла подмышечной впадины. Уровень заднего угла подмышечной впадины переносят отметкой на позвоночник с помощью антропометра.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>высота_талии_сбоку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Высота линии талии</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №7. Расстояние по вертикали от пола до точки уровня талии. Уровень талии переносят отметками с помощью антропометра на позвоночник и середину передней поверхности тела.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>высота_бедра</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Высота: бедро</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальное расстояние от бедра до пола.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Впс</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation>Высота подъягодичной складки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №12. Расстояние по вертикали от пола до середины подъягодичной складки.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>высота_колена</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Высота коленной точки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальное расстояние от сгиба колена сзади до пола.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>высота_икры</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation>Высота: икры</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальное расстояние от широкой части икры ноги до пола</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>высота_лодыжки_сверху</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Высота: щиколотка</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальное расстояние от глубокой выемки сзади лодыжки до пола.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>высота_лодыжки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Высота: лодыжка</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальное расстояние от точки переда ноги до уровня пола.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>высота_ВысотаБедер</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation>Высота: ВысотаБедер</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальное расстояние от наиболее выступающей точки живота до пола, через переднюю поверхность бедра</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>высота_талии_спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние от линии талии до пола спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальное расстояние от талии спереди до пола.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Вст</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Высота сосковой точки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Расстояние по вертикали от сосковой точки до пола.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Впт</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Высота плечевой точки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Расстояние по вертикали от плечевой точки до пола.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>высота_шеи_спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Высота точки основания шеи спереди до пола</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальное расстояние от шеи спереди до пола.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>высота_шеи_сбоку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Высота точки основания шеи сбоку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальное расстояние от шеи сбоку до пола.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дшк</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние от шейной точки до колена</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Определяют как разность размерных признаков №9 и №10.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>высота_талии_сбоку_до_колена</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Высота: Талия Сбоку до Колена</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Расстояние по вертикали от талии до сгиба колена на задней стороне ноги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Высота_боковая_талия_бедра</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Высота: боковая от талии до бедер </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation>Расстояние от линии талии до віступающей точки ягодицы</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>высота_от_колена_до_лодыжки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Высота от колена до лодыжки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальное расстояние до пола от максимально выступающей точки живота.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>расстояние_от_шеи_сзади_к_талии_сбоку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние по вертикали от пола до точки основания шеи сзади.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Расстояние от шеи до талии (&quot;А02.высота_шеи_сзади&quot; - &quot;А05.высота_талии_сбоку&quot;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ширина_плечей</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина: Плечо</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальное расстояние от плеча до плеча</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ширина_груди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина: Грудь</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Измеряют горизонтально над основанием грудных желез между вертикалями, мысленно проведенными вверх от передних углов подмышечных впадин.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ширина_талии</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина: Талия</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальное расстояние от одной стороны талии до другой</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ширина_бёдер</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина: Таз</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальное расстояние от бедра до бедра</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ширина_от_живота_до_бедра</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина: от живота до бедра</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальное расстояние между наиболее выступающей точкой живота и наиболее выступающей точкой бедра.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Пкор</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Положение корпуса</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Размерный признак в стандарте №74.Измеряют по горизонтали расстояние от шейной точки до вертикальной плоскости, касательной паиболее выступающих назад точек обеих лопаток.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>отступ_талии_сзади</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Отступ: талии сзади</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальное расстояние между плоской палочкой, размещенной так, чтобы она касалась бедра и лопатки, и поясницей сзади</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>отступ_лодыжки_наибольший</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Отступ: Лодыжки наибольший</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>рука_длина_ладони</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation>Рука: длина ладони</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Размер от запястья до основания среднего пальца</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Вертикальный диаметр руки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Размер от запястья до конца среднего пальца</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>рука_ширина_ладони</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation>Рука: ширина ладони</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Ширина ладони</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>рука_обхват_ладони</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Рука: Обхват ладони</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Обхват ладони в максимально широком месте</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Окис</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват кисти</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation>Прижмите большой палец к ладони и максимально наклоните в сторону мизинца. Измеряется охват ладони в самом широком месте.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ступня_ширина</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Ступня: Ширина</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Ширина стопы в самом широком месте</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ступня_длина</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Ступня: Длина</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation>Мерка от задней части пятки до конца самого длинного пальца ноги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>обхват_ступни</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Ступня: обхват ступни</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Измерьте окружность самой широкой части стопы</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Ос</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват подъема стопы</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №51. Ленту накладывают через заднюю наиболее выступающую вниз область пятки и высшую точку стопы, замыкают спереди. Размер читают по верхнему краю ленты.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Огол</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват головы</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №48. Измеряют через точку инион и центры лобных бугров. Ленту замыкают на лбу.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Вгол</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Высота головы</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальное расстояние от макушки до нижней точки челюсти.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>голова_глубина</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation>Голова: Глубина</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальное расстояние от лба до задней части головы.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>голова_ширина</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Голова: ширина</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальное расстояние от одной стороны головы до другой в самом широком месте</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>от_макушки_до_шеи_сзади</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Голова: От макушки до шеи сзади</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальное расстояние от макушки до шеи сзади. (&apos;Высота: Общая&apos; - &apos;Высота: Шея Сзади&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дшош</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние от шейной точки до точки основания шеи сбоку по линии измерения обхвата шеи</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальное расстояние от подбородка до точки основания шеи сзади по линии измерения обхвата шеи. (&apos;Высота&apos; - &apos;Высота: Шея Сзади&apos; - &apos;Голова: Длина&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Сш1</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation>Полуобхват шеи для сорочек</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation>Окружность средней части шеи, примерно на посередине между челюстью и туловищем.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>обхват_шеи</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват шеи</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №13. Ленту накладывают на основание шеи так, чтобы оба края ленты плотно прилегали к ее поверхности, и замыкают спереди над яремной вырезкой. Размер читают по нижнему краю ленты.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ОгI</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват груди первый</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №14. Ленту накладывают на лопатки. По спине лента должна проходить горизонтально, касаясь верхним краем задних углов подмышечной впадин, затем по подмышечным впадинам. Спереди лента должна проходить на уровне передних углов подмышечных впадин и замыкаться на правой стороне груди. По верхнему краю ленты делают отметку спереди над правой сосковой точкой.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ОгII</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват груди второй</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №15. Ленту накладывают на лопатки. По спине лента должна проходить горизонтально, касаясь верхним краем задних углов подмышечных впадин, затем по подмышечным впадинам в плоскости косого сечения, спереди — через сосковые точки и замыкаться на правой стороне груди.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ОгIII</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват груди третий</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №16. Ленту накладывают горизонтально вокруг туловища через сосковые точки и замыкают на правой стороне груди.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>обхват_рёбер</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Окружность рёбер</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Обхват вокруг рёбер на уровне нижнего ребра, параллельно полу.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>обхват_талии</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват талии</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>обхват_бёдер_сверху</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват бёдер сверху</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №18. Ленту накладывают горизонтально вокруг туловища на уровне линии талии и замыкают спереди.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>высота_талии_сзади</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Высота: Талия Сзади</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальное расстояние между плоской палкой, расположенной перпендикулярно к пятке, и наибольшим углублением лодыжки.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Обхват бёдер сверху, через саму выступающую точку живота, параллельно полу.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>обхват_бёдер</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват бедер без учета выступания живота</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №20. Ленту накладывают горизонтально вокруг туловища на уровне ягодичных точек и замыкают на правой стороне туловища.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Сш</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Полуобхват шеи</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Ленту накладывают на основание шеи так, чтобы оба края ленты плотно прилегали к ее поверхности, и замыкают спереди над яремной вырезкой. Размер читают по нижнему краю ленты. Мерка записывается в половинном размере.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>СгI</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>ширина груди первая, спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>СгII</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Полуобхват груди второй</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation>Ленту накладывают на лопатки. По спине лента должна проходить горизонтально, касаясь верхним краем задних углов подмышечных впадин, затем по подмышечным впадинам в плоскости косого сечения, спереди — через сосковые точки и замыкаться на правой стороне груди. Мерка записывается в половинном размере.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>СгIII</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Полуобхват груди третий</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Ленту накладывают горизонтально вокруг туловища через сосковые точки и замыкают на правой стороне груди. Мерка записывается в половинном размере.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>дуга_ребра_спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Дуга ребра, спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>От одной стороны рёбер до другой стороны рёбер, спереди.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Ст</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Полуобхват талии</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Ленту накладывают горизонтально вокруг туловища на уровне линии талии и замыкают спереди. Мерка записывается в половинном размере.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>дуга_бедер_спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Дуга верхней части бёдер, спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation>От одной стороны бёдер до другой спереди.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>СбI</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation>Полуобхват бедер без учета выступания живота</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Размерный признак №20. Ленту накладывают на ягодичные точки. Лента должна проходить горизонтально вокруг туловища и замыкаться на правой стороне туловища</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>шея_дуга_половина_спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Дуга передней половины шеи</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Половина от  &apos;Дуга шеи, спереди&apos;. (&apos;Дуга шеи, спереди&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>четверть_обхвата_груди_первого_спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Половина ширины груди 1</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Половина от  &apos;Ширины груди первой&apos;.   ( Ширина груди первая, спереди&apos; / 2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>грудь_дуга_половина_спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Дуга груди, спереди, половина</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation>Половина от &apos;Дуга груди, спереди&apos;. (&apos;Дуга груди, спереди&apos;/2).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Шг3_пол</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина груди третья, половина</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Половина от ширины груди третьей. ( Шг3/2)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина ребер спереди, половина</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Половина от Ширины ребер спереди (Ширина ребер спереди/2)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина талии, перед, половина</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Половина от &quot;Ширины талии, спереди&quot; (&apos;Ширина талии, спереди/2)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина бедер первая, спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Половина от &quot;Полуобхвата бедер первого, спереди&quot;. (&quot;Полуобхват бедер первый, спереди&quot;/2)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation>Половинный передний полуобхват бедер второй</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation>Рассчитывается как половина от &quot;Переднего полуобхвата бедер второго&quot;.(&quot;Передний полуобхват бедер второй&quot;/2)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Задний полуобхват шеи </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation>Полуобхват груди первый, сзади</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>От одной стороны ребер до другой, обхватывая лентойсзади. (&apos;Обхват ребер&apos; - &apos;Ширина ребер спереди&apos;)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Сб</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation>Полуобхват бедер с учетом выступания живота</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Расстояние от основания шеи спереди между грудью до лини талии спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дб</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Длина боковой части</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ДтсI</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние от линии талии сзади до точки основания шеи сбоку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №43. Измеряют параллельно позвоночнику от линии талии сзади до точки основания шеи сбоку.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Впрп</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние от точки основания шеи сбоку до линии обхвата груди первого спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дпер</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Длина переда от линии талии вверх по центру до начала ложбины</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дпг</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Длина от талии до основания грудных желез</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дтс1</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние от линии талии сзади до точки основания шеи сбоку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Размерный признак в стандарте №43. Измеряют параллельно позвоночнику от линии талии сзади до точки основания шеи сбоку.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дтс</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Длина спины до талии с учетом выступа лопаток</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №40. Измеряют от точки основания шеи сзади до отметки уровня талии на позвоночнике через пластину.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Впрз</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние от точки основания шеи сзади до линии обхватов груди первого и второго с учетом выступа лопаток</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Гт1</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Глубина талии первая</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Размерный признак в стандарте №78. Измеряют по горизонтали расстояние от вертикальной плоскости, касательной к выступающим точкам лопаток, до линейки, приложенной горизонтально к продольным мышцам спины на уровне линии талии.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ГтII</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation>Глубина талии вторая</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Размерный признак в стандарте №79. Измеряют по горизонтали расстояние от вертикальной плоскости, касательной к ягодичным точкам, до линейки, приложенной горизонтально к продольным мышцам спины на уровне линии талии.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>талия_до_бедра_зад</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation>От талии до линии бедра сзади</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>талия_до_бедра_бок</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation>От талии сбоку до бедра сбоку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>От талии сбоку до бедра сбоку.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Шп</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation>Длина плечевого ската</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №31. Измеряют от точки основания шеи сбоку до плечевой точки.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>dпл</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation>Плечевой диаметр</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №53. Измеряют спереди между плечевыми точками без деформации мягких тканей.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Шг1</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина груди первая</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Шг</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина груди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №45. Измеряют по поверхности тела расстояние между передними углами подмышечных впадин. Нижний край ленты должен касаться отметки, сделанной при измерении обхвата груди первого.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дпз</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation>Дуга плечевого пояса сзади</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Шс</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина спины</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №47. Измеряют по поверхности тела ресстояние между задними углами подмышечных впадин. Нижний край ленты должен быть расположен на уровне отметки заднего угла подмышечной впадины на позвоночнике.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>dш</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation>Поперечный диаметр шеи</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №54. Измеряют между точками основания шеи сбоку.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Цг</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние между сосковыми точками</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №46. Измеряют между сосковыми точками в горизонтальной плоскости. Размер читают по верхнему краю ленты.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Вг</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние от точки основания шеи сбоку до сосковой точки (высота груди)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation>Измеряют от точки  основания шеи до выступающей точки грудной железы.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Впкп</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Высота плеча косая спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Измеряют от выступающей точки грудной железы до плечевой точки.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Впк</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Высота плеча косая</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №41. Измеряют кратчайшее расстояние от отметки уровня талии на позвоночнике до плечевой точки.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Впрк</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation>Высота проймы косая</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation>Расстояние от шейной точки до уровня заднего угла подмышечной впадины спереди</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дрзап</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Длина рукава от плеча до линии обхвата запястья</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Измеряют расстояние от плечевой точки до линии обхвата запястья.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дрлок</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation>Длина руки до локтя</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation>Измеряют расстояние от плечевой точки до лучевой точки.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Втр</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation>Внутренняя длина рукава (с окатом)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Оп</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват плеча</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №28. Измеряют перпендикулярно оси плеча. Лента Верхним краем должна касаться заднего угла подмышечной впадины и замыкаться на наружной поверхности руки. Размер читают по верхнему краю ленты.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Олк</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват локтя</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Озап</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват запястья</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №29. Измеряют перпендикулярно оси предплечья по лучезапястному суставу через головку локтевой кости. Ленту замыкают на наружной поверхности руки. Размер читают по нижнему краю ленты.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Длуч</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние от точки основания шеи сбоку до лучевой точки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №33. Измеряют от точки основания шеи сбоку через плечевую точку до линии обхвата запястья.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ДIIIп</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние от точки основания шеи сбоку до конца третьего пальца</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>dпзр</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Передне-задний диаметр руки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Измеряют горизонтально на уровне заднего угла подмышечной впадины.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дн</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Длина ноги по внутренней поверхности</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №27. Измеряют по внутренней поверхности ноги расстояние от промежности до пола при слегка раздвинутых ногах. Для измерения используют сантиметровую ленту, верхний край которой укреплен на жесткой пластине.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дсб</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние от линии талии до пола сбоку (длина брюк)</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №25. Измеряют от точки уровня талии по боковой поверхности бедра вертикально до пола.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Обед</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват бедра</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №21. Ленту накладывают горизонтально вокруг бедра, касаясь верхним краем подъягодичной складки, и замыкают на наружной поверхности бедра.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>обхват_икры_ноги</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Нога: обхват икры</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №23. Ленту накладывают горизонтально вокруг ноги в области максимального развития икроножной мышцы и замыкают на наружной поверхности голени.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Ощ</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват щиколотки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Окс</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation>Обхват колена в согнутом положении ноги</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дтк</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние от линии талии до колена</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>crotch_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation>Длина промежности</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дпс</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation>Расстояние от линии талии до подъягодичной складки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Двчт</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Длина дуги верхней части туловища через точку основания шеи сбоку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №44. Измеряют сзади параллельно позвоночнику от линии талии к точке основания шеи сбоку, касаясь этой точки внутренним краем ленты. Спереди лента должна проходить через сосковую точку, далее вниз до линии талии.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дбр</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation>Длина бретели от выступающего уголка лопатки вертикально до начала грудной железы</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Дп</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation>Дуга через высшую точку плечевого сустава</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Номер размерного признака в стандарте №38. Измеряют в вертикальной плоскости расстояние от заднего угла подмышечной впадины через высшую точку плечевого сустава до переднего угла подмышечной впадины.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина вытачки: Плечо</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина вытачки: Грудь</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина вытачки: Талия</translation>

--- a/share/translations/measurements_uk_UA.ts
+++ b/share/translations/measurements_uk_UA.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Р</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation>Зріст</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від найвищої точки голови до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_шиї_ззаду</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Висота шиї ззаду</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань шиї ззаду (від сьомого шийного хребця) до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_лопатки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation>Висота лопатки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від лопатки до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_пахва</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation>Висота пахва</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від пахва до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_талії_збоку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Висота талії збоку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від талії збоку до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_стегна</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Висота стегна</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від стегна до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_сідничної_складки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation>Висота сідничної складки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від сідничної складки, де сідничний м&apos;яз зустрічає верхню частину задньої сторони стегна, до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_коліна</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Висота: колінної точки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від згину на задній частині коліна до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_ікри</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation>Висота ікри</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від найширшої точки ікри до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_гомілки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Висота гомілки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від найглибшої виїмки задньої щиколотки до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_щиколотки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Висота щиколотки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від передньої найвищої точки ступні до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_талії_зпереду</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation>Висота талії зпереду</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань талії зпереду до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_соскової_точки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation>Висота соскової точки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від соскової точки до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_шиї_зпереду</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation>Висота шиї зпереду</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань шиї зпереду до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_шиї_збоку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation>Висота шиї збоку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань шиї збоку до підлоги.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_шиї_ззаду_до_коліна</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Висота від шиї ззаду до коліна</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від шиї ззаду (шийного хребця) до згину коліна ззаду.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_талії_збоку_до_коліна</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation>Висота талії збоку до коліна</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від талії збоку до згину коліна ззаду.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_талії_до_стегна</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Висота від талії збоку до стегна</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від талії збоку до рівня стегна.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_коліна_до_щиколотки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation>Висота коліна до щиколотки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань між згином коліна ззаду до точки, де перед ноги зустрічає верх стопи.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>висота_шиї_ззаду_до_талії_збоку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation>Висота шиї ззаду до талії збоку</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation>Вертикальна відстань від шиї ззаду до талії збоку. (&apos;Висота шиї збоку&apos; - &apos;Висота талії збоку&apos;).</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ширина_плеча</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина плеча</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальна відстань між нахилами лівого та правого плечей.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ширина_грудей</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина грудей</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальна відстань ширини грудей від боку до боку.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ширина_талії</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина талії</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальна відстань талії від боку до боку.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ширина_стегна</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина стегна</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальна відстань стегна від боку до боку. </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>ширина_живота_до_стегна</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation>Ширина від живота до стегна</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальна відстань між точками найбільшого виступу живота і стегна.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>положення_корпуса_шия_ззаду</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation>Положення корпусу шиї ззаду</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальна відстань від лопатки до шиї ззаду.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>положення_корпусу_талія_ззаду</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation>Положення корпусу: талія ззаду</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation>Горизонтальна відстань між плоскою палицею, що доторкається стегна і лопаток, і талії ззаду.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>положення_корпусу_щиколотка</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation>Положення корпусу: щиколотка</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>рука_довжина_долоні</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation>Рука: довжина долоні</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Довжина від зап&apos;ястя до основи середнього пальця руки. </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>hand_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Довжина кисті</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation>Довжина від зап&apos;ястя до кінця середнього пальця руки. </translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>рука_ширина_долоні</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation>Рука: ширина долоні</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Виміряють найбільшу ширину долоні.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>окружність_долоні</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Рука: окружність долоні</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation>Окружність найширшої частини долоні.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>окружність_руки</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation>Рука: окружність</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation>Складіть великий палець так щоб він прилягав до долоні. Міряйте окружність навколо найширшої частини руки.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_width</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation>Ступня: ширина</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation>Вимірюють найширшу частину ступні.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>foot_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation>Ступня: довжина</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation>Вимірюють від п&apos;ятки до кінця найдовшого пальця.</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Шп</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation>Довжина плечового ската</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>Цг</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>crotch_length</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation>Довжина промежини</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>

--- a/share/translations/measurements_zh_CN.ts
+++ b/share/translations/measurements_zh_CN.ts
@@ -4,4424 +4,4424 @@
 <context>
     <name>VTranslateMeasurements</name>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="216"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
         <source>height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation>高度</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
         <source>Height: Total</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="219"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
         <source>Vertical distance from crown of head to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="223"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
         <source>height_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
         <source>Height: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="226"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
         <source>height_scapula</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
         <source>Height: Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
         <source>Vertical distance from the Scapula (Blade point) to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="424"/>
         <source>height_armpit</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="426"/>
         <source>Height: Armpit</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="240"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="427"/>
         <source>Vertical distance from the Armpit to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="244"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="431"/>
         <source>height_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="433"/>
         <source>Height: Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="247"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="434"/>
         <source>Vertical distance from the Waist Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="251"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
         <source>height_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="440"/>
         <source>Height: Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="254"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="441"/>
         <source>Vertical distance from the Hip level to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="258"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
         <source>height_gluteal_fold</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="260"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="447"/>
         <source>Height: Gluteal Fold</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="261"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="448"/>
         <source>Vertical distance from the Gluteal fold, where the Gluteal muscle meets the top of the back thigh, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="265"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
         <source>height_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="267"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="454"/>
         <source>Height: Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="268"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="455"/>
         <source>Vertical distance from the fold at the back of the Knee to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="459"/>
         <source>height_calf</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="461"/>
         <source>Height: Calf</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="462"/>
         <source>Vertical distance from the widest point of the calf to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="279"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="466"/>
         <source>height_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="468"/>
         <source>Height: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="282"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
         <source>Vertical distance from the deepest indentation of the back of the ankle to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="286"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="473"/>
         <source>height_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="475"/>
         <source>Height: Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="289"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
         <source>Vertical distance from point where the front leg meets the foot to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="293"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="480"/>
         <source>height_highhip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="482"/>
         <source>Height: Highhip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="296"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
         <source>Vertical distance from the Highhip level, where front abdomen is most prominent, to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="487"/>
         <source>height_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
         <source>Height: Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="490"/>
         <source>Vertical distance from the Waist Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="307"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="494"/>
         <source>height_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="309"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="496"/>
         <source>Height: Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
         <source>Vertical distance from Bustpoint to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="314"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="501"/>
         <source>height_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="316"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="503"/>
         <source>Height: Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="504"/>
         <source>Vertical distance from the Shoulder Tip to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="321"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="508"/>
         <source>height_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="323"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="510"/>
         <source>Height: Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="511"/>
         <source>Vertical distance from the Neck Front to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="328"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="515"/>
         <source>height_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="330"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
         <source>Height: Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="518"/>
         <source>Vertical distance from the Neck Side to the floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="335"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
         <source>height_neck_back_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="337"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="524"/>
         <source>Height: Neck Back to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="525"/>
         <source>Vertical distance from the Neck Back (cervicale vertebra) to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="342"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
         <source>height_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="531"/>
         <source>Height: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="345"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="532"/>
         <source>Vertical distance from the Waist Side to the fold at the back of the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="350"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
         <source>height_waist_side_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="352"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="539"/>
         <source>Height: Waist Side to Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="540"/>
         <source>Vertical distance from the Waist Side to the Hip level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="544"/>
         <source>height_knee_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="546"/>
         <source>Height: Knee to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="547"/>
         <source>Vertical distance from the fold at the back of the knee to the point where the front leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="364"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="551"/>
         <source>height_neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
         <source>Height: Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="367"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="554"/>
         <source>Vertical distance from Neck Back to Waist Side. (&apos;Height: Neck Back&apos; - &apos;Height: Waist Side&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="374"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="561"/>
         <source>Vertical height from Waist Back to floor.</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="592"/>
         <source>width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="594"/>
         <source>Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="595"/>
         <source>Horizontal distance from Shoulder Tip to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="396"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="599"/>
         <source>width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="601"/>
         <source>Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="399"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="602"/>
         <source>Horizontal distance from Bust Side to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="403"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="606"/>
         <source>width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
         <source>Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="406"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="609"/>
         <source>Horizontal distance from Waist Side to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="613"/>
         <source>width_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
         <source>Width: Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="616"/>
         <source>Horizontal distance from Hip Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="620"/>
         <source>width_abdomen_to_hip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="622"/>
         <source>Width: Abdomen to Hip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
         <source>Horizontal distance from the greatest abdomen prominence to the greatest hip prominence.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="436"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="653"/>
         <source>indent_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="438"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
         <source>Indent: Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="656"/>
         <source>Horizontal distance from Scapula (Blade point) to the Neck Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="443"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
         <source>indent_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="445"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
         <source>Indent: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
         <source>Horizontal distance between a flat stick, placed to touch Hip and Scapula, and Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="450"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="667"/>
         <source>indent_ankle_high</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="669"/>
         <source>Indent: Ankle High</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="469"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="702"/>
         <source>hand_palm_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="471"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
         <source>Hand: Palm length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="705"/>
         <source>Length from Wrist line to base of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="476"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="709"/>
         <source>hand_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="478"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
         <source>Hand: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="712"/>
         <source>Length from Wrist line to end of middle finger.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="483"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="716"/>
         <source>hand_palm_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="485"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
         <source>Hand: Palm width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="719"/>
         <source>Measure where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="489"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="722"/>
         <source>hand_palm_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="724"/>
         <source>Hand: Palm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="492"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
         <source>Circumference where Palm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="495"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
         <source>hand_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="497"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="730"/>
         <source>Hand: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="731"/>
         <source>Tuck thumb toward smallest finger, bring fingers close together. Measure circumference around widest part of hand.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="514"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="762"/>
         <source>foot_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
         <source>Foot: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="517"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="765"/>
         <source>Measure at widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
         <source>foot_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
         <source>Foot: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
         <source>Measure from back of heel to end of longest toe.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
         <source>foot_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
         <source>Foot: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
         <source>Measure circumference around widest part of foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
         <source>foot_instep_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
         <source>Foot: Instep circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
         <source>Measure circumference at tallest part of instep.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="553"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
         <source>head_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
         <source>Head: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="556"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
         <source>Measure circumference at largest level of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="826"/>
         <source>head_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="562"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="828"/>
         <source>Head: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="563"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
         <source>Vertical distance from Head Crown to bottom of jaw.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="567"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="833"/>
         <source>head_depth</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="569"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
         <source>Head: Depth</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="570"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="836"/>
         <source>Horizontal distance from front of forehead to back of head.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="840"/>
         <source>head_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="842"/>
         <source>Head: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
         <source>Horizontal distance from Head Side to Head Side, where Head is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="847"/>
         <source>head_crown_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="849"/>
         <source>Head: Crown to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="850"/>
         <source>Vertical distance from Crown to Neck Back. (&apos;Height: Total&apos; - &apos;Height: Neck Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
         <source>head_chin_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="856"/>
         <source>Head: Chin to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="857"/>
         <source>Vertical distance from Chin to Neck Back. (&apos;Height&apos; - &apos;Height: Neck Back&apos; - &apos;Head: Length&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="608"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="899"/>
         <source>neck_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="901"/>
         <source>Neck circumference, midsection</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="611"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
         <source>Circumference of Neck midsection, about halfway between jaw and torso.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="615"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="906"/>
         <source>neck_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="908"/>
         <source>Neck circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="618"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="909"/>
         <source>Neck circumference at base of Neck, touching Neck Back, Neck Sides, and Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="623"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="914"/>
         <source>highbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="916"/>
         <source>Highbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="626"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
         <source>Circumference at Highbust, following shortest distance between Armfolds across chest, high under armpits.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="630"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="921"/>
         <source>bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="923"/>
         <source>Bust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="633"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="924"/>
         <source>Circumference around Bust, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="637"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
         <source>lowbust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="930"/>
         <source>Lowbust circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="640"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="931"/>
         <source>Circumference around LowBust under the breasts, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="644"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
         <source>rib_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="646"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="937"/>
         <source>Rib circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="938"/>
         <source>Circumference around Ribs at level of the lowest rib at the side, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="652"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="943"/>
         <source>waist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="654"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="945"/>
         <source>Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="660"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="951"/>
         <source>highhip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="953"/>
         <source>Highhip circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="946"/>
         <source>Circumference around Waist, following natural contours. Waists are  typically higher in back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="371"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="558"/>
         <source>height_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="373"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="560"/>
         <source>Height: Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="453"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
         <source>Horizontal Distance between a flat stick, placed perpendicular to Heel, and the greatest indentation of Ankle.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="663"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="954"/>
         <source>Circumference around Highhip, where Abdomen protrusion is  greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="959"/>
         <source>hip_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="670"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="961"/>
         <source>Hip circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="671"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="962"/>
         <source>Circumference around Hip where Hip protrusion is greatest, parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="676"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
         <source>neck_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
         <source>Neck arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="679"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
         <source>From Neck Side to Neck Side through Neck Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="683"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
         <source>highbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="685"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
         <source>Highbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
         <source>From Highbust Side (Armpit) to HIghbust Side (Armpit) across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="690"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
         <source>bust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
         <source>Bust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="693"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
         <source>From Bust Side to Bust Side across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="697"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="988"/>
         <source>size</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="699"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
         <source>Size</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="700"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="991"/>
         <source>Same as bust_arc_f.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="995"/>
         <source>lowbust_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="706"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
         <source>Lowbust arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="707"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="998"/>
         <source>From Lowbust Side to Lowbust Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1002"/>
         <source>rib_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="713"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
         <source>Rib arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="714"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1005"/>
         <source>From Rib Side to Rib Side, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1009"/>
         <source>waist_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="720"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
         <source>Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="721"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1012"/>
         <source>From Waist Side to Waist Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
         <source>highhip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="727"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1018"/>
         <source>Highhip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="728"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1019"/>
         <source>From Highhip Side to Highhip Side across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="732"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1023"/>
         <source>hip_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="734"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
         <source>Hip arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="735"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1026"/>
         <source>From Hip Side to Hip Side across Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="739"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
         <source>neck_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="741"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
         <source>Neck arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
         <source>Half of &apos;Neck arc, front&apos;. (&apos;Neck arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="746"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1037"/>
         <source>highbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="748"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1039"/>
         <source>Highbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="749"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
         <source>Half of &apos;Highbust arc, front&apos;. From Highbust Front to Highbust Side. (&apos;Highbust arc,  front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="754"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1045"/>
         <source>bust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="756"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
         <source>Bust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1048"/>
         <source>Half of &apos;Bust arc, front&apos;. (&apos;Bust arc, front&apos;/2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="761"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1052"/>
         <source>lowbust_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="763"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
         <source>Lowbust arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="764"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1055"/>
         <source>Half of &apos;Lowbust arc, front&apos;.  (&apos;Lowbust Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1059"/>
         <source>rib_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="770"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
         <source>Rib arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="771"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1062"/>
         <source>Half of &apos;Rib arc, front&apos;.   (&apos;Rib Arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1066"/>
         <source>waist_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="777"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
         <source>Waist arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1069"/>
         <source>Half of &apos;Waist arc, front&apos;. (&apos;Waist arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="782"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1073"/>
         <source>highhip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
         <source>Highhip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="785"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1076"/>
         <source>Half of &apos;Highhip arc, front&apos;.  (&apos;Highhip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="789"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1080"/>
         <source>hip_arc_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
         <source>Hip arc, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="792"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1083"/>
         <source>Half of &apos;Hip arc, front&apos;. (&apos;Hip arc, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="796"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1087"/>
         <source>neck_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="798"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
         <source>Neck arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1090"/>
         <source>From Neck Side to Neck Side across back. (&apos;Neck circumference&apos; - &apos;Neck arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="804"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
         <source>highbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1097"/>
         <source>Highbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="807"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1098"/>
         <source>From Highbust Side  to Highbust Side across back. (&apos;Highbust circumference&apos; - &apos;Highbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="811"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
         <source>bust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="813"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1104"/>
         <source>Bust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1105"/>
         <source>From Bust Side to Bust Side across back. (&apos;Bust circumference&apos; - &apos;Bust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
         <source>lowbust_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1112"/>
         <source>Lowbust arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
         <source>From Lowbust Side to Lowbust Side across back.  (&apos;Lowbust circumference&apos; - &apos;Lowbust arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="827"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1118"/>
         <source>rib_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1120"/>
         <source>Rib arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="830"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
         <source>From Rib Side to Rib side across back. (&apos;Rib circumference&apos; - &apos;Rib arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1126"/>
         <source>waist_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="837"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1128"/>
         <source>Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="838"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
         <source>From Waist Side to Waist Side across back. (&apos;Waist circumference&apos; - &apos;Waist arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="843"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1134"/>
         <source>highhip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="845"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1136"/>
         <source>Highhip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="846"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
         <source>From Highhip Side to Highhip Side across back. (&apos;Highhip circumference&apos; - &apos;Highhip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="851"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1142"/>
         <source>hip_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
         <source>Hip arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="854"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1145"/>
         <source>From Hip Side to Hip Side across back. (&apos;Hip circumference&apos; - &apos;Hip arc, front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="859"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
         <source>neck_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="861"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1152"/>
         <source>Neck arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1153"/>
         <source>Half of &apos;Neck arc, back&apos;. (&apos;Neck arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="866"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
         <source>highbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1159"/>
         <source>Highbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="869"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1160"/>
         <source>Half of &apos;Highbust arc, back&apos;. From Highbust Back to Highbust Side. (&apos;Highbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="874"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
         <source>bust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1167"/>
         <source>Bust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="877"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1168"/>
         <source>Half of &apos;Bust arc, back&apos;. (&apos;Bust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="881"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
         <source>lowbust_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="883"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1174"/>
         <source>Lowbust arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="884"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
         <source>Half of &apos;Lowbust Arc, back&apos;. (&apos;Lowbust arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1179"/>
         <source>rib_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="890"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
         <source>Rib arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="891"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1182"/>
         <source>Half of &apos;Rib arc, back&apos;. (&apos;Rib arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1186"/>
         <source>waist_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="897"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1188"/>
         <source>Waist arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="898"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
         <source>Half of &apos;Waist arc, back&apos;. (&apos;Waist  arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
         <source>highhip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="904"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
         <source>Highhip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="905"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
         <source>Half of &apos;Highhip arc, back&apos;. From Highhip Back to Highbust Side. (&apos;Highhip arc, back&apos;/ 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="910"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
         <source>hip_arc_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="912"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
         <source>Hip arc, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="913"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
         <source>Half of &apos;Hip arc, back&apos;. (&apos;Hip arc, back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="917"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1208"/>
         <source>hip_with_abdomen_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="919"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
         <source>Hip arc with Abdomen, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1216"/>
         <source>body_armfold_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
         <source>Body circumference at Armfold level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1219"/>
         <source>Measure around arms and torso at Armfold level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1223"/>
         <source>body_bust_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
         <source>Body circumference at Bust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1226"/>
         <source>Measure around arms and torso at Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
         <source>body_torso_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
         <source>Body circumference of full torso</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
         <source>Circumference around torso from mid-shoulder around crotch back up to mid-shoulder.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1238"/>
         <source>hip_circ_with_abdomen</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1240"/>
         <source>Hip circumference, including Abdomen</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
         <source>Measurement at Hip level, including the depth of the Abdomen. (Hip arc, back + Hip arc with abdomen, front).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="967"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1312"/>
         <source>neck_front_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="969"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1314"/>
         <source>Neck Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="974"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1319"/>
         <source>neck_front_to_waist_flat_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="976"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1321"/>
         <source>Neck Front to Waist Front flat</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
         <source>From Neck Front down between breasts to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="981"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1326"/>
         <source>armpit_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1328"/>
         <source>Armpit to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="984"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
         <source>From Armpit down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="987"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
         <source>shoulder_tip_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="989"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1334"/>
         <source>Shoulder Tip to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1335"/>
         <source>From Shoulder Tip, curving around Armscye Front, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="994"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
         <source>neck_side_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="996"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1341"/>
         <source>Neck Side to Waist level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1342"/>
         <source>From Neck Side straight down front to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1001"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
         <source>neck_side_to_waist_bustpoint_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1003"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1348"/>
         <source>Neck Side to Waist level, through Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1004"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1349"/>
         <source>From Neck Side over Bustpoint to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
         <source>neck_front_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1010"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1355"/>
         <source>Neck Front to Highbust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1011"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1356"/>
         <source>Neck Front down to Highbust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1014"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
         <source>highbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1361"/>
         <source>Highbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1022"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1367"/>
         <source>neck_front_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1369"/>
         <source>Neck Front to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1030"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1375"/>
         <source>bust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1032"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1377"/>
         <source>Bust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1033"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1378"/>
         <source>From Bust Front down to Waist level. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Bust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1038"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
         <source>lowbust_to_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1040"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
         <source>Lowbust Front to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
         <source>From Lowbust Front down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
         <source>rib_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1046"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
         <source>Rib Side to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1047"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
         <source>From lowest rib at side down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1396"/>
         <source>shoulder_tip_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1053"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
         <source>Shoulder Tip to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1054"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1399"/>
         <source>From Shoulder Tip around Armscye down to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1403"/>
         <source>neck_side_to_bust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1060"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
         <source>Neck Side to Bust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1061"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1406"/>
         <source>From Neck Side straight down front to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
         <source>neck_side_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1067"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
         <source>Neck Side to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1068"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
         <source>From Neck Side straight down front to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
         <source>shoulder_center_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1074"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
         <source>Shoulder center to Highbust level, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1075"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
         <source>From mid-Shoulder down front to Highbust level, aimed at Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1424"/>
         <source>shoulder_tip_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1081"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1426"/>
         <source>Shoulder Tip to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1082"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
         <source>From Shoulder Tip, curving around Armscye Back, then down to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
         <source>neck_side_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1088"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
         <source>Neck Side to Waist level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1089"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
         <source>From Neck Side straight down back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1093"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1438"/>
         <source>neck_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1440"/>
         <source>Neck Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1096"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
         <source>From Neck Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1099"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1444"/>
         <source>neck_side_to_waist_scapula_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1101"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
         <source>Neck Side to Waist level, through Scapula</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1447"/>
         <source>From Neck Side across Scapula down to Waist level, forming a straight line.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1107"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
         <source>neck_back_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1109"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
         <source>Neck Back to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
         <source>From Neck Back down to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1113"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1458"/>
         <source>highbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1460"/>
         <source>Highbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1116"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1461"/>
         <source>From Highbust Back down to Waist Back. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Highbust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1121"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1466"/>
         <source>neck_back_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1123"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1468"/>
         <source>Neck Back to Bust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1469"/>
         <source>From Neck Back down to Bust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
         <source>bust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1129"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1474"/>
         <source>Bust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1130"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1475"/>
         <source>From Bust Back down to Waist level. (&apos;Neck Back to Waist Back&apos; - &apos;Neck Back to Bust Back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1135"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
         <source>lowbust_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1137"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1482"/>
         <source>Lowbust Back to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1138"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1483"/>
         <source>From Lowbust Back down to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1141"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
         <source>shoulder_tip_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1488"/>
         <source>Shoulder Tip to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1144"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1489"/>
         <source>From Shoulder Tip around Armscye down to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1148"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
         <source>neck_side_to_bust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1150"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1495"/>
         <source>Neck Side to Bust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1496"/>
         <source>From Neck Side straight down back to Bust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1155"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
         <source>neck_side_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1157"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
         <source>Neck Side to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1158"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1503"/>
         <source>From Neck Side straight down back to Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1507"/>
         <source>shoulder_center_to_highbust_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1164"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
         <source>Shoulder center to Highbust level, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1165"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1510"/>
         <source>From mid-Shoulder down back to Highbust level, aimed through Scapula.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1169"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1514"/>
         <source>waist_to_highhip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1171"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
         <source>Waist Front to Highhip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1172"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1517"/>
         <source>From Waist Front to Highhip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1175"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
         <source>waist_to_hip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1177"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
         <source>Waist Front to Hip Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1178"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
         <source>From Waist Front to Hip Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1181"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1526"/>
         <source>waist_to_highhip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1183"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1528"/>
         <source>Waist Side to Highhip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1184"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
         <source>From Waist Side to Highhip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1187"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1532"/>
         <source>waist_to_highhip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1189"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
         <source>Waist Back to Highhip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1190"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1535"/>
         <source>From Waist Back down to Highhip Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1193"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1538"/>
         <source>waist_to_hip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1195"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1540"/>
         <source>Waist Back to Hip Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1201"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1546"/>
         <source>waist_to_hip_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1203"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
         <source>Waist Side to Hip Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1204"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1549"/>
         <source>From Waist Side to Hip Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1207"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1552"/>
         <source>shoulder_slope_neck_side_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1209"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1554"/>
         <source>Shoulder Slope Angle from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1210"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and line from Neck Side parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1215"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1560"/>
         <source>shoulder_slope_neck_side_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1217"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1562"/>
         <source>Shoulder Slope length from Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1218"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1563"/>
         <source>Vertical distance between Neck Side and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1222"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1567"/>
         <source>shoulder_slope_neck_back_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1224"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1569"/>
         <source>Shoulder Slope Angle from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1225"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1570"/>
         <source>Angle formed by  line from Neck Back to Shoulder Tip and line from Neck Back parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1230"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1575"/>
         <source>shoulder_slope_neck_back_height</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1232"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
         <source>Shoulder Slope length from Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1233"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1578"/>
         <source>Vertical distance between Neck Back and Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1237"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1582"/>
         <source>shoulder_slope_shoulder_tip_angle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1239"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
         <source>Shoulder Slope Angle from Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1241"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1586"/>
         <source>Angle formed by line from Neck Side to Shoulder Tip and vertical line at Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1246"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
         <source>neck_back_to_across_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1248"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1593"/>
         <source>Neck Back to Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1249"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1594"/>
         <source>From neck back, down to level of Across Back measurement.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1253"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1598"/>
         <source>across_back_to_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1255"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
         <source>Across Back to Waist back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1256"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1601"/>
         <source>From middle of Across Back down to Waist back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1272"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1643"/>
         <source>shoulder_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1274"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1645"/>
         <source>Shoulder length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1275"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1646"/>
         <source>From Neck Side to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1278"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
         <source>shoulder_tip_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1280"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1651"/>
         <source>Shoulder Tip to Shoulder Tip, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1281"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1652"/>
         <source>From Shoulder Tip to Shoulder Tip, across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1285"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
         <source>across_chest_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1287"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1658"/>
         <source>Across Chest</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1288"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
         <source>From Armscye to Armscye at narrowest width across chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1292"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1663"/>
         <source>armfold_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1294"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
         <source>Armfold to Armfold, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1295"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1666"/>
         <source>From Armfold to Armfold, shortest distance between Armfolds, not parallel to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1300"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1671"/>
         <source>shoulder_tip_to_shoulder_tip_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1302"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1673"/>
         <source>Shoulder Tip to Shoulder Tip, front, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1303"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
         <source>Half of&apos; Shoulder Tip to Shoulder tip, front&apos;. (&apos;Shoulder Tip to Shoulder Tip, front&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1308"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1679"/>
         <source>across_chest_half_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1310"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
         <source>Across Chest, half</source>
         <comment>Full measurement name.</comment>
         <translation>1/2胸围</translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1311"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1682"/>
         <source>Half of &apos;Across Chest&apos;. (&apos;Across Chest&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
         <source>shoulder_tip_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1317"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1688"/>
         <source>Shoulder Tip to Shoulder Tip, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1318"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1689"/>
         <source>From Shoulder Tip to Shoulder Tip, across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1322"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1693"/>
         <source>across_back_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1324"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
         <source>Across Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1325"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1696"/>
         <source>From Armscye to Armscye at the narrowest width of the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1329"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1700"/>
         <source>armfold_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1331"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1702"/>
         <source>Armfold to Armfold, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1332"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
         <source>From Armfold to Armfold across the back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1336"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1707"/>
         <source>shoulder_tip_to_shoulder_tip_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1338"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
         <source>Shoulder Tip to Shoulder Tip, back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1339"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1710"/>
         <source>Half of &apos;Shoulder Tip to Shoulder Tip, back&apos;. (&apos;Shoulder Tip to Shoulder Tip,  back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1344"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1715"/>
         <source>across_back_half_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1346"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1717"/>
         <source>Across Back, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1347"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
         <source>Half of &apos;Across Back&apos;. (&apos;Across Back&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1351"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1722"/>
         <source>neck_front_to_shoulder_tip_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1353"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1724"/>
         <source>Neck Front to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1354"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
         <source>From Neck Front to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1357"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1728"/>
         <source>neck_back_to_shoulder_tip_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1359"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1730"/>
         <source>Neck Back to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1360"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1731"/>
         <source>From Neck Back to Shoulder Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1363"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1734"/>
         <source>neck_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1365"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1736"/>
         <source>Neck Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1366"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1737"/>
         <source>Measure between the &apos;legs&apos; of an unclosed necklace or chain draped around the neck.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1383"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1777"/>
         <source>bustpoint_to_bustpoint</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1385"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1779"/>
         <source>Bustpoint to Bustpoint</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1386"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
         <source>From Bustpoint to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1389"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1783"/>
         <source>bustpoint_to_neck_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1391"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1785"/>
         <source>Bustpoint to Neck Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1392"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
         <source>From Neck Side to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1395"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1789"/>
         <source>bustpoint_to_lowbust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1397"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
         <source>Bustpoint to Lowbust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1398"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1792"/>
         <source>From Bustpoint down to Lowbust level, following curve of bust or chest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1402"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1796"/>
         <source>bustpoint_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1404"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1798"/>
         <source>Bustpoint to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1405"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
         <source>From Bustpoint to straight down to Waist level, forming a straight line (not curving along the body).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1410"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1804"/>
         <source>bustpoint_to_bustpoint_half</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1412"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
         <source>Bustpoint to Bustpoint, half</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1413"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1807"/>
         <source>Half of &apos;Bustpoint to Bustpoint&apos;. (&apos;Bustpoint to Bustpoint&apos; / 2).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1417"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1811"/>
         <source>bustpoint_neck_side_to_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1419"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1813"/>
         <source>Bustpoint, Neck Side to Waist level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1420"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
         <source>From Neck Side to Bustpoint, then straight down to Waist level. (&apos;Neck Side to Bustpoint&apos; + &apos;Bustpoint to Waist level&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1425"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
         <source>bustpoint_to_shoulder_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1427"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
         <source>Bustpoint to Shoulder Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1428"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
         <source>From Bustpoint to Shoulder tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1431"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1825"/>
         <source>bustpoint_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1433"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1827"/>
         <source>Bustpoint to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1434"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
         <source>From Bustpoint to Waist Front, in a straight line, not following the curves of the body.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1439"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
         <source>bustpoint_to_bustpoint_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1441"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
         <source>Bustpoint to Bustpoint Halter</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1442"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
         <source>From Bustpoint around Neck Back down to other Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1446"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1840"/>
         <source>bustpoint_to_shoulder_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1448"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1842"/>
         <source>Bustpoint to Shoulder Center</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1449"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1843"/>
         <source>From center of Shoulder to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1452"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1846"/>
         <source>bustpoint_to_neck_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1454"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1848"/>
         <source>Bustpoint to Neck Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1455"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1849"/>
         <source>From Neck Front to Bustpoint.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1470"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1889"/>
         <source>shoulder_tip_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1472"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1891"/>
         <source>Shoulder Tip to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1473"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
         <source>From Shoulder Tip diagonal to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1477"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1896"/>
         <source>neck_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1479"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1898"/>
         <source>Neck Front to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1480"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
         <source>From Neck Front diagonal to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1484"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1903"/>
         <source>neck_side_to_waist_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1486"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1905"/>
         <source>Neck Side to Waist Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1487"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
         <source>From Neck Side diagonal across front to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1491"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1910"/>
         <source>shoulder_tip_to_waist_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1493"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1912"/>
         <source>Shoulder Tip to Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1494"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1913"/>
         <source>From Shoulder Tip diagonal to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1498"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1917"/>
         <source>shoulder_tip_to_waist_b_1in_offset</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1500"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1919"/>
         <source>Shoulder Tip to Waist Back, with 1in (2.54cm) offset</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1502"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1921"/>
         <source>Mark 1in (2.54cm) outward from Waist Back along Waist level. Measure from Shoulder Tip diagonal to mark.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1506"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
         <source>neck_back_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1508"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
         <source>Neck Back to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1509"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
         <source>From Neck Back diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1513"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
         <source>neck_side_to_waist_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1515"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
         <source>Neck Side to Waist Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1516"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
         <source>From Neck Side diagonal across back to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1520"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
         <source>neck_side_to_armfold_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1522"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
         <source>Neck Side to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1523"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
         <source>From Neck Side diagonal to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1527"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1946"/>
         <source>neck_side_to_armpit_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1529"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1948"/>
         <source>Neck Side to Highbust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1530"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
         <source>From Neck Side diagonal across front to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1534"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1953"/>
         <source>neck_side_to_bust_side_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1536"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1955"/>
         <source>Neck Side to Bust Side, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1537"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
         <source>Neck Side diagonal across front to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1960"/>
         <source>neck_side_to_armfold_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1543"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1962"/>
         <source>Neck Side to Armfold Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1544"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
         <source>From Neck Side diagonal to Armfold Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1548"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1967"/>
         <source>neck_side_to_armpit_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1550"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1969"/>
         <source>Neck Side to Highbust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1551"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
         <source>From Neck Side diagonal across back to Highbust Side (Armpit).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1555"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1974"/>
         <source>neck_side_to_bust_side_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1557"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1976"/>
         <source>Neck Side to Bust Side, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1558"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
         <source>Neck Side diagonal across back to Bust Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1574"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2026"/>
         <source>arm_shoulder_tip_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1576"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2028"/>
         <source>Arm: Shoulder Tip to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1577"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2029"/>
         <source>Bend Arm, measure from Shoulder Tip around Elbow to radial Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1581"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2033"/>
         <source>arm_shoulder_tip_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1583"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2035"/>
         <source>Arm: Shoulder Tip to Elbow, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1584"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2036"/>
         <source>Bend Arm, measure from Shoulder Tip to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1588"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2040"/>
         <source>arm_elbow_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1590"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2042"/>
         <source>Arm: Elbow to Wrist, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1591"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
         <source>Elbow tip to wrist. (&apos;Arm: Shoulder Tip to Wrist, bent&apos; - &apos;Arm: Shoulder Tip to Elbow, bent&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1597"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2049"/>
         <source>arm_elbow_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1599"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
         <source>Arm: Elbow circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1600"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2052"/>
         <source>Elbow circumference, arm is bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1603"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
         <source>arm_shoulder_tip_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1605"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
         <source>Arm: Shoulder Tip to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1606"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
         <source>From Shoulder Tip to Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1610"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
         <source>arm_shoulder_tip_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1612"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
         <source>Arm: Shoulder Tip to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1613"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
         <source>From Shoulder tip to Elbow Tip, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1617"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
         <source>arm_elbow_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1619"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
         <source>Arm: Elbow to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1620"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
         <source>From Elbow to Wrist, arm straight. (&apos;Arm: Shoulder Tip to Wrist&apos; - &apos;Arm: Shoulder Tip to Elbow&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1625"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2077"/>
         <source>arm_armpit_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1627"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
         <source>Arm: Armpit to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1628"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2080"/>
         <source>From Armpit to ulna Wrist bone, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1632"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
         <source>arm_armpit_to_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1634"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
         <source>Arm: Armpit to Elbow, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1635"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
         <source>From Armpit to inner Elbow, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1639"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2091"/>
         <source>arm_elbow_to_wrist_inside</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1641"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2093"/>
         <source>Arm: Elbow to Wrist, inside</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1642"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
         <source>From inside Elbow to Wrist. (&apos;Arm: Armpit to Wrist, inside&apos; - &apos;Arm: Armpit to Elbow, inside&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1647"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2099"/>
         <source>arm_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1649"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2101"/>
         <source>Arm: Upper Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1650"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
         <source>Arm circumference at Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1653"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2105"/>
         <source>arm_above_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1655"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2107"/>
         <source>Arm: Above Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1656"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
         <source>Arm circumference at Bicep level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1659"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
         <source>arm_elbow_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1661"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2113"/>
         <source>Arm: Elbow circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1662"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2114"/>
         <source>Elbow circumference, arm straight.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1665"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
         <source>arm_lower_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1667"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
         <source>Arm: Lower Arm circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1668"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2120"/>
         <source>Arm circumference where lower arm is widest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1672"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
         <source>arm_wrist_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1674"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
         <source>Arm: Wrist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1675"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
         <source>Wrist circumference.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1678"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2130"/>
         <source>arm_shoulder_tip_to_armfold_line</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1680"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2132"/>
         <source>Arm: Shoulder Tip to Armfold line</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1681"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2133"/>
         <source>From Shoulder Tip down to Armpit level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1684"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2136"/>
         <source>arm_neck_side_to_wrist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1686"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2138"/>
         <source>Arm: Neck Side to Wrist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1687"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2139"/>
         <source>From Neck Side to Wrist. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1692"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2144"/>
         <source>arm_neck_side_to_finger_tip</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1694"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
         <source>Arm: Neck Side to Finger Tip</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1695"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2147"/>
         <source>From Neck Side down arm to tip of middle finger. (&apos;Shoulder Length&apos; + &apos;Arm: Shoulder Tip to Wrist&apos; + &apos;Hand: Length&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1701"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
         <source>armscye_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1703"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2155"/>
         <source>Armscye: Circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2156"/>
         <source>Let arm hang at side. Measure Armscye circumference through Shoulder Tip and Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1709"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
         <source>armscye_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1711"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2163"/>
         <source>Armscye: Length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1712"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2164"/>
         <source>Vertical distance from Shoulder Tip to Armpit.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1716"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2168"/>
         <source>armscye_width</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1718"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2170"/>
         <source>Armscye: Width</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1719"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2171"/>
         <source>Horizontal distance between Armscye Front and Armscye Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1723"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2175"/>
         <source>arm_neck_side_to_outer_elbow</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1725"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2177"/>
         <source>Arm: Neck side to Elbow</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1726"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2178"/>
         <source>From Neck Side over Shoulder Tip down to Elbow. (Shoulder length + Arm: Shoulder Tip to Elbow).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1742"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2219"/>
         <source>leg_crotch_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1744"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2221"/>
         <source>Leg: Crotch to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1745"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2222"/>
         <source>Stand feet close together. Measure from crotch level (touching body, no extra space) down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1836"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2313"/>
         <source>From Waist Side along curve to Hip level then straight down to  Knee level. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height Knee&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1856"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2352"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Front down between legs and up to Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1863"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2359"/>
         <source>Put tape across gap between buttocks at Hip level. Measure from Waist Back to mid-Crotch, either at the vagina or between testicles and anus).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1876"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2372"/>
         <source>rise_length_side_sitting</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1909"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2405"/>
         <source>Vertical distance from Waist side down to Crotch level. Use formula (Height: Waist side - Leg: Crotch to floor).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2162"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2720"/>
         <source>This information is pulled from pattern charts in some  patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1750"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2227"/>
         <source>leg_waist_side_to_floor</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1752"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2229"/>
         <source>Leg: Waist Side to floor</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1753"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2230"/>
         <source>From Waist Side along curve to Hip level then straight down to floor.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1757"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2234"/>
         <source>leg_thigh_upper_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1759"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2236"/>
         <source>Leg: Thigh Upper circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1760"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2237"/>
         <source>Thigh circumference at the fullest part of the upper Thigh near the Crotch.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1765"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2242"/>
         <source>leg_thigh_mid_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1767"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2244"/>
         <source>Leg: Thigh Middle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1768"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2245"/>
         <source>Thigh circumference about halfway between Crotch and Knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1772"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2249"/>
         <source>leg_knee_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1774"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2251"/>
         <source>Leg: Knee circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1775"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2252"/>
         <source>Knee circumference with straight leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1778"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2255"/>
         <source>leg_knee_small_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1780"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2257"/>
         <source>Leg: Knee Small circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1781"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2258"/>
         <source>Leg circumference just below the knee.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1784"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2261"/>
         <source>leg_calf_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1786"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2263"/>
         <source>Leg: Calf circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1787"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2264"/>
         <source>Calf circumference at the largest part of lower leg.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1791"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2268"/>
         <source>leg_ankle_high_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1793"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2270"/>
         <source>Leg: Ankle High circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1794"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2271"/>
         <source>Ankle circumference where the indentation at the back of the ankle is the deepest.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1799"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2276"/>
         <source>leg_ankle_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1801"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2278"/>
         <source>Leg: Ankle circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1802"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2279"/>
         <source>Ankle circumference where front of leg meets the top of the foot.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1806"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2283"/>
         <source>leg_knee_circ_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1808"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2285"/>
         <source>Leg: Knee circumference, bent</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1809"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2286"/>
         <source>Knee circumference with leg bent.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1812"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2289"/>
         <source>leg_ankle_diag_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1814"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2291"/>
         <source>Leg: Ankle diagonal circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1815"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2292"/>
         <source>Ankle circumference diagonal from top of foot to bottom of heel.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1819"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2296"/>
         <source>leg_crotch_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1821"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2298"/>
         <source>Leg: Crotch to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1822"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2299"/>
         <source>From Crotch to Ankle. (&apos;Leg: Crotch to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1826"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2303"/>
         <source>leg_waist_side_to_ankle</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1828"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2305"/>
         <source>Leg: Waist Side to Ankle</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1829"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2306"/>
         <source>From Waist Side to Ankle. (&apos;Leg: Waist Side to Floor&apos; - &apos;Height: Ankle&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1833"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2310"/>
         <source>leg_waist_side_to_knee</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1835"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2312"/>
         <source>Leg: Waist Side to Knee</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1853"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2349"/>
         <source>crotch_length</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1855"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2351"/>
         <source>Crotch length</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1860"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2356"/>
         <source>crotch_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1862"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2358"/>
         <source>Crotch length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1868"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2364"/>
         <source>crotch_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1870"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2366"/>
         <source>Crotch length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1871"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2367"/>
         <source>From Waist Front to start of vagina or end of testicles. (&apos;Crotch length&apos; - &apos;Crotch length, back&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1878"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2374"/>
         <source>Rise length, side, sitting</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1880"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2376"/>
         <source>From Waist Side around hip curve down to surface, while seated on hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1895"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2391"/>
         <source>Vertical distance from Waist Back to Crotch level. (&apos;Height: Waist Back&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1902"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2398"/>
         <source>Vertical Distance from Waist Front to Crotch level. (&apos;Height: Waist Front&apos; - &apos;Leg: Crotch to Floor&apos;)</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1906"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2402"/>
         <source>rise_length_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1908"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2404"/>
         <source>Rise length, side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1885"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2381"/>
         <source>rise_length_diag</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="920"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1211"/>
         <source>Curve stiff paper around front of abdomen, tape at sides. Measure from Hip Side to Hip Side over paper across front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1315"/>
         <source>From Neck Front, over tape between Breastpoints, down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1017"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1362"/>
         <source>From Highbust Front to Waist Front. Use tape to bridge gap between Bustpoints. (&apos;Neck Front to Waist Front&apos; - &apos;Neck Front to Highbust Front&apos;).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1025"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1370"/>
         <source>From Neck Front down to Bust Front. Requires tape to cover gap between Bustpoints.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1196"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1541"/>
         <source>From Waist Back down to Hip Back. Requires tape to cover the gap between buttocks.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1887"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2383"/>
         <source>Rise length, diagonal</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1888"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2384"/>
         <source>Measure from Waist Side diagonally to a string tied at the top of the leg, seated on a hard surface.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1892"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2388"/>
         <source>rise_length_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1894"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2390"/>
         <source>Rise length, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1899"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2395"/>
         <source>rise_length_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1901"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2397"/>
         <source>Rise length, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1925"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2446"/>
         <source>neck_back_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1927"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2448"/>
         <source>Neck Back to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1928"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2449"/>
         <source>From Neck Back around Neck Side down to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1932"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2453"/>
         <source>waist_to_waist_halter</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1934"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2455"/>
         <source>Waist to Waist Halter, around Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1935"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2456"/>
         <source>From Waist level around Neck Back to Waist level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1939"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2460"/>
         <source>waist_natural_circ</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1941"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2462"/>
         <source>Natural Waist circumference</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1942"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2463"/>
         <source>Torso circumference at men&apos;s natural side Abdominal Obliques indentation, if Oblique indentation isn&apos;t found then just below the Navel level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1947"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2468"/>
         <source>waist_natural_arc_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1949"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2470"/>
         <source>Natural Waist arc, front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1950"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2471"/>
         <source>From Side to Side at the Natural Waist level, across the front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1954"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2475"/>
         <source>waist_natural_arc_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1956"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2477"/>
         <source>Natural Waist arc, back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1957"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2478"/>
         <source>From Side to Side at Natural Waist level, across the back. Calculate as ( Natural Waist circumference - Natural Waist arc (front) ).</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1961"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2482"/>
         <source>waist_to_natural_waist_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1963"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2484"/>
         <source>Waist Front to Natural Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1964"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2485"/>
         <source>Length from Waist Front to Natural Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1968"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2489"/>
         <source>waist_to_natural_waist_b</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1970"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2491"/>
         <source>Waist Back to Natural Waist Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1971"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2492"/>
         <source>Length from Waist Back to Natural Waist Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1975"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2496"/>
         <source>arm_neck_back_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1977"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2498"/>
         <source>Arm: Neck Back to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1978"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2499"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1983"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2504"/>
         <source>arm_neck_back_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1985"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2506"/>
         <source>Arm: Neck Back to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1986"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2507"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1990"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2511"/>
         <source>arm_neck_side_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1992"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2513"/>
         <source>Arm: Neck Side to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1993"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2514"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1997"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2518"/>
         <source>arm_neck_side_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="1999"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2520"/>
         <source>Arm: Neck Side to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2000"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2521"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Neck Side to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2005"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2526"/>
         <source>arm_across_back_center_to_elbow_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2007"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2528"/>
         <source>Arm: Across Back Center to Elbow, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2008"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2529"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2013"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2534"/>
         <source>arm_across_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2015"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2536"/>
         <source>Arm: Across Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2016"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2537"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Middle of Back to Elbow Tip to Wrist bone.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2021"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2542"/>
         <source>arm_armscye_back_center_to_wrist_bent</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2023"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2544"/>
         <source>Arm: Armscye Back Center to Wrist, high bend</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2024"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2545"/>
         <source>Bend Arm with Elbow out, hand in front. Measure from Armscye Back to Elbow Tip.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2041"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2585"/>
         <source>neck_back_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2043"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2587"/>
         <source>Neck Back to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2044"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2588"/>
         <source>From Neck Back, over Shoulder, to Bust Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2048"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2592"/>
         <source>neck_back_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2050"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2594"/>
         <source>Neck Back to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2051"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2595"/>
         <source>From Neck Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2055"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2599"/>
         <source>neck_back_to_armfold_front_to_waist_side</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2057"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2601"/>
         <source>Neck Back, over Shoulder, to Waist Side</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2058"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2602"/>
         <source>From Neck Back, over Shoulder, down chest to Waist Side.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2062"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2606"/>
         <source>highbust_back_over_shoulder_to_armfold_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2064"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2608"/>
         <source>Highbust Back, over Shoulder, to Armfold Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2065"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2609"/>
         <source>From Highbust Back over Shoulder to Armfold Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2069"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2613"/>
         <source>highbust_back_over_shoulder_to_waist_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2071"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2615"/>
         <source>Highbust Back, over Shoulder, to Waist Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2072"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2616"/>
         <source>From Highbust Back, over Shoulder touching  Neck Side, to Waist Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2076"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2620"/>
         <source>neck_back_to_armfold_front_to_neck_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2078"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2622"/>
         <source>Neck Back, to Armfold Front, to Neck Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2079"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2623"/>
         <source>From Neck Back, over Shoulder to Armfold Front, under arm and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2084"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2628"/>
         <source>across_back_center_to_armfold_front_to_across_back_center</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2086"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2630"/>
         <source>Across Back Center, circled around Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2087"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2631"/>
         <source>From center of Across Back, over Shoulder, under Arm, and return to start.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2092"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2636"/>
         <source>neck_back_to_armfold_front_to_highbust_back</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2094"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2638"/>
         <source>Neck Back, to Armfold Front, to Highbust Back</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2095"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2639"/>
         <source>From Neck Back over Shoulder to Armfold Front, under arm to Highbust Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2100"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2644"/>
         <source>armfold_to_armfold_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2102"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2646"/>
         <source>Armfold to Armfold, front, curved through Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2104"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2648"/>
         <source>Measure in a curve from Armfold Left Front through Bust Front curved back up to Armfold Right Front.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2108"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2652"/>
         <source>armfold_to_bust_front</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2110"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2654"/>
         <source>Armfold to Bust Front</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2111"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2655"/>
         <source>Measure from Armfold Front to Bust Front, shortest distance between the two, as straight as possible.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2115"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2659"/>
         <source>highbust_b_over_shoulder_to_highbust_f</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2117"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2661"/>
         <source>Highbust Back, over Shoulder, to Highbust level</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2119"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2663"/>
         <source>From Highbust Back, over Shoulder, then aim at Bustpoint, stopping measurement at Highbust level.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2124"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2668"/>
         <source>armscye_arc</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2126"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2670"/>
         <source>Armscye: Arc</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2127"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2671"/>
         <source>From Armscye at Across Chest over ShoulderTip  to Armscye at Across Back.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2143"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2701"/>
         <source>dart_width_shoulder</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2145"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2703"/>
         <source>Dart Width: Shoulder</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2146"/>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2154"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2704"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2712"/>
         <source>This information is pulled from pattern charts in some patternmaking systems, e.g. Winifred P. Aldrich&apos;s &quot;Metric Pattern Cutting&quot;.</source>
         <comment>Full measurement description.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2151"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2709"/>
         <source>dart_width_bust</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2153"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2711"/>
         <source>Dart Width: Bust</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2159"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2717"/>
         <source>dart_width_waist</source>
         <comment>Name in a formula. Don&apos;t use math symbols and space in name!!!!</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2161"/>
+        <location filename="../../src/libs/vpatterndb/vtranslatemeasurements.cpp" line="2719"/>
         <source>Dart Width: Waist</source>
         <comment>Full measurement name.</comment>
         <translation type="unfinished"></translation>

--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -8473,6 +8473,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8638,6 +8642,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12786,6 +12806,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Typ</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Smazat</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -8492,6 +8492,10 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <source>Bottom:</source>
         <translation>Unten:</translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8658,6 +8662,22 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     <message>
         <source>Piece renamed to: </source>
         <translation>Schnittteil wurde umbenannt in: </translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12814,6 +12834,98 @@ wie gewohnt in SeamlyME laden können.
     <message>
         <source>Show Point Name</source>
         <translation>Bezeichnung des Punktes anzeigen</translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished">Schnittpunkt</translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished">Markierung</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Typ</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished">Schlitz</translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished">Burg</translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished">Diamant</translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished">Unterart</translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished">Geradeaus</translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished">Ausgeschlossen</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Löschen</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -8473,6 +8473,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation type="unfinished">Κάτω:</translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8638,6 +8642,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12785,6 +12805,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished">Διατομή</translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Τύπος</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">Κανένα</translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished">Διχοτόμος</translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished">Εξαιρούμενο</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Διαγραφή</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -8476,6 +8476,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation type="unfinished">Bottom:</translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8641,6 +8645,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12790,6 +12810,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished">Intersection</translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished">Notch</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Type</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">None</translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished">Straightforward</translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished">Bisector</translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished">Excluded</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Delete</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -8476,6 +8476,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation type="unfinished">Bottom:</translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8641,6 +8645,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12790,6 +12810,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished">Intersection</translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished">Notch</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Type</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">None</translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished">Straightforward</translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished">Bisector</translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished">Excluded</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Delete</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -8476,6 +8476,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation type="unfinished">Bottom:</translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8641,6 +8645,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12790,6 +12810,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished">Intersection</translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished">Notch</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Type</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">None</translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished">Straightforward</translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished">Bisector</translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished">Excluded</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Delete</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -8476,6 +8476,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation type="unfinished">Bottom:</translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8641,6 +8645,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12790,6 +12810,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished">Intersection</translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished">Notch</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Type</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">None</translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished">Straightforward</translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished">Bisector</translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished">Excluded</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Delete</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -8549,6 +8549,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation>Abajo:</translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8715,6 +8719,22 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Piece renamed to: </source>
         <translation>El nombre de pieza se cambió a: </translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12872,6 +12892,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation>Mostrar Nombre del Punto</translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished">Intersección</translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished">Piquete</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Tipo</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">Ninguno</translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished">Abertura</translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished">VInterno</translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished">VExterno</translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished">Diamante</translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished">Subtipo</translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished">Directo</translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished">Bisectriz</translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished">Excluido</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Eliminar</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -8473,6 +8473,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8638,6 +8642,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12786,6 +12806,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Tyyppi</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Poista</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -8476,6 +8476,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation>Bas:</translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8641,6 +8645,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12789,6 +12809,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished">Repère de montage</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Type</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Supprimer</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -8472,6 +8472,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8637,6 +8641,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12783,6 +12803,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">למחוק</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -8473,6 +8473,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8638,6 +8642,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12784,6 +12804,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">hapus</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -8476,6 +8476,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation>Fondo:</translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8641,6 +8645,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12788,6 +12808,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Tipo</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Elimina</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -8481,6 +8481,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation>Onder:</translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8647,6 +8651,22 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Piece renamed to: </source>
         <translation>Patroondeel hernoemd tot: </translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -12800,6 +12820,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation>Toon Puntnaam</translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished">Kruispunt van lijnen</translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished">Pasmarkering</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Soort</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">Geen</translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished">Knipje</translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished">T Pasmarkering</translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished">U Pasmarkering</translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished">Kasteel</translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished">Diamant</translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished">Subtype</translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished">Rechttoe rechtaan</translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished">Uitgezonderd</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -8472,6 +8472,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation type="unfinished">Base:</translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8637,6 +8641,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12783,6 +12803,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished">nenhum</translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished">Reto</translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished">Bissetriz</translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Excluir</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -8472,6 +8472,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8637,6 +8641,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12783,6 +12803,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Șterge</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -8506,6 +8506,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation>Нижнее:</translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8672,6 +8676,22 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Piece renamed to: </source>
         <translation>Деталь переименована в: </translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -10403,13 +10423,13 @@ Press enter to temporarily add it to the list.</source>
         <translation>Дюймы</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed.
+        <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10477,13 +10497,13 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Устанавливает звук щелчка при выборе узла.</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use.
-When checked the separator for the user&apos;s locale is used.
+        <source>Selects what decimal separator char to use. 
+When checked the separator for the user&apos;s locale is used. 
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed.
+        <source>When checked the Welcome window will not be displayed. 
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12827,6 +12847,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation>Показать Название Точки</translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished">Пересечение</translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished">Надсечка</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Тип</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished">Щель</translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished">Т-Надсечка</translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished">U-Надсечка</translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished">V Внутренний</translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished">V Внешний</translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished">Замок</translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished">Алмаз</translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished">Тип</translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished">Прямой</translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished">Биссектриса</translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished">Исключён</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Удалить</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -8475,6 +8475,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation>Нижнє:</translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8640,6 +8644,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12788,6 +12808,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished">Перетин</translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished">Надсічка</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished">Тип</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished">Пряма</translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished">Бісектриса</translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished">Виключений</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">Видалити</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -8472,6 +8472,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Bottom:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>
@@ -8637,6 +8641,22 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Piece renamed to: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Node Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exclude Node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Node</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -12783,6 +12803,98 @@ load in SeamlyME as usual.
     <message>
         <source>Show Point Name</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seam Allowance Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>By length</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Intersection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge symmetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>First edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Second edge right angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Notch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Slit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UNotch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VInternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VExternal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Castle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Diamond</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtype</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Straightforward</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Bisector</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Excluded</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished">删除</translation>
     </message>
 </context>
 <context>

--- a/src/libs/vpatterndb/vpiece.cpp
+++ b/src/libs/vpatterndb/vpiece.cpp
@@ -1,54 +1,53 @@
-/***************************************************************************
- **  @file   vpiece.cpp
- **  @author Douglas S Caskey
- **  @date   17 Sep, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//******************************************************************************
+//  @file   vpiece.cpp
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @copyright
+//  Copyright (C) 2017 - 2023 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
+//******************************************************************************
 
-/************************************************************************
- **
- **  @file   vpiece.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   3 11, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//******************************************************************************
+//  @file   vpiece.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   3 11, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentine project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//
+//******************************************************************************
 
 #include "vpiece.h"
 #include "vpiece_p.h"
@@ -476,13 +475,12 @@ void VPiece::setAnchors(const QVector<quint32> &anchors)
     d->m_anchors = anchors;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief MissingNodes find missing nodes in piece. When we deleted object in piece and return this piece need
- * understand, what nodes need make invisible.
- * @param piece changed piece.
- * @return  list with missing nodes.
- */
+//******************************************************************************
+/// @brief MissingNodes find missing nodes in piece. When we deleted object in piece and return this piece need
+///  understand, what nodes need make invisible.
+/// @param piece changed piece.
+/// @return  list with missing nodes.
+//******************************************************************************
 QVector<quint32> VPiece::MissingNodes(const VPiece &piece) const
 {
     return d->m_path.MissingNodes(piece.GetPath());
@@ -524,21 +522,19 @@ void VPiece::SetPatternPieceData(const VPieceLabelData &data)
     d->m_ppData = data;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Returns full access to the pattern piece data object
- * @return pattern piece data object
- */
+//******************************************************************************
+/// @brief Returns full access to the pattern piece data object
+/// @return pattern piece data object
+//******************************************************************************
 VPieceLabelData &VPiece::GetPatternPieceData()
 {
     return d->m_ppData;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Returns the read only reference to the pattern piece data object
- * @return pattern piece data object
- */
+//******************************************************************************
+/// @brief Returns the read only reference to the pattern piece data object
+/// @return pattern piece data object
+//******************************************************************************
 const VPieceLabelData &VPiece::GetPatternPieceData() const
 {
     return d->m_ppData;
@@ -550,41 +546,37 @@ void VPiece::SetPatternInfo(const VPatternLabelData &info)
     d->m_piPatternInfo = info;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Returns full access to the pattern info geometry object
- * @return pattern info geometry object
- */
+//******************************************************************************
+/// @brief Returns full access to the pattern info geometry object
+/// @return pattern info geometry object
+//******************************************************************************
 VPatternLabelData &VPiece::GetPatternInfo()
 {
     return d->m_piPatternInfo;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Returns the read only reference to the pattern info geometry object
- * @return pattern info geometry object
- */
+//******************************************************************************
+/// @brief Returns the read only reference to the pattern info geometry object
+/// @return pattern info geometry object
+//******************************************************************************
 const VPatternLabelData &VPiece::GetPatternInfo() const
 {
     return d->m_piPatternInfo;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VDetail::GetGrainlineGeometry full access to the grainline geometry object
- * @return reference to grainline geometry object
- */
+//******************************************************************************
+/// @brief VDetail::GetGrainlineGeometry full access to the grainline geometry object
+/// @return reference to grainline geometry object
+//******************************************************************************
 VGrainlineData &VPiece::GetGrainlineGeometry()
 {
     return d->m_glGrainline;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VDetail::GetGrainlineGeometry returns the read-only reference to the grainline geometry object
- * @return reference to grainline geometry object
- */
+//******************************************************************************
+/// @brief VDetail::GetGrainlineGeometry returns the read-only reference to the grainline geometry object
+/// @return reference to grainline geometry object
+//******************************************************************************
 const VGrainlineData &VPiece::GetGrainlineGeometry() const
 {
     return d->m_glGrainline;

--- a/src/libs/vpatterndb/vpiece.h
+++ b/src/libs/vpatterndb/vpiece.h
@@ -1,54 +1,54 @@
-/***************************************************************************
- **  @file   vpiece.h
- **  @author Douglas S Caskey
- **  @date   Jan 3, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//******************************************************************************
+//  @file   vpiece.h
+//  @author Douglas S Caskey
+//  @date   Jan 3, 2023
+//
+//  @copyright
+//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
+//******************************************************************************
 
-/************************************************************************
- **
- **  @file   vpiece.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   3 11, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//******************************************************************************
+//
+//  @file   vpiece.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   3 11, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//
+//******************************************************************************
 
 #ifndef VPIECE_H
 #define VPIECE_H

--- a/src/libs/vpatterndb/vpiece.h
+++ b/src/libs/vpatterndb/vpiece.h
@@ -70,6 +70,7 @@ struct NotchData
     qreal        angle {};
     qreal        offset {};
     int          count {};
+    bool         isNotch {};
 };
 
 class VPieceData;

--- a/src/libs/vpatterndb/vpiecenode.h
+++ b/src/libs/vpatterndb/vpiecenode.h
@@ -1,53 +1,52 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//******************************************************************************
+//  @file   vpiecenode.h
+//  @author Douglas S Caskey
+//  @date  1 Mar, 2025
+//
+//  @copyright
+//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
+//******************************************************************************
 
- ************************************************************************
- **
- **  @file
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   3 11, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//******************************************************************************
+//  @file
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   3 11, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentine project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//******************************************************************************
 
 #ifndef VPIECENODE_H
 #define VPIECENODE_H

--- a/src/libs/vpatterndb/vpiecepath.cpp
+++ b/src/libs/vpatterndb/vpiecepath.cpp
@@ -235,6 +235,19 @@ void VPiecePath::SetNodes(const QVector<VPieceNode> &nodes)
     d->m_nodes = nodes;
 }
 
+QVector<VPieceNode> VPiecePath::removeNode(const quint32 &id)
+{
+    QVector<VPieceNode> nodes = GetNodes();
+    for (int i = 0; i < nodes.size(); ++i)
+    {
+        if (nodes.at(i).GetId() == id)
+        {
+            nodes.removeAt(i);
+        }
+    }
+    return nodes;
+}
+
 //---------------------------------------------------------------------------------------------------------------------
 PiecePathType VPiecePath::GetType() const
 {

--- a/src/libs/vpatterndb/vpiecepath.cpp
+++ b/src/libs/vpatterndb/vpiecepath.cpp
@@ -1,54 +1,54 @@
-/***************************************************************************
- **  @file   vpiecepath.cpp
- **  @author Douglas S Caskey
- **  @date   17 Sep, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//******************************************************************************
+//  @file   vpiecepath.cpp
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @copyright
+//  Copyright (C) 2017 - 2023 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//******************************************************************************
 
- /************************************************************************
- **
- **  @file
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   22 11, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//******************************************************************************
+//
+//  @file
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   22 11, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//
+//******************************************************************************
 
 #include "vpiecepath.h"
 #include "vpiecepath_p.h"
@@ -132,13 +132,12 @@ VSAPoint CurveEndPoint(VSAPoint candidate, const VContainer *data, const VPieceN
     return candidate;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief indexOfNode return index in list node using id object.
- * @param list list nodes detail.
- * @param id object (arc, point, spline, splinePath) id.
- * @return index in list or -1 id can't find.
- */
+//******************************************************************************
+/// @brief indexOfNode return index in list node using id object.
+/// @param list list nodes detail.
+/// @param id object (arc, point, spline, splinePath) id.
+/// @return index in list or -1 id can't find.
+//******************************************************************************
 int IndexOfNode(const QVector<VPieceNode> &list, quint32 id)
 {
     for (int i = 0; i < list.size(); ++i)
@@ -522,13 +521,12 @@ int VPiecePath::indexOfNode(quint32 id) const
     return indexOfNode(d->m_nodes, id);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief NodeOnEdge return nodes located on edge with index.
- * @param index index of edge.
- * @param p1 first node.
- * @param p2 second node.
- */
+//******************************************************************************
+/// @brief NodeOnEdge return nodes located on edge with index.
+/// @param index index of edge.
+/// @param p1 first node.
+/// @param p2 second node.
+//******************************************************************************
 void VPiecePath::NodeOnEdge(quint32 index, VPieceNode &p1, VPieceNode &p2) const
 {
     const QVector<VPieceNode> list = ListNodePoint();
@@ -561,14 +559,13 @@ bool VPiecePath::Contains(quint32 id) const
     return false;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief OnEdge checks if two poins located on the edge. Edge is line between two points. If between two points
- * located arcs or splines ignore this.
- * @param p1 id first point.
- * @param p2 id second point.
- * @return true - on edge, false - no.
- */
+//******************************************************************************
+/// @brief OnEdge checks if two poins located on the edge. Edge is line between two points. If between two points
+///  located arcs or splines ignore this.
+/// @param p1 id first point.
+/// @param p2 id second point.
+/// @return true - on edge, false - no.
+//******************************************************************************
 bool VPiecePath::OnEdge(quint32 p1, quint32 p2) const
 {
     const QVector<VPieceNode> list = ListNodePoint();
@@ -606,14 +603,13 @@ bool VPiecePath::OnEdge(quint32 p1, quint32 p2) const
     }
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Edge return edge index in detail. Edge is line between two points. If between two points
- * located arcs or splines ignore this.
- * @param p1 id first point.
- * @param p2 id second point.
- * @return edge index or -1 if points are not located on edge
- */
+//******************************************************************************
+/// @brief Edge return edge index in detail. Edge is line between two points. If between two points
+///  located arcs or splines ignore this.
+/// @param p1 id first point.
+/// @param p2 id second point.
+/// @return edge index or -1 if points are not located on edge
+//******************************************************************************
 int VPiecePath::Edge(quint32 p1, quint32 p2) const
 {
     if (OnEdge(p1, p2) == false)
@@ -638,11 +634,10 @@ int VPiecePath::Edge(quint32 p1, quint32 p2) const
     }
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief listNodePoint return list nodes only with points.
- * @return list points node.
- */
+//******************************************************************************
+/// @brief listNodePoint return list nodes only with points.
+/// @return list points node.
+//******************************************************************************
 QVector<VPieceNode> VPiecePath::ListNodePoint() const
 {
     QVector<VPieceNode> list;
@@ -656,12 +651,11 @@ QVector<VPieceNode> VPiecePath::ListNodePoint() const
     return list;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief RemoveEdge return path without edge with index.
- * @param index idex of edge.
- * @return path without edge with index.
- */
+//******************************************************************************
+/// @brief RemoveEdge return path without edge with index.
+/// @param index idex of edge.
+/// @return path without edge with index.
+//******************************************************************************
 VPiecePath VPiecePath::RemoveEdge(quint32 index) const
 {
     VPiecePath path(*this);

--- a/src/libs/vpatterndb/vpiecepath.h
+++ b/src/libs/vpatterndb/vpiecepath.h
@@ -1,54 +1,54 @@
-/***************************************************************************
- **  @file   vpiecepath.h
- **  @author Douglas S Caskey
- **  @date   Dec 11, 2022
- **
- **  @copyright
- **  Copyright (C) 2017 - 2022 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//******************************************************************************
+//  @file   vpiecepath.h
+//  @author Douglas S Caskey
+//  @date   Dec 11, 2022
+//
+//  @copyright
+//  Copyright (C) 2017 - 2022 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//******************************************************************************
 
- /************************************************************************
- **
- **  @file
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   22 11, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//******************************************************************************
+//
+//  @file
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   22 11, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//
+//******************************************************************************
 
 #ifndef VPIECEPATH_H
 #define VPIECEPATH_H

--- a/src/libs/vpatterndb/vpiecepath.h
+++ b/src/libs/vpatterndb/vpiecepath.h
@@ -91,6 +91,7 @@ public:
 
     QVector<VPieceNode> GetNodes() const;
     void                SetNodes(const QVector<VPieceNode> &nodes);
+    QVector<VPieceNode> removeNode(const quint32 &id);
 
     PiecePathType       GetType() const;
     void                SetType(PiecePathType type);

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -147,7 +147,7 @@ PatternPieceDialog::PatternPieceDialog(const VContainer *data, const quint32 &to
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     setWindowIcon(QIcon(":/toolicon/32x32/new_piece.png"));
 
-    // Set the position that the dialog opens based on user preference. 
+    // Set the position that the dialog opens based on user preference.
     setDialogPosition();
 
     //Limit dialog height to 80% of screen size
@@ -636,61 +636,63 @@ bool PatternPieceDialog::eventFilter(QObject *object, QEvent *event)
                 VPieceNode rowNode = qvariant_cast<VPieceNode>(rowItem->data(Qt::UserRole));
                 NotchType notchType = rowNode.getNotchType();
                 NotchSubType notchSubType = rowNode.getNotchSubType();
+                int notchCount = rowNode.getNotchCount();
+
                 switch (keyEvent->key())
                 {
                     case Qt::Key_N:
                     {
-                        setNotch(rowItem, false, NotchType::Slit, notchSubType);
+                        setNotch(rowItem, false, NotchType::Slit, notchSubType, notchCount);
                         return true;
                     }
                     case Qt::Key_S:
                     {
-                        setNotch(rowItem, true, NotchType::Slit, notchSubType);
+                        setNotch(rowItem, true, NotchType::Slit, notchSubType, notchCount);
                         return true;
                     }
                     case Qt::Key_T:
                     {
-                        setNotch(rowItem, true, NotchType::TNotch, notchSubType);
+                        setNotch(rowItem, true, NotchType::TNotch, notchSubType, notchCount);
                         return true;
                     }
                     case Qt::Key_U:
                     {
-                        setNotch(rowItem, true, NotchType::UNotch, notchSubType);
+                        setNotch(rowItem, true, NotchType::UNotch, notchSubType, notchCount);
                         return true;
                     }
                     case Qt::Key_I:
                     {
-                        setNotch(rowItem, true, NotchType::VInternal, notchSubType);
+                        setNotch(rowItem, true, NotchType::VInternal, notchSubType, notchCount);
                         return true;
                     }
                     case Qt::Key_E:
                     {
-                        setNotch(rowItem, true, NotchType::VExternal, notchSubType);
+                        setNotch(rowItem, true, NotchType::VExternal, notchSubType, notchCount);
                         return true;
                     }
                     case Qt::Key_C:
                     {
-                        setNotch(rowItem, true, NotchType::Castle, notchSubType);
+                        setNotch(rowItem, true, NotchType::Castle, notchSubType, notchCount);
                         return true;
                     }
                     case Qt::Key_D:
                     {
-                        setNotch(rowItem, true, NotchType::Diamond, notchSubType);
+                        setNotch(rowItem, true, NotchType::Diamond, notchSubType, notchCount);
                         return true;
                     }
                     case Qt::Key_F:
                     {
-                        setNotch(rowItem, true, notchType, NotchSubType::Straightforward);
+                        setNotch(rowItem, true, notchType, NotchSubType::Straightforward, notchCount);
                         return true;
                     }
                     case Qt::Key_B:
                     {
-                        setNotch(rowItem, true, notchType, NotchSubType::Bisector);
+                        setNotch(rowItem, true, notchType, NotchSubType::Bisector, notchCount);
                         return true;
                     }
                     case Qt::Key_X:
                     {
-                        setNotch(rowItem, true, notchType, NotchSubType::Intersection);
+                        setNotch(rowItem, true, notchType, NotchSubType::Intersection, notchCount);
                         return true;
                     }
                 }
@@ -789,15 +791,17 @@ void PatternPieceDialog::showMainPathContextMenu(const QPoint &pos)
         return;
     }
 
-    // workaround for https://bugreports.qt.io/browse/QTBUG-97559: assign parent to QMenu
-    QScopedPointer<QMenu> menu(new QMenu(ui->mainPath_ListWidget));
-    NodeInfo info;
-    NotchType notchType = NotchType::Slit;
-    NotchSubType notchSubType = NotchSubType::Straightforward;
-    bool isNotch = false;
     QListWidgetItem *rowItem = ui->mainPath_ListWidget->item(row);
     SCASSERT(rowItem != nullptr);
     VPieceNode rowNode = qvariant_cast<VPieceNode>(rowItem->data(Qt::UserRole));
+
+    // workaround for https://bugreports.qt.io/browse/QTBUG-97559: assign parent to QMenu
+    QScopedPointer<QMenu> menu(new QMenu(ui->mainPath_ListWidget));
+    NodeInfo info;
+    NotchType notchType = rowNode.getNotchType();
+    NotchSubType notchSubType = rowNode.getNotchSubType();
+    int notchCount = rowNode.getNotchCount();
+    bool isNotch = false;
 
     QAction *actionNotch     = nullptr;
     QAction *actionNone      = nullptr;
@@ -812,6 +816,10 @@ void PatternPieceDialog::showMainPathContextMenu(const QPoint &pos)
     QAction *actionStraightforward = nullptr;
     QAction *actionBisector        = nullptr;
     QAction *actionIntersection    = nullptr;
+
+    QAction *action1Notch = nullptr;
+    QAction *action2Notch = nullptr;
+    QAction *action3Notch = nullptr;
 
     QAction *actionReverse   = nullptr;
     QAction *actionDuplicate = nullptr;
@@ -845,7 +853,12 @@ void PatternPieceDialog::showMainPathContextMenu(const QPoint &pos)
         actionStraightforward = notchSubtypeMenu->addAction(QIcon(), tr("Straightforward") + QStringLiteral("\tShift + F"));
         actionBisector        = notchSubtypeMenu->addAction(QIcon(), tr("Bisector") + QStringLiteral("\tShift + B"));
         actionIntersection    = notchSubtypeMenu->addAction(QIcon(), tr("Intersection") + QStringLiteral("\tShift + X"));
-    }
+
+        QMenu *notchCountMenu = notchMenu->addMenu(tr("Count"));
+        action1Notch = notchCountMenu->addAction(QIcon(), QStringLiteral("1"));
+        action2Notch = notchCountMenu->addAction(QIcon(), QStringLiteral("2"));
+        action3Notch = notchCountMenu->addAction(QIcon(), QStringLiteral("3"));
+}
 
     QAction *actionExcluded = menu->addAction(tr("Excluded") + QStringLiteral("\tCtrl + E"));
     actionExcluded->setCheckable(true);
@@ -927,8 +940,23 @@ void PatternPieceDialog::showMainPathContextMenu(const QPoint &pos)
             isNotch = true;
             notchSubType = NotchSubType::Intersection;
         }
+        else if (selectedAction == action1Notch)
+        {
+            isNotch = true;
+            notchCount = 1;
+        }
+        else if (selectedAction == action2Notch)
+        {
+            isNotch = true;
+            notchCount = 2;
+        }
+        else if (selectedAction == action3Notch)
+        {
+            isNotch = true;
+            notchCount = 3;
+        }
 
-        setNotch(rowItem, isNotch, notchType, notchSubType);
+        setNotch(rowItem, isNotch, notchType, notchSubType, notchCount);
     }
 
     validateObjects(isMainPathValid());
@@ -3563,7 +3591,7 @@ QString PatternPieceDialog::createPieceName() const
  * @param notchType of the selected submenu item.
  */
 void PatternPieceDialog::setNotch(QListWidgetItem *rowItem, bool isNotch, NotchType notchType,
-                                  NotchSubType notchSubType)
+                                  NotchSubType notchSubType, int count)
 {
     VPieceNode rowNode = qvariant_cast<VPieceNode>(rowItem->data(Qt::UserRole));
     if (rowNode.GetTypeTool() == Tool::NodePoint)
@@ -3571,6 +3599,7 @@ void PatternPieceDialog::setNotch(QListWidgetItem *rowItem, bool isNotch, NotchT
         rowNode.setNotch(isNotch);
         rowNode.setNotchType(notchType);
         rowNode.setNotchSubType(notchSubType);
+        rowNode.setNotchCount(count);
         NodeInfo info;
         info = getNodeInfo(rowNode, true);
         rowItem->setData(Qt::UserRole, QVariant::fromValue(rowNode));

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.h
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.h
@@ -287,7 +287,7 @@ private:
     void                        duplicateNode(QListWidgetItem *rowItem);
     void                        excludeNode(QListWidgetItem *rowItem);
     void                        setNotch(QListWidgetItem *rowItem, bool isNotch, NotchType notchType,
-                                         NotchSubType notchSubType);
+                                         NotchSubType notchSubType, int notchCount);
     void                        setCurrentText(QComboBox *box, const QString &text) const;
     qreal                       getFormulaValue(QPlainTextEdit *text) const;
 };

--- a/src/libs/vtools/tools/nodeDetails/vnodepoint.cpp
+++ b/src/libs/vtools/tools/nodeDetails/vnodepoint.cpp
@@ -73,13 +73,16 @@
 
 #include "../../../vgeometry/vpointf.h"
 #include "../../../vwidgets/vgraphicssimpletextitem.h"
+#include "../../undocommands/savepieceoptions.h"
 #include "../../undocommands/label/showpointname.h"
 #include "../../undocommands/label/movelabel.h"
 #include "../ifc/xml/vdomdocument.h"
 #include "../ifc/ifcdef.h"
 #include "../vmisc/vabstractapplication.h"
 #include "../vpatterndb/vcontainer.h"
+#include "../vpatterndb/vpiece.h"
 #include "../vpatterndb/vpiecenode.h"
+#include "../vpatterndb/vpiecepath.h"
 #include "../vwidgets/vmaingraphicsscene.h"
 #include "../vwidgets/vmaingraphicsview.h"
 #include "../vabstracttool.h"
@@ -326,21 +329,253 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
     {
         return;
     }
-    if (qgraphicsitem_cast<PatternPieceTool *>(parentItem()))
+
+    PatternPieceTool *tool = qgraphicsitem_cast<PatternPieceTool *>(parentItem());
+    if (tool)
     {
         QMenu menu;
+
+        const VPiece piece = VAbstractTool::data.GetPiece(tool->getId());
+        const int index = piece.GetPath().indexOfNode(m_id);
+        VPieceNode node = piece.GetPath().at(index);
 
         QAction *actionShowPointName = menu.addAction(QIcon("://icon/16x16/open_eye.png"), tr("Show Point Name"));
         actionShowPointName->setCheckable(true);
         actionShowPointName->setChecked(VAbstractTool::data.GeometricObject<VPointF>(m_id)->isShowPointName());
+
+        QAction *actionByLength        = nullptr;
+        QAction *actionByIntersection  = nullptr;
+        QAction *actionFirstEdgeSym    = nullptr;
+        QAction *actionSecondEdgeSym   = nullptr;
+        QAction *actionFirstEdgeRight  = nullptr;
+        QAction *actionSecondEdgeRight = nullptr;
+        QMenu *angleTypeMenu  = menu.addMenu(tr("Seam Allowance Angle"));
+        actionByLength        = angleTypeMenu->addAction(QIcon(), tr("By length"));
+        actionByIntersection  = angleTypeMenu->addAction(QIcon(), tr("Intersection"));
+        actionFirstEdgeSym    = angleTypeMenu->addAction(QIcon(), tr("First edge symmetry"));
+        actionSecondEdgeSym   = angleTypeMenu->addAction(QIcon(), tr("Second edge symmetry"));
+        actionFirstEdgeRight  = angleTypeMenu->addAction(QIcon(), tr("First edge right angle"));
+        actionSecondEdgeRight = angleTypeMenu->addAction(QIcon(), tr("Second edge right angle"));
+
+        switch (static_cast<int>(node.GetAngleType()))
+        {
+            case (PieceNodeAngle::ByLength):
+            {
+                actionByLength->setCheckable(true);
+                actionByLength->setChecked(true);
+                break;
+            }
+            case (PieceNodeAngle::ByPointsIntersection):
+            {
+                actionByIntersection->setCheckable(true);
+                actionByIntersection->setChecked(true);
+                break;
+            }
+            case (PieceNodeAngle::ByFirstEdgeSymmetry):
+            {
+                actionFirstEdgeSym->setCheckable(true);
+                actionFirstEdgeSym->setChecked(true);
+                break;
+            }
+            case (PieceNodeAngle::BySecondEdgeSymmetry):
+            {
+                actionSecondEdgeSym->setCheckable(true);
+                actionSecondEdgeSym->setChecked(true);
+                break;
+            }
+            case (PieceNodeAngle::ByFirstEdgeRightAngle):
+            {
+                actionFirstEdgeRight->setCheckable(true);
+                actionFirstEdgeRight->setChecked(true);
+                break;
+            }
+            case (PieceNodeAngle::BySecondEdgeRightAngle):
+            {
+                actionSecondEdgeRight->setCheckable(true);
+                actionSecondEdgeRight->setChecked(true);
+                break;
+            }
+            default:
+                break;
+        }
+
+
+        NotchType notchType = node.getNotchType();
+        NotchSubType notchSubType = node.getNotchSubType();
+        int notchCount = node.getNotchCount();
+        bool isNotch = false;
+
+        QAction *actionNotch     = nullptr;
+        QMenu *notchMenu = menu.addMenu(tr("Notch"));
+        actionNotch = notchMenu->menuAction();
+        actionNotch->setCheckable(true);
+        actionNotch->setChecked(node.isNotch());
+
+        QAction *actionNone      = nullptr;
+        QAction *actionSlit      = nullptr;
+        QAction *actionTNotch    = nullptr;
+        QAction *actionUNotch    = nullptr;
+        QAction *actionVInternal = nullptr;
+        QAction *actionVExternal = nullptr;
+        QAction *actionCastle    = nullptr;
+        QAction *actionDiamond   = nullptr;
+        QMenu *notchTypeMenu = notchMenu->addMenu(tr("Type"));
+        actionNone      = notchTypeMenu->addAction( tr("None") + QStringLiteral("\tShift + N"));
+        actionSlit      = notchTypeMenu->addAction(QIcon("://icon/24x24/slit_notch.png"),       tr("Slit") + QStringLiteral("\tShift + S"));
+        actionTNotch    = notchTypeMenu->addAction(QIcon("://icon/24x24/t_notch.png"),          tr("TNotch") + QStringLiteral("\tShift + T"));
+        actionUNotch    = notchTypeMenu->addAction(QIcon("://icon/24x24/u_notch.png"),          tr("UNotch") + QStringLiteral("\tShift + U"));
+        actionVInternal = notchTypeMenu->addAction(QIcon("://icon/24x24/internal_v_notch.png"), tr("VInternal") + QStringLiteral("\tShift + I"));
+        actionVExternal = notchTypeMenu->addAction(QIcon("://icon/24x24/external_v_notch.png"), tr("VExternal") + QStringLiteral("\tShift + E"));
+        actionCastle    = notchTypeMenu->addAction(QIcon("://icon/24x24/castle_notch.png"),     tr("Castle") + QStringLiteral("\tShift + C"));
+        actionDiamond   = notchTypeMenu->addAction(QIcon("://icon/24x24/diamond_notch.png"),    tr("Diamond") + QStringLiteral("\tShift + D"));
+
+        QAction *actionStraightforward = nullptr;
+        QAction *actionBisector        = nullptr;
+        QAction *actionIntersection    = nullptr;
+        QMenu *notchSubtypeMenu = notchMenu->addMenu(tr("Subtype"));
+        actionStraightforward = notchSubtypeMenu->addAction(QIcon(), tr("Straightforward") + QStringLiteral("\tShift + F"));
+        actionBisector        = notchSubtypeMenu->addAction(QIcon(), tr("Bisector") + QStringLiteral("\tShift + B"));
+        actionIntersection    = notchSubtypeMenu->addAction(QIcon(), tr("Intersection") + QStringLiteral("\tShift + X"));
+
+        QAction *action1Notch = nullptr;
+        QAction *action2Notch = nullptr;
+        QAction *action3Notch = nullptr;
+        QMenu *notchCountMenu = notchMenu->addMenu(tr("Count"));
+        action1Notch = notchCountMenu->addAction(QIcon(), QStringLiteral("1"));
+        action2Notch = notchCountMenu->addAction(QIcon(), QStringLiteral("2"));
+        action3Notch = notchCountMenu->addAction(QIcon(), QStringLiteral("3"));
+
+        QAction *actionExcludeNode = menu.addAction(QIcon(), tr("Excluded"));
+
+        QAction *actionDeleteNode = menu.addAction(QIcon(QIcon::fromTheme("edit-delete")), tr("Delete"));
 
         QAction *selectedAction = menu.exec(event->screenPos());
         if (selectedAction == actionShowPointName)
         {
             qApp->getUndoStack()->push(new ShowPointName(doc, m_id, selectedAction->isChecked()));
         }
+        else if (selectedAction == actionExcludeNode)
+        {
+            emit nodeExcluded(m_id);
+        }
+        else if (selectedAction == actionDeleteNode)
+        {
+            emit nodeDeleted(m_id);
+        }
+        else if (selectedAction == actionByLength)
+        {
+            emit nodeAngleChanged(m_id, PieceNodeAngle::ByLength);
+        }
+        else if (selectedAction == actionByIntersection)
+        {
+            emit nodeAngleChanged(m_id, PieceNodeAngle::ByPointsIntersection);
+        }
+        else if (selectedAction == actionFirstEdgeSym)
+        {
+            emit nodeAngleChanged(m_id, PieceNodeAngle::ByFirstEdgeSymmetry);
+        }
+        else if (selectedAction == actionSecondEdgeSym)
+        {
+            emit nodeAngleChanged(m_id, PieceNodeAngle::BySecondEdgeSymmetry);
+        }
+        else if (selectedAction == actionFirstEdgeRight)
+        {
+            emit nodeAngleChanged(m_id, PieceNodeAngle::ByFirstEdgeRightAngle);
+        }
+        else if (selectedAction == actionSecondEdgeRight)
+        {
+            emit nodeAngleChanged(m_id, PieceNodeAngle::BySecondEdgeRightAngle);
+        }
+        else
+        {
+            if (selectedAction == actionNone)
+            {
+                isNotch = false;
+                notchType = NotchType::Slit;
+            }
+            else if (selectedAction == actionSlit)
+            {
+                isNotch = true;
+                notchType = NotchType::Slit;
+            }
+            else if (selectedAction == actionTNotch)
+            {
+                isNotch = true;
+                notchType = NotchType::TNotch;
+            }
+            else if (selectedAction == actionUNotch)
+            {
+                isNotch = true;
+                notchType = NotchType::UNotch;
+            }
+            else if (selectedAction == actionVInternal)
+            {
+                isNotch = true;
+                notchType = NotchType::VInternal;
+            }
+            else if (selectedAction == actionVExternal)
+            {
+                isNotch = true;
+                notchType = NotchType::VExternal;
+            }
+            else if (selectedAction == actionCastle)
+            {
+                isNotch = true;
+                notchType = NotchType::Castle;
+            }
+            else if (selectedAction == actionDiamond)
+            {
+                isNotch = true;
+                notchType = NotchType::Diamond;
+            }
+            else if (selectedAction == actionStraightforward)
+            {
+                isNotch = true;
+                notchSubType = NotchSubType::Straightforward;
+            }
+            else if (selectedAction == actionBisector)
+            {
+                isNotch = true;
+                notchSubType = NotchSubType::Bisector;
+            }
+            else if (selectedAction == actionIntersection)
+            {
+                isNotch = true;
+                notchSubType = NotchSubType::Intersection;
+            }
+            else if (selectedAction == action1Notch)
+            {
+                isNotch = true;
+                notchCount = 1;
+            }
+            else if (selectedAction == action2Notch)
+            {
+                isNotch = true;
+                notchCount = 2;
+            }
+            else if (selectedAction == action3Notch)
+            {
+                isNotch = true;
+                notchCount = 3;
+            }
+
+            if (node.GetId() == m_id && node.GetTypeTool() == Tool::NodePoint)
+            {
+                NotchData notchData;
+                notchData.isNotch = isNotch;
+                notchData.type    = notchType;
+                notchData.subType = notchSubType;
+                notchData.length  = ToPixel(node.getNotchLength(), *VDataTool::data.GetPatternUnit());
+                notchData.width   = ToPixel(node.getNotchWidth(),  *VDataTool::data.GetPatternUnit());
+                notchData.angle   = node.getNotchAngle();
+                notchData.count   = notchCount;
+
+                emit notchChanged(m_id, notchData);
+            }
+        }
     }
 }
+
 
 //---------------------------------------------------------------------------------------------------------------------
 void VNodePoint::EnableToolMove(bool move)

--- a/src/libs/vtools/tools/nodeDetails/vnodepoint.cpp
+++ b/src/libs/vtools/tools/nodeDetails/vnodepoint.cpp
@@ -454,7 +454,14 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
         //Setup Delete Node menu
         QAction *actionDeleteNode = menu.addAction(QIcon(QIcon::fromTheme("edit-delete")), tr("Delete"));
 
-        //Execute menu at current mouse position and handle selected item. 
+        if (piece.isLocked())
+        {
+            actionNotch->setEnabled(false);
+            angleTypeMenu->setEnabled(false);
+            actionExcludeNode->setEnabled(false);
+            actionDeleteNode->setEnabled(false);
+        }
+        //Execute menu at current mouse position and handle selected item.
         QAction *selectedAction = menu.exec(event->screenPos());
         if (selectedAction == actionShowPointName)
         {

--- a/src/libs/vtools/tools/nodeDetails/vnodepoint.cpp
+++ b/src/libs/vtools/tools/nodeDetails/vnodepoint.cpp
@@ -1,53 +1,54 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//******************************************************************************
+//  @file   vnodepoint.cpp
+//  @author Douglas S Caskey
+//  @date  1 Mar, 2025
+//
+//  @copyright
+//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
+//******************************************************************************
 
- ************************************************************************
- **
- **  @file   vnodepoint.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   November 15, 2013
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//******************************************************************************
+//
+//   @file   vnodepoint.cpp
+//   @author Roman Telezhynskyi <dismine(at)gmail.com>
+//   @date   November 15, 2013
+//
+//   @brief
+//   @copyright
+//   This source code is part of the Valentine project, a pattern making
+//   program, whose allow create and modeling patterns of clothing.
+//   Copyright (C) 2013-2015 Seamly2D project
+//   <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//   Seamly2D is free software: you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation, either version 3 of the License, or
+//   (at your option) any later version.
+//
+//   Seamly2D is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   GNU General Public License for more details.
+//
+//   You should have received a copy of the GNU General Public License
+//   along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//
+//******************************************************************************
 
 #include "vnodepoint.h"
 
@@ -92,18 +93,17 @@
 
 const QString VNodePoint::ToolType = QStringLiteral("modeling");
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VNodePoint constructor.
- * @param doc dom document container.
- * @param data container with variables.
- * @param id object id in container.
- * @param idPoint object id in containerPoint.
- * @param typeCreation way we create this tool.
- * @param idTool tool id.
- * @param qoParent QObject parent
- * @param parent parent object.
- */
+//******************************************************************************
+/// @brief VNodePoint constructor.
+/// @param doc dom document container.
+/// @param data container with variables.
+/// @param id object id in container.
+/// @param idPoint object id in containerPoint.
+/// @param typeCreation way we create this tool.
+/// @param idTool tool id.
+/// @param qoParent QObject parent
+/// @param parent parent object.
+//******************************************************************************
 VNodePoint::VNodePoint(VAbstractPattern *doc, VContainer *data, quint32 id, quint32 idPoint, const Source &typeCreation,
                        const QString &blockName, const quint32 &idTool, QObject *qoParent, QGraphicsItem *parent)
     : VAbstractNode(doc, data, id, idPoint, blockName, idTool, qoParent)
@@ -123,17 +123,16 @@ VNodePoint::VNodePoint(VAbstractPattern *doc, VContainer *data, quint32 id, quin
     setCursor(Qt::ArrowCursor);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Create help create tool.
- * @param doc dom document container.
- * @param data container with variables.
- * @param id object id in container.
- * @param idPoint object id in containerPoint.
- * @param parse parser file mode.
- * @param typeCreation way we create this tool.
- * @param idTool tool id.
- */
+//******************************************************************************
+/// @brief Create help create tool.
+/// @param doc dom document container.
+/// @param data container with variables.
+/// @param id object id in container.
+/// @param idPoint object id in containerPoint.
+/// @param parse parser file mode.
+/// @param typeCreation way we create this tool.
+/// @param idTool tool id.
+//******************************************************************************
 void VNodePoint::Create(VAbstractPattern *doc, VContainer *data, VMainGraphicsScene *scene,
                         quint32 id, quint32 idPoint, const Document &parse,
                         const Source &typeCreation, const QString &blockName, const quint32 &idTool)
@@ -184,10 +183,9 @@ void VNodePoint::pointChosen()
     emit chosenTool(m_id, SceneObject::Point);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief FullUpdateFromFile update tool data form file.
- */
+//******************************************************************************
+/// @brief FullUpdateFromFile update tool data form file.
+//******************************************************************************
 void VNodePoint::FullUpdateFromFile()
 {
     try
@@ -200,10 +198,9 @@ void VNodePoint::FullUpdateFromFile()
     }
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief AddToFile add tag with Information about tool into file.
- */
+//******************************************************************************
+/// @brief AddToFile add tag with Information about tool into file.
+//******************************************************************************
 void VNodePoint::AddToFile()
 {
     const QSharedPointer<VPointF> point = VAbstractTool::data.GeometricObject<VPointF>(m_id);
@@ -248,11 +245,10 @@ void VNodePoint::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
     VScenePoint::hoverEnterEvent(event);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief mouseReleaseEvent handle mouse release events.
- * @param event mouse release event.
- */
+//******************************************************************************
+/// @brief mouseReleaseEvent handle mouse release events.
+/// @param event mouse release event.
+//******************************************************************************
 void VNodePoint::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
 {
     if (event->button() == Qt::LeftButton)
@@ -262,11 +258,10 @@ void VNodePoint::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
     VScenePoint::mouseReleaseEvent(event);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief setPointNamePosition change name text position.
- * @param pos new position.
- */
+//******************************************************************************
+/// @brief setPointNamePosition change name text position.
+/// @param pos new position.
+//******************************************************************************
 void VNodePoint::setPointNamePosition(quint32 id, const QPointF &pos)
 {
     if (id == m_id)
@@ -297,11 +292,10 @@ void VNodePoint::setPointNameVisiblity(quint32 id, bool visible)
     }
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief nameChangedPosition point name change position.
- * @param pos new position.
- */
+//******************************************************************************
+/// @brief nameChangedPosition point name change position.
+/// @param pos new position.
+//******************************************************************************
 void VNodePoint::nameChangedPosition(const QPointF &pos)
 {
     qApp->getUndoStack()->push(new MoveLabel(doc, pos - this->pos(), m_id));
@@ -322,7 +316,10 @@ void VNodePoint::HideNode()
     hide();
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+//******************************************************************************
+/// @brief contextMenuEvent show context menu for point nodes.
+/// @param event  contextmenu event.
+//******************************************************************************
 void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
 {
     if (m_suppressContextMenu)
@@ -343,6 +340,7 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
         actionShowPointName->setCheckable(true);
         actionShowPointName->setChecked(VAbstractTool::data.GeometricObject<VPointF>(m_id)->isShowPointName());
 
+        //Setup actions for Seam Allowance corner type sub menu
         QAction *actionByLength        = nullptr;
         QAction *actionByIntersection  = nullptr;
         QAction *actionFirstEdgeSym    = nullptr;
@@ -357,6 +355,7 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
         actionFirstEdgeRight  = angleTypeMenu->addAction(QIcon(), tr("First edge right angle"));
         actionSecondEdgeRight = angleTypeMenu->addAction(QIcon(), tr("Second edge right angle"));
 
+        // Set checkmark for current Seam Allowance corner type
         switch (static_cast<int>(node.GetAngleType()))
         {
             case (PieceNodeAngle::ByLength):
@@ -399,18 +398,20 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
                 break;
         }
 
-
+        // Set default Notch values
         NotchType notchType = node.getNotchType();
         NotchSubType notchSubType = node.getNotchSubType();
         int notchCount = node.getNotchCount();
         bool isNotch = false;
 
+        //Setup Notch menu
         QAction *actionNotch     = nullptr;
         QMenu *notchMenu = menu.addMenu(tr("Notch"));
         actionNotch = notchMenu->menuAction();
         actionNotch->setCheckable(true);
         actionNotch->setChecked(node.isNotch());
 
+        //Setup Notch type submenu
         QAction *actionNone      = nullptr;
         QAction *actionSlit      = nullptr;
         QAction *actionTNotch    = nullptr;
@@ -429,6 +430,7 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
         actionCastle    = notchTypeMenu->addAction(QIcon("://icon/24x24/castle_notch.png"),     tr("Castle") + QStringLiteral("\tShift + C"));
         actionDiamond   = notchTypeMenu->addAction(QIcon("://icon/24x24/diamond_notch.png"),    tr("Diamond") + QStringLiteral("\tShift + D"));
 
+        //Setup Notch subtype submenu
         QAction *actionStraightforward = nullptr;
         QAction *actionBisector        = nullptr;
         QAction *actionIntersection    = nullptr;
@@ -437,6 +439,7 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
         actionBisector        = notchSubtypeMenu->addAction(QIcon(), tr("Bisector") + QStringLiteral("\tShift + B"));
         actionIntersection    = notchSubtypeMenu->addAction(QIcon(), tr("Intersection") + QStringLiteral("\tShift + X"));
 
+        //setup Notch count submenu
         QAction *action1Notch = nullptr;
         QAction *action2Notch = nullptr;
         QAction *action3Notch = nullptr;
@@ -445,10 +448,13 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
         action2Notch = notchCountMenu->addAction(QIcon(), QStringLiteral("2"));
         action3Notch = notchCountMenu->addAction(QIcon(), QStringLiteral("3"));
 
+        //Setup Exclude node menu
         QAction *actionExcludeNode = menu.addAction(QIcon(), tr("Excluded"));
 
+        //Setup Delete Node menu
         QAction *actionDeleteNode = menu.addAction(QIcon(QIcon::fromTheme("edit-delete")), tr("Delete"));
 
+        //Execute menu at current mouse position and handle selected item. 
         QAction *selectedAction = menu.exec(event->screenPos());
         if (selectedAction == actionShowPointName)
         {

--- a/src/libs/vtools/tools/nodeDetails/vnodepoint.cpp
+++ b/src/libs/vtools/tools/nodeDetails/vnodepoint.cpp
@@ -356,7 +356,7 @@ void VNodePoint::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
         actionSecondEdgeRight = angleTypeMenu->addAction(QIcon(), tr("Second edge right angle"));
 
         // Set checkmark for current Seam Allowance corner type
-        switch (static_cast<int>(node.GetAngleType()))
+        switch (static_cast<PieceNodeAngle>(node.GetAngleType()))
         {
             case (PieceNodeAngle::ByLength):
             {

--- a/src/libs/vtools/tools/nodeDetails/vnodepoint.h
+++ b/src/libs/vtools/tools/nodeDetails/vnodepoint.h
@@ -62,6 +62,7 @@
 #include <QtGlobal>
 
 #include "../ifc/xml/vabstractpattern.h"
+#include "../vpatterndb/vpiece.h"
 #include "../vmisc/def.h"
 #include "vabstractnode.h"
 #include "../vwidgets/vscenepoint.h"
@@ -86,13 +87,10 @@ public:
     virtual void    setPointNameVisiblity(quint32 id, bool visible) Q_DECL_OVERRIDE;
 
 signals:
-    /**
-     * @brief showContextMenu emit when need show tool context menu.
-     * @param event context menu event.
-     */
-     //void ShowOptions();
-     //void ToggleInLayout(bool checked);
-     //void Delete();
+    void            nodeAngleChanged(quint32 id, PieceNodeAngle type);
+    void            notchChanged(quint32 id, NotchData notchData);
+    void            nodeExcluded(quint32 id);
+    void            nodeDeleted(quint32 id);
 
 public slots:
     virtual void    FullUpdateFromFile() Q_DECL_OVERRIDE;

--- a/src/libs/vtools/tools/nodeDetails/vnodepoint.h
+++ b/src/libs/vtools/tools/nodeDetails/vnodepoint.h
@@ -1,53 +1,52 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//******************************************************************************
+//  @file   vnodepoint.h
+//  @author Douglas S Caskey
+//  @date  1 Mar, 2025
+//
+//  @copyright
+//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
+//******************************************************************************
 
- ************************************************************************
- **
- **  @file   vnodepoint.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   November 15, 2013
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//******************************************************************************
+//  @file   vnodepoint.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   November 15, 2013
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentine project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2015 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//******************************************************************************
 
 #ifndef VNODEPOINT_H
 #define VNODEPOINT_H
@@ -67,9 +66,9 @@
 #include "vabstractnode.h"
 #include "../vwidgets/vscenepoint.h"
 
-/**
- * @brief The VNodePoint class point detail node.
- */
+//******************************************************************************
+//  @brief The VNodePoint class point detail node.
+//******************************************************************************
 class VNodePoint: public VAbstractNode, public VScenePoint
 {
     Q_OBJECT

--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -1,54 +1,54 @@
-/***************************************************************************
- **  @file   pattern_piece_tool.cpp
- **  @author Douglas S Caskey
- **  @date   17 Sep, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2022 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//******************************************************************************
+//  @file   pattern_piece_tool.cpp
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @copyright
+//  Copyright (C) 2017 - 2022 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//******************************************************************************
 
-/************************************************************************
- **
- **  @file   PatternPieceTool.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   6 11, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//******************************************************************************
+//
+//  @file   PatternPieceTool.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   6 11, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//
+//******************************************************************************
 
 #include "pattern_piece_tool.h"
 
@@ -623,10 +623,9 @@ void PatternPieceTool::updatePieceDetails()
     UpdatePatternLabel();
     UpdateGrainline();
 }
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief UpdateLabel updates the text label, making it just big enough for the text to fit it
- */
+//******************************************************************************
+/// @brief UpdateLabel updates the text label, making it just big enough for the text to fit it
+//******************************************************************************
 void PatternPieceTool::UpdatePieceLabel()
 {
 
@@ -651,10 +650,9 @@ void PatternPieceTool::UpdatePieceLabel()
     }
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief UpdatePatternLabel updates the pattern info label
- */
+//******************************************************************************
+/// @brief UpdatePatternLabel updates the pattern info label
+//******************************************************************************
 void PatternPieceTool::UpdatePatternLabel()
 {
     const VPiece piece = VAbstractTool::data.GetPiece(m_id);
@@ -678,10 +676,9 @@ void PatternPieceTool::UpdatePatternLabel()
     }
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VToolDetail::UpdateGrainline updates the grain line item
- */
+//******************************************************************************
+/// @brief VToolDetail::UpdateGrainline updates the grain line item
+//******************************************************************************
 void PatternPieceTool::UpdateGrainline()
 {
     const VPiece piece = VAbstractTool::data.GetPiece(m_id);
@@ -713,10 +710,9 @@ void PatternPieceTool::UpdateGrainline()
     }
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief saveMovePiece saves the move piece operation to the undo stack
- */
+//******************************************************************************
+/// @brief saveMovePiece saves the move piece operation to the undo stack
+//******************************************************************************
 void PatternPieceTool::saveMovePiece(const QPointF &ptPos)
 {
     VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -729,10 +725,9 @@ void PatternPieceTool::saveMovePiece(const QPointF &ptPos)
     qApp->getUndoStack()->push(moveCommand);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief saveResizePiece saves the resize piece label operation to the undo stack
- */
+//******************************************************************************
+/// @brief saveResizePiece saves the resize piece label operation to the undo stack
+//******************************************************************************
 void PatternPieceTool::saveResizePiece(qreal dLabelW, int iFontSize)
 {
     VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -750,10 +745,9 @@ void PatternPieceTool::saveResizePiece(qreal dLabelW, int iFontSize)
     qApp->getUndoStack()->push(resizeCommand);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief savePieceRotation saves the rotation piece label operation to the undo stack
- */
+//******************************************************************************
+/// @brief savePieceRotation saves the rotation piece label operation to the undo stack
+//******************************************************************************
 void PatternPieceTool::savePieceRotation(qreal dRot)
 {
     VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -773,10 +767,9 @@ void PatternPieceTool::savePieceRotation(qreal dRot)
 }
 
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief SaveMovePattern saves the pattern label position
- */
+//******************************************************************************
+/// @brief SaveMovePattern saves the pattern label position
+//******************************************************************************
 void PatternPieceTool::SaveMovePattern(const QPointF &ptPos)
 {
     VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -789,10 +782,9 @@ void PatternPieceTool::SaveMovePattern(const QPointF &ptPos)
     qApp->getUndoStack()->push(moveCommand);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief: SaveResizePattern saves the pattern label width and font size
- */
+//******************************************************************************
+/// @brief: SaveResizePattern saves the pattern label width and font size
+//******************************************************************************
 void PatternPieceTool::SaveResizePattern(qreal dLabelW, int iFontSize)
 {
     VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -874,10 +866,9 @@ void PatternPieceTool::SaveRotateGrainline(qreal dRot, const QPointF &ptPos)
     qApp->getUndoStack()->push(rotateCommand);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief VToolDetail::paint draws a bounding box around piece, if one of its text or grainline items is not idle.
- */
+//******************************************************************************
+/// @brief VToolDetail::paint draws a bounding box around piece, if one of its text or grainline items is not idle.
+//******************************************************************************
 void PatternPieceTool::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
 {
     QColor  color;
@@ -1573,6 +1564,19 @@ void PatternPieceTool::SaveDialogChange()
     UpdatePieceLabel();
 }
 
+//******************************************************************************
+/// @brief nodeAngleChanged handle seam allowance corner type changes.
+///
+/// This method handles the signal sent that the Seam Allowance corner type has changed.
+///
+/// @param id  node id.
+/// @param type  Type of Seam Allowance corner type.
+///
+/// @details
+/// -Method loops through the piece nodes looking for the chosen nodem and when found
+///  sets the corner type in a new copy of the piece. Calls the SavePieceOptions undo
+///  command.
+//******************************************************************************
 void PatternPieceTool::nodeAngleChanged(quint32 id, PieceNodeAngle type)
 {
     const VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -1595,6 +1599,19 @@ void PatternPieceTool::nodeAngleChanged(quint32 id, PieceNodeAngle type)
     }
 }
 
+//******************************************************************************
+/// @brief notchChanged handle notch changes.
+///
+/// This method handles the signal sent that the Notch properties have changed.
+///
+/// @param id  node id.
+/// @param notchData  struct of the notch data.
+///
+/// @details
+/// -Method loops through the piece nodes looking for the chosen nodem and when found
+///  sets the change of the notch properties  in a new copy of the piece. Calls the
+///  SavePieceOptions undo command.
+//******************************************************************************
 void PatternPieceTool::notchChanged(quint32 id, NotchData notchData)
 {
     const VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -1620,6 +1637,18 @@ void PatternPieceTool::notchChanged(quint32 id, NotchData notchData)
     }
 }
 
+//******************************************************************************
+/// @brief nodeExcluded handle excluding node.
+///
+/// This method handles the signal sent that the node should be exculded.
+///
+/// @param id  node id.
+///
+/// @details
+/// -Method loops through the piece nodes looking for the chosen nodem and when found
+///  sets the node to be excluded from the main path in a new copy of the piece. Calls the
+///  SavePieceOptions undo command.
+//******************************************************************************
 void PatternPieceTool::nodeExcluded(quint32 id)
 {
     const VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -1642,6 +1671,16 @@ void PatternPieceTool::nodeExcluded(quint32 id)
     }
 }
 
+//******************************************************************************
+/// @brief nodeDeleted handle delete node.
+///
+/// This method handles the signal sent that the node should be deleted.
+///
+/// @param id  node id.
+///
+/// @details
+/// -Method removes node form the main path of the piece.
+//******************************************************************************
 void PatternPieceTool::nodeDeleted(quint32 id)
 {
     const VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -2072,9 +2111,9 @@ void PatternPieceTool::UpdateLabelItem(VTextGraphicsItem *labelItem, QPointF pos
     labelItem->getTextLines() > 0 ? labelItem->show() : labelItem->hide();
 }
 
-/**
- * @brief editPieceProperties - routine to edit pattern piece properties .
- */
+//******************************************************************************
+/// @brief editPieceProperties - routine to edit pattern piece properties .
+//******************************************************************************
 void PatternPieceTool::editPieceProperties()
 {
     QSharedPointer<PatternPieceDialog> dialog = QSharedPointer<PatternPieceDialog>(new PatternPieceDialog(getData(),
@@ -2088,10 +2127,10 @@ void PatternPieceTool::editPieceProperties()
     m_dialog->show();
 }
 
-/**
- * @brief toggleInLayout - routine to toggle if pattern piece is included and visible in layout.
- * @param checked - true if piece is included.
- */
+//******************************************************************************
+/// @brief toggleInLayout - routine to toggle if pattern piece is included and visible in layout.
+/// @param checked - true if piece is included.
+//******************************************************************************
 void PatternPieceTool::toggleInLayout(bool checked)
 {
     TogglePieceInLayout *cmd = new TogglePieceInLayout(m_id, checked, &(VAbstractTool::data), doc);
@@ -2099,10 +2138,10 @@ void PatternPieceTool::toggleInLayout(bool checked)
     qApp->getUndoStack()->push(cmd);
 }
 
-/**
- * @brief togglePieceLock - routine to toggle if pattern piece is locked and editiable.
- * @param checked - true if piece is locked.
- */
+//******************************************************************************
+/// @brief togglePieceLock - routine to toggle if pattern piece is locked and editiable.
+/// @param checked - true if piece is locked.
+//******************************************************************************
 void PatternPieceTool::togglePieceLock(bool checked)
 {
     TogglePieceLock *cmd = new TogglePieceLock(m_id, checked, &(VAbstractTool::data), doc);
@@ -2112,10 +2151,10 @@ void PatternPieceTool::togglePieceLock(bool checked)
     EnableToolMove(!checked);
 }
 
-/**
- * @brief toggleFlipping - routine to toggle forbidding flipping.
- * @param checked - true if flipping is forbidden.
- */
+//******************************************************************************
+/// @brief toggleFlipping - routine to toggle forbidding flipping.
+/// @param checked - true if flipping is forbidden.
+//******************************************************************************
 void PatternPieceTool::toggleFlipping(bool checked)
 {
     VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -2130,10 +2169,10 @@ void PatternPieceTool::toggleFlipping(bool checked)
     showStatus(tr("Forbid Flipping changed: ") + (checked ? tr("Enabled") : tr("Disabled")));
 }
 
-/**
- * @brief toggleSeamLine - routine to toggle the visibility of the seam line.
- * @param checked - true if seam line is visible.
- */
+//******************************************************************************
+/// @brief toggleSeamLine - routine to toggle the visibility of the seam line.
+/// @param checked - true if seam line is visible.
+//******************************************************************************
 void PatternPieceTool::toggleSeamLine(bool checked)
 {
     VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -2148,10 +2187,10 @@ void PatternPieceTool::toggleSeamLine(bool checked)
     showStatus(tr("Seam line visibility changed: ") + (checked ? tr("Hide") : tr("Show")));
 }
 
-/**
- * @brief toggleSeamAllowance - routine to toggle the visibility of the seam allowance.
- * @param checked - true if seam allowance is visible.
- */
+//******************************************************************************
+/// @brief toggleSeamAllowance - routine to toggle the visibility of the seam allowance.
+/// @param checked - true if seam allowance is visible.
+//******************************************************************************
 void PatternPieceTool::toggleSeamAllowance(bool checked)
 {
     VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -2166,10 +2205,10 @@ void PatternPieceTool::toggleSeamAllowance(bool checked)
     showStatus(tr("Seam allowance visibility changed: ") + (checked ? tr("Show") : tr("Hide")));
 }
 
-/**
- * @brief toggleGrainline - routine to toggle the visibility of the  piece grainline.
- * @param checked - true if grainline is visible.
- */
+//******************************************************************************
+/// @brief toggleGrainline - routine to toggle the visibility of the  piece grainline.
+/// @param checked - true if grainline is visible.
+//******************************************************************************
 void PatternPieceTool::toggleGrainline(bool checked)
 {
     VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -2184,10 +2223,10 @@ void PatternPieceTool::toggleGrainline(bool checked)
     showStatus(tr("Grainline visibility changed: ") + (checked ? tr("Show") : tr("Hide")));
 }
 
-/**
- * @brief togglePatternLabel - routine to toggle the visibility of the  pattern label.
- * @param checked - true if pattern label is visible.
- */
+//******************************************************************************
+/// @brief togglePatternLabel - routine to toggle the visibility of the  pattern label.
+/// @param checked - true if pattern label is visible.
+//******************************************************************************
 void PatternPieceTool::togglePatternLabel(bool checked)
 {
     VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -2202,10 +2241,10 @@ void PatternPieceTool::togglePatternLabel(bool checked)
     showStatus(tr("Pattern label visibility changed: ") + (checked ? tr("Show") : tr("Hide")));
 }
 
-/**
- * @brief togglePieceLabel - routine to toggle the visibility of the piece label.
- * @param checked - true if piece label is visible.
- */
+//******************************************************************************
+/// @brief togglePieceLabel - routine to toggle the visibility of the piece label.
+/// @param checked - true if piece label is visible.
+//******************************************************************************
 void PatternPieceTool::togglePieceLabel(bool checked)
 {
     VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
@@ -2220,10 +2259,9 @@ void PatternPieceTool::togglePieceLabel(bool checked)
     showStatus(tr("Piece label visibility changed: ") + (checked ? tr("Show") : tr("Hide")));
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief renamePiece - routine to rename pattern piece.
- */
+//******************************************************************************
+/// @brief renamePiece - routine to rename pattern piece.
+//******************************************************************************
 void PatternPieceTool::renamePiece(VPiece piece)
 {
     QInputDialog *dialog = new QInputDialog(nullptr);

--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -1573,6 +1573,98 @@ void PatternPieceTool::SaveDialogChange()
     UpdatePieceLabel();
 }
 
+void PatternPieceTool::nodeAngleChanged(quint32 id, PieceNodeAngle type)
+{
+    const VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
+    VPiece newPiece = oldPiece;
+
+    for (int i = 0; i< oldPiece.GetPath().CountNodes(); ++i)
+    {
+        VPieceNode node = oldPiece.GetPath().at(i);
+        if (node.GetId() == id && node.GetTypeTool() == Tool::NodePoint)
+        {
+            node.SetAngleType(type);
+            newPiece.GetPath()[i] = node;
+
+            SavePieceOptions *undoCommand = new SavePieceOptions(oldPiece, newPiece, doc, m_id);
+            undoCommand->setText(tr("Update Node Angle"));
+            connect(undoCommand, &SavePieceOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
+            qApp->getUndoStack()->push(undoCommand);
+            return;
+        }
+    }
+}
+
+void PatternPieceTool::notchChanged(quint32 id, NotchData notchData)
+{
+    const VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
+    VPiece newPiece = oldPiece;
+
+    for (int i = 0; i< oldPiece.GetPath().CountNodes(); ++i)
+    {
+        VPieceNode node = oldPiece.GetPath().at(i);
+        if (node.GetId() == id && node.GetTypeTool() == Tool::NodePoint)
+        {
+            node.setNotch(notchData.isNotch);
+            node.setNotchType(notchData.type);
+            node.setNotchSubType(notchData.subType);
+            node.setNotchCount(notchData.count);
+            newPiece.GetPath()[i] = node;
+
+            SavePieceOptions *undoCommand = new SavePieceOptions(oldPiece, newPiece, doc, m_id);
+            undoCommand->setText(tr("Update Notch"));
+            connect(undoCommand, &SavePieceOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
+            qApp->getUndoStack()->push(undoCommand);
+            return;
+        }
+    }
+}
+
+void PatternPieceTool::nodeExcluded(quint32 id)
+{
+    const VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
+    VPiece newPiece = oldPiece;
+
+    for (int i = 0; i< oldPiece.GetPath().CountNodes(); ++i)
+    {
+        VPieceNode node = oldPiece.GetPath().at(i);
+        if (node.GetId() == id && node.GetTypeTool() == Tool::NodePoint)
+        {
+            node.SetExcluded(true);
+            newPiece.GetPath()[i] = node;
+
+            SavePieceOptions *undoCommand = new SavePieceOptions(oldPiece, newPiece, doc, m_id);
+            undoCommand->setText(tr("Exclude Node"));
+            connect(undoCommand, &SavePieceOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
+            qApp->getUndoStack()->push(undoCommand);
+            return;
+        }
+    }
+}
+
+void PatternPieceTool::nodeDeleted(quint32 id)
+{
+    const VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
+    VPiece newPiece = oldPiece;
+    VPiecePath path = newPiece.GetPath();
+    int index = path.indexOfNode(id);
+    QVector<VPieceNode> nodes = path.GetNodes();
+    VPieceNode node = nodes.at(index);
+
+    if (node.GetTypeTool() == Tool::NodePoint)
+    {
+        QVector<VPieceNode> newNodes = path.removeNode(id);
+        path.SetNodes(newNodes);
+        newPiece.SetPath(path);
+
+        SavePieceOptions *undoCommand = new SavePieceOptions(oldPiece, newPiece, doc, m_id);
+        undoCommand->setText(tr("Delete Node"));
+        connect(undoCommand, &SavePieceOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
+        qApp->getUndoStack()->push(undoCommand);
+        return;
+    }
+}
+
 //---------------------------------------------------------------------------------------------------------------------
 VPieceItem::MoveTypes PatternPieceTool::FindLabelGeometry(const VPatternLabelData &labelData, qreal &rotationAngle,
                                                             qreal &labelWidth, qreal &labelHeight, QPointF &pos)
@@ -1790,12 +1882,20 @@ void PatternPieceTool::initializeNode(const VPieceNode &node, VMainGraphicsScene
             VNodePoint *tool = qobject_cast<VNodePoint*>(VAbstractPattern::getTool(node.GetId()));
             SCASSERT(tool != nullptr);
 
-            connect(tool, &VNodePoint::chosenTool, scene, &VMainGraphicsScene::chosenItem, Qt::UniqueConnection);
-            tool->setParentItem(parent);
-            tool->SetParentType(ParentType::Item);
-            tool->SetExluded(node.isExcluded());
-            tool->setVisible(!node.isExcluded());//Hide excluded point
-            doc->IncrementReferens(node.GetId());
+            if (tool->parent() != parent)
+            {
+                connect(tool, &VNodePoint::chosenTool, scene, &VMainGraphicsScene::chosenItem, Qt::UniqueConnection);
+                connect(tool, &VNodePoint::notchChanged, parent, &PatternPieceTool::notchChanged, Qt::UniqueConnection);
+                connect(tool, &VNodePoint::nodeAngleChanged, parent,
+                        &PatternPieceTool::nodeAngleChanged, Qt::UniqueConnection);
+                connect(tool, &VNodePoint::nodeExcluded, parent, &PatternPieceTool::nodeExcluded, Qt::UniqueConnection);
+                connect(tool, &VNodePoint::nodeDeleted, parent, &PatternPieceTool::nodeDeleted, Qt::UniqueConnection);
+                tool->setParentItem(parent);
+                tool->SetParentType(ParentType::Item);
+                tool->SetExluded(node.isExcluded());
+                doc->IncrementReferens(node.GetId());
+            }
+            tool->setVisible(!node.isExcluded()); //Hide excluded point
             break;
         }
         case (Tool::NodeArc):

--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -1580,21 +1580,24 @@ void PatternPieceTool::SaveDialogChange()
 void PatternPieceTool::nodeAngleChanged(quint32 id, PieceNodeAngle type)
 {
     const VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
-    VPiece newPiece = oldPiece;
-
-    for (int i = 0; i< oldPiece.GetPath().CountNodes(); ++i)
+    if (!oldPiece.isLocked())
     {
-        VPieceNode node = oldPiece.GetPath().at(i);
-        if (node.GetId() == id && node.GetTypeTool() == Tool::NodePoint)
-        {
-            node.SetAngleType(type);
-            newPiece.GetPath()[i] = node;
+        VPiece newPiece = oldPiece;
 
-            SavePieceOptions *undoCommand = new SavePieceOptions(oldPiece, newPiece, doc, m_id);
-            undoCommand->setText(tr("Update Node Angle"));
-            connect(undoCommand, &SavePieceOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
-            qApp->getUndoStack()->push(undoCommand);
-            return;
+        for (int i = 0; i< oldPiece.GetPath().CountNodes(); ++i)
+        {
+            VPieceNode node = oldPiece.GetPath().at(i);
+            if (node.GetId() == id && node.GetTypeTool() == Tool::NodePoint)
+            {
+                node.SetAngleType(type);
+                newPiece.GetPath()[i] = node;
+
+                SavePieceOptions *undoCommand = new SavePieceOptions(oldPiece, newPiece, doc, m_id);
+                undoCommand->setText(tr("Update Node Angle"));
+                connect(undoCommand, &SavePieceOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
+                qApp->getUndoStack()->push(undoCommand);
+                return;
+            }
         }
     }
 }
@@ -1615,24 +1618,27 @@ void PatternPieceTool::nodeAngleChanged(quint32 id, PieceNodeAngle type)
 void PatternPieceTool::notchChanged(quint32 id, NotchData notchData)
 {
     const VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
-    VPiece newPiece = oldPiece;
-
-    for (int i = 0; i< oldPiece.GetPath().CountNodes(); ++i)
+    if (!oldPiece.isLocked())
     {
-        VPieceNode node = oldPiece.GetPath().at(i);
-        if (node.GetId() == id && node.GetTypeTool() == Tool::NodePoint)
-        {
-            node.setNotch(notchData.isNotch);
-            node.setNotchType(notchData.type);
-            node.setNotchSubType(notchData.subType);
-            node.setNotchCount(notchData.count);
-            newPiece.GetPath()[i] = node;
+        VPiece newPiece = oldPiece;
 
-            SavePieceOptions *undoCommand = new SavePieceOptions(oldPiece, newPiece, doc, m_id);
-            undoCommand->setText(tr("Update Notch"));
-            connect(undoCommand, &SavePieceOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
-            qApp->getUndoStack()->push(undoCommand);
-            return;
+        for (int i = 0; i< oldPiece.GetPath().CountNodes(); ++i)
+        {
+            VPieceNode node = oldPiece.GetPath().at(i);
+            if (node.GetId() == id && node.GetTypeTool() == Tool::NodePoint)
+            {
+                node.setNotch(notchData.isNotch);
+                node.setNotchType(notchData.type);
+                node.setNotchSubType(notchData.subType);
+                node.setNotchCount(notchData.count);
+                newPiece.GetPath()[i] = node;
+
+                SavePieceOptions *undoCommand = new SavePieceOptions(oldPiece, newPiece, doc, m_id);
+                undoCommand->setText(tr("Update Notch"));
+                connect(undoCommand, &SavePieceOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
+                qApp->getUndoStack()->push(undoCommand);
+                return;
+            }
         }
     }
 }
@@ -1652,21 +1658,24 @@ void PatternPieceTool::notchChanged(quint32 id, NotchData notchData)
 void PatternPieceTool::nodeExcluded(quint32 id)
 {
     const VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
-    VPiece newPiece = oldPiece;
-
-    for (int i = 0; i< oldPiece.GetPath().CountNodes(); ++i)
+    if (!oldPiece.isLocked())
     {
-        VPieceNode node = oldPiece.GetPath().at(i);
-        if (node.GetId() == id && node.GetTypeTool() == Tool::NodePoint)
-        {
-            node.SetExcluded(true);
-            newPiece.GetPath()[i] = node;
+        VPiece newPiece = oldPiece;
 
-            SavePieceOptions *undoCommand = new SavePieceOptions(oldPiece, newPiece, doc, m_id);
-            undoCommand->setText(tr("Exclude Node"));
-            connect(undoCommand, &SavePieceOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
-            qApp->getUndoStack()->push(undoCommand);
-            return;
+        for (int i = 0; i< oldPiece.GetPath().CountNodes(); ++i)
+        {
+            VPieceNode node = oldPiece.GetPath().at(i);
+            if (node.GetId() == id && node.GetTypeTool() == Tool::NodePoint)
+            {
+                node.SetExcluded(true);
+                newPiece.GetPath()[i] = node;
+
+                SavePieceOptions *undoCommand = new SavePieceOptions(oldPiece, newPiece, doc, m_id);
+                undoCommand->setText(tr("Exclude Node"));
+                connect(undoCommand, &SavePieceOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
+                qApp->getUndoStack()->push(undoCommand);
+                return;
+            }
         }
     }
 }
@@ -1684,23 +1693,26 @@ void PatternPieceTool::nodeExcluded(quint32 id)
 void PatternPieceTool::nodeDeleted(quint32 id)
 {
     const VPiece oldPiece = VAbstractTool::data.GetPiece(m_id);
-    VPiece newPiece = oldPiece;
-    VPiecePath path = newPiece.GetPath();
-    int index = path.indexOfNode(id);
-    QVector<VPieceNode> nodes = path.GetNodes();
-    VPieceNode node = nodes.at(index);
-
-    if (node.GetTypeTool() == Tool::NodePoint)
+    if (!oldPiece.isLocked())
     {
-        QVector<VPieceNode> newNodes = path.removeNode(id);
-        path.SetNodes(newNodes);
-        newPiece.SetPath(path);
+        VPiece newPiece = oldPiece;
+        VPiecePath path = newPiece.GetPath();
+        int index = path.indexOfNode(id);
+        QVector<VPieceNode> nodes = path.GetNodes();
+        VPieceNode node = nodes.at(index);
 
-        SavePieceOptions *undoCommand = new SavePieceOptions(oldPiece, newPiece, doc, m_id);
-        undoCommand->setText(tr("Delete Node"));
-        connect(undoCommand, &SavePieceOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
-        qApp->getUndoStack()->push(undoCommand);
-        return;
+        if (node.GetTypeTool() == Tool::NodePoint)
+        {
+            QVector<VPieceNode> newNodes = path.removeNode(id);
+            path.SetNodes(newNodes);
+            newPiece.SetPath(path);
+
+            SavePieceOptions *undoCommand = new SavePieceOptions(oldPiece, newPiece, doc, m_id);
+            undoCommand->setText(tr("Delete Node"));
+            connect(undoCommand, &SavePieceOptions::NeedLiteParsing, doc, &VAbstractPattern::LiteParseTree);
+            qApp->getUndoStack()->push(undoCommand);
+            return;
+        }
     }
 }
 

--- a/src/libs/vtools/tools/pattern_piece_tool.h
+++ b/src/libs/vtools/tools/pattern_piece_tool.h
@@ -60,6 +60,7 @@
 
 #include "vinteractivetool.h"
 
+#include "../vpatterndb/vpiece.h"
 #include "../vwidgets/vtextgraphicsitem.h"
 #include "../vwidgets/vgrainlineitem.h"
 
@@ -154,6 +155,12 @@ protected slots:
     void                 SaveMoveGrainline(const QPointF& ptPos);
     void                 SaveResizeGrainline(qreal dLength);
     void                 SaveRotateGrainline(qreal dRot, const QPointF& ptPos);
+
+private slots:
+    void                 nodeAngleChanged(quint32 id, PieceNodeAngle notchData);
+    void                 notchChanged(quint32 id, NotchData notchData);
+    void                 nodeExcluded(quint32 id);
+    void                 nodeDeleted(quint32 id);
 
 protected:
     virtual void         AddToFile () Q_DECL_OVERRIDE;

--- a/src/libs/vtools/tools/pattern_piece_tool.h
+++ b/src/libs/vtools/tools/pattern_piece_tool.h
@@ -1,54 +1,52 @@
-/***************************************************************************
- **  @file   pattern_piece_tool.h
- **  @author Douglas S Caskey
- **  @date   Dec 11, 2022
- **
- **  @copyright
- **  Copyright (C) 2017 - 2022 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//******************************************************************************
+//  @file   pattern_piece_tool.h
+//  @author Douglas S Caskey
+//  @date   Dec 11, 2022
+//
+//  @copyright
+//  Copyright (C) 2017 - 2022 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//******************************************************************************
 
-/************************************************************************
- **
- **  @file   vtoolseamallowance.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   6 11, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//******************************************************************************
+//  @file   vtoolseamallowance.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   6 11, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//******************************************************************************
 
 #ifndef PATTERNPIECE_TOOL_H
 #define PATTERNPIECE_TOOL_H


### PR DESCRIPTION
This PR enhances the point node context menu in Piece mode. It will speed up the workflow eliminating the need to open the Pattern Piece dialog by adding the following items to the context menu:

1. Seam Allowance angle type.

![image](https://github.com/user-attachments/assets/2763960f-0fc1-4b5f-be47-518952f1ccdb)

2. Notch type, Subtype, and Count. If a node is not currently set as a notch, selecting a Count item will automatically set the notch as the default type set in the Prefs with a Subtype of Straight Forward, and with the selected Count.

![image](https://github.com/user-attachments/assets/0db5bbc7-5436-41bf-ab34-96dc99c53f61)

3. Excluded. This will exclude the node from the mainpath.  
4. Delete. This will delete the node from the mainpath.

Each new menu action is a accompanied the appropriate Undo / Redo actions. 

![image](https://github.com/user-attachments/assets/9063a18a-ffd9-4183-900b-46ea3bdaa38b)
 
![image](https://github.com/user-attachments/assets/48f16be6-77c7-4413-b2dc-20b67facdfd7)

![image](https://github.com/user-attachments/assets/b5e69b51-2fa9-4ba7-9e08-7336dd1e7fad)

![image](https://github.com/user-attachments/assets/c208bc31-f879-4e81-8688-79a2d0f0082e)

PR Includes an lupdate for new menu items.

This closes issue #1257 