### PR TITLE
Feature: Show only ISO lineweights

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -9543,6 +9543,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -8494,7 +8494,7 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     </message>
     <message>
         <source>Count</source>
-        <translation type="unfinished"></translation>
+        <translation>Zählen</translation>
     </message>
 </context>
 <context>
@@ -8665,19 +8665,19 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     </message>
     <message>
         <source>Update Node Angle</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktualisieren des Knotenwinkels</translation>
     </message>
     <message>
         <source>Update Notch</source>
-        <translation type="unfinished"></translation>
+        <translation>Aktualisieren Kerbe</translation>
     </message>
     <message>
         <source>Exclude Node</source>
-        <translation type="unfinished"></translation>
+        <translation>Knoten ausschließen</translation>
     </message>
     <message>
         <source>Delete Node</source>
-        <translation type="unfinished"></translation>
+        <translation>Knoten löschen</translation>
     </message>
 </context>
 <context>
@@ -9563,6 +9563,10 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <source>Y Offset:</source>
         <translation>Y Versatz:</translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation>Nur ISO-Liniengewichte in Dropdown-Boxen anzeigen</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -10409,13 +10413,13 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <translation>Zoll</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the SeamlyMe preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10483,13 +10487,13 @@ You can change this setting in the SeamlyMe preferences.</source>
         <translation>Legt den Klickton für die Knotenauswahl fest.</translation>
     </message>
     <message>
-        <source>Selects what decimal separator char to use. 
-When checked the separator for the user&apos;s locale is used. 
+        <source>Selects what decimal separator char to use.
+When checked the separator for the user&apos;s locale is used.
 When unchecked the period is used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>When checked the Welcome window will not be displayed. 
+        <source>When checked the Welcome window will not be displayed.
 You can change this setting in the Seamly2D preferences.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12837,95 +12841,95 @@ wie gewohnt in SeamlyME laden können.
     </message>
     <message>
         <source>Seam Allowance Angle</source>
-        <translation type="unfinished"></translation>
+        <translation>Nahtzugabe-Winkel</translation>
     </message>
     <message>
         <source>By length</source>
-        <translation type="unfinished"></translation>
+        <translation>Nach Länge</translation>
     </message>
     <message>
         <source>Intersection</source>
-        <translation type="unfinished">Schnittpunkt</translation>
+        <translation>Schnittpunkt</translation>
     </message>
     <message>
         <source>First edge symmetry</source>
-        <translation type="unfinished"></translation>
+        <translation>Erste Kantensymmetrie</translation>
     </message>
     <message>
         <source>Second edge symmetry</source>
-        <translation type="unfinished"></translation>
+        <translation>Zweite Kantensymmetrie</translation>
     </message>
     <message>
         <source>First edge right angle</source>
-        <translation type="unfinished"></translation>
+        <translation>Erste Kante rechter Winkel</translation>
     </message>
     <message>
         <source>Second edge right angle</source>
-        <translation type="unfinished"></translation>
+        <translation>Zweite Kante rechter Winkel</translation>
     </message>
     <message>
         <source>Notch</source>
-        <translation type="unfinished">Markierung</translation>
+        <translation>Markierung</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished">Typ</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation>Keine</translation>
     </message>
     <message>
         <source>Slit</source>
-        <translation type="unfinished">Schlitz</translation>
+        <translation>Schlitz</translation>
     </message>
     <message>
         <source>TNotch</source>
-        <translation type="unfinished"></translation>
+        <translation>TMarkierung</translation>
     </message>
     <message>
         <source>UNotch</source>
-        <translation type="unfinished"></translation>
+        <translation>UMarkierung</translation>
     </message>
     <message>
         <source>VInternal</source>
-        <translation type="unfinished"></translation>
+        <translation>VInnen</translation>
     </message>
     <message>
         <source>VExternal</source>
-        <translation type="unfinished"></translation>
+        <translation>VAussen</translation>
     </message>
     <message>
         <source>Castle</source>
-        <translation type="unfinished">Burg</translation>
+        <translation>Burg</translation>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished">Diamant</translation>
+        <translation>Diamant</translation>
     </message>
     <message>
         <source>Subtype</source>
-        <translation type="unfinished">Unterart</translation>
+        <translation>Unterart</translation>
     </message>
     <message>
         <source>Straightforward</source>
-        <translation type="unfinished">Geradeaus</translation>
+        <translation>Geradeaus</translation>
     </message>
     <message>
         <source>Bisector</source>
-        <translation type="unfinished"></translation>
+        <translation>Halbierende</translation>
     </message>
     <message>
         <source>Count</source>
-        <translation type="unfinished"></translation>
+        <translation>Zählen</translation>
     </message>
     <message>
         <source>Excluded</source>
-        <translation type="unfinished">Ausgeschlossen</translation>
+        <translation>Ausgeschlossen</translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="unfinished">Löschen</translation>
+        <translation>Löschen</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -9543,6 +9543,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -9546,6 +9546,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -9546,6 +9546,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -9546,6 +9546,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -9546,6 +9546,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -8551,7 +8551,7 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Count</source>
-        <translation type="unfinished"></translation>
+        <translation>Cuenta</translation>
     </message>
 </context>
 <context>
@@ -8722,19 +8722,20 @@ Press enter to temporarily add it to the list.</source>
     </message>
     <message>
         <source>Update Node Angle</source>
-        <translation type="unfinished"></translation>
+        <translation>Actualizar ángulo de nodo</translation>
     </message>
     <message>
         <source>Update Notch</source>
-        <translation type="unfinished"></translation>
+        <translation>Actualizar Piquete</translation>
     </message>
     <message>
         <source>Exclude Node</source>
-        <translation type="unfinished"></translation>
+        <translatorcomment>Eliminar nodo</translatorcomment>
+        <translation>Nodo de exclusión</translation>
     </message>
     <message>
         <source>Delete Node</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -9619,6 +9620,10 @@ actualización:</translation>
     <message>
         <source>Y Offset:</source>
         <translation>Desplazamiento Y:</translation>
+    </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation>Mostrar sólo los pesos de línea ISO en los cuadros desplegables</translation>
     </message>
 </context>
 <context>
@@ -12895,95 +12900,95 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Seam Allowance Angle</source>
-        <translation type="unfinished"></translation>
+        <translation>Ángulo de costura</translation>
     </message>
     <message>
         <source>By length</source>
-        <translation type="unfinished"></translation>
+        <translation>Por longitud</translation>
     </message>
     <message>
         <source>Intersection</source>
-        <translation type="unfinished">Intersección</translation>
+        <translation>Intersección</translation>
     </message>
     <message>
         <source>First edge symmetry</source>
-        <translation type="unfinished"></translation>
+        <translation>Primera simetría de aristas</translation>
     </message>
     <message>
         <source>Second edge symmetry</source>
-        <translation type="unfinished"></translation>
+        <translation>Segunda simetría de aristas</translation>
     </message>
     <message>
         <source>First edge right angle</source>
-        <translation type="unfinished"></translation>
+        <translation>Primera arista ángulo recto</translation>
     </message>
     <message>
         <source>Second edge right angle</source>
-        <translation type="unfinished"></translation>
+        <translation>Segundo arista ángulo recto</translation>
     </message>
     <message>
         <source>Notch</source>
-        <translation type="unfinished">Piquete</translation>
+        <translation>Piquete</translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished">Tipo</translation>
+        <translation>Tipo</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished">Ninguno</translation>
+        <translation>Ninguno</translation>
     </message>
     <message>
         <source>Slit</source>
-        <translation type="unfinished">Abertura</translation>
+        <translation>Abertura</translation>
     </message>
     <message>
         <source>TNotch</source>
-        <translation type="unfinished"></translation>
+        <translation>TPiquete</translation>
     </message>
     <message>
         <source>UNotch</source>
-        <translation type="unfinished"></translation>
+        <translation>UPiquete</translation>
     </message>
     <message>
         <source>VInternal</source>
-        <translation type="unfinished">VInterno</translation>
+        <translation>VInterno</translation>
     </message>
     <message>
         <source>VExternal</source>
-        <translation type="unfinished">VExterno</translation>
+        <translation>VExterno</translation>
     </message>
     <message>
         <source>Castle</source>
-        <translation type="unfinished"></translation>
+        <translation>Castillo</translation>
     </message>
     <message>
         <source>Diamond</source>
-        <translation type="unfinished">Diamante</translation>
+        <translation>Diamante</translation>
     </message>
     <message>
         <source>Subtype</source>
-        <translation type="unfinished">Subtipo</translation>
+        <translation>Subtipo</translation>
     </message>
     <message>
         <source>Straightforward</source>
-        <translation type="unfinished">Directo</translation>
+        <translation>Directo</translation>
     </message>
     <message>
         <source>Bisector</source>
-        <translation type="unfinished">Bisectriz</translation>
+        <translation>Bisectriz</translation>
     </message>
     <message>
         <source>Count</source>
-        <translation type="unfinished"></translation>
+        <translation>Cuenta</translation>
     </message>
     <message>
         <source>Excluded</source>
-        <translation type="unfinished">Excluido</translation>
+        <translation>Excluido</translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="unfinished">Eliminar</translation>
+        <translation>Eliminar</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -9543,6 +9543,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -9546,6 +9546,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -9542,6 +9542,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -9543,6 +9543,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -9546,6 +9546,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -9551,6 +9551,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -9542,6 +9542,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -9542,6 +9542,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -9577,6 +9577,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -9545,6 +9545,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -9542,6 +9542,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Y Offset:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show only ISO line weights in drop down boxes</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>

--- a/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
+++ b/src/app/seamly2d/core/vtooloptionspropertybrowser.cpp
@@ -722,10 +722,11 @@ void VToolOptionsPropertyBrowser::addPropertyLineWeight(Tool *tool, const QStrin
 {
     VPE::LineWeightProperty *lineWeightProperty = new VPE::LineWeightProperty(propertyName);
     lineWeightProperty->setLineWeights(lineWeightList());
-    const qint32 index = VPE::LineWeightProperty::indexOfLineWeight(lineWeightList(), tool->getLineWeight());
+    qint32 index = VPE::LineWeightProperty::indexOfLineWeight(lineWeightList(), tool->getLineWeight());
     if (index == -1)
     {
-        qWarning() << "Can't find line weight" << tool->getLineWeight() <<  "in list";
+        index = 6;
+        //qWarning() << "Can't find line weight" << tool->getLineWeight() <<  "in list";
     }
     lineWeightProperty->setValue(index);
     addProperty(lineWeightProperty, AttrLineWeight);

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
@@ -3,11 +3,13 @@
 //  @author Douglas S Caskey
 //  @date   26 Oct, 2023
 //
-//  @copyright
-//  Copyright (C) 2017 - 2022 Seamly, LLC
-//  https://github.com/fashionfreedom/seamly2d
-//
 //  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2025 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
 //  Seamly2D is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
@@ -19,7 +21,7 @@
 //  GNU General Public License for more details.
 //
 //  You should have received a copy of the GNU General Public License
-//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
 //-----------------------------------------------------------------------------
 
 #include "preferencesgraphicsviewpage.h"
@@ -215,6 +217,7 @@ PreferencesGraphicsViewPage::PreferencesGraphicsViewPage (QWidget *parent)
 
     // Always use current pen
     ui->useCurrentPen_checkBox->setChecked(qApp->Seamly2DSettings()->useCurrentPen());
+    ui->showOnlyIso_CheckBox->setChecked(qApp->Seamly2DSettings()->showOnlyIso());
 
     // Font preferences
     // Pattern piece labels font
@@ -267,13 +270,13 @@ PreferencesGraphicsViewPage::~PreferencesGraphicsViewPage ()
     delete ui;
 }
 
-// @brief enableOffsets() enable offset spinboxes.
-//
-// This method enables / disables the offset spinboxes based on the radio button checked.
-//
-// @Details
-//  - Enables spinboxes when the Offset radio button is checked.
-//  - Disables spinboxes when any other radio button is checked.
+/// @brief enableOffsets() enable offset spinboxes.
+///
+/// This method enables / disables the offset spinboxes based on the radio button checked.
+///
+/// @Details
+///  - Enables spinboxes when the Offset radio button is checked.
+///  - Disables spinboxes when any other radio button is checked.
 void PreferencesGraphicsViewPage::enableOffsets()
 {
     if (ui->offset_RadioButton->isChecked())
@@ -403,8 +406,9 @@ void PreferencesGraphicsViewPage::Apply()
     // Pan Zoom while Space key pressed
     settings->setPanActiveSpaceKey(ui->panActiveSpacePressed_CheckBox->isChecked());
 
-    // Always use current pen
+    // Pen
     settings->setUseCurrentPen(ui->useCurrentPen_checkBox->isChecked());
+    settings->setShowIsoOnly(ui->showOnlyIso_CheckBox->isChecked());
 
     //Fonts
     settings->setLabelFont(ui->labelFont_ComboBox->currentFont());

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.h
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.h
@@ -1,26 +1,28 @@
-/***************************************************************************
- **  @file   PreferencesGraphicsViewPage.h
- **  @author Douglas S Caskey
- **  @date   26 Oct, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   PreferencesGraphicsViewPage.h
+//  @author Douglas S Caskey
+//  @date   26 Oct, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2025 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #ifndef PREFERENCES_GRAPHICSVIEWPAGE_H
 #define PREFERENCES_GRAPHICSVIEWPAGE_H

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
@@ -3229,6 +3229,13 @@ border-radius: 4px;
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="showOnlyIso_CheckBox">
+            <property name="text">
+             <string>Show only ISO line weights in drop down boxes</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -274,7 +274,7 @@ MainWindow::MainWindow(QWidget *parent)
         initializeToolBarVisibility();
 
         setCurrentFile(""); // Set a new unsaved pattern filename to an empty string.
-        WindowsLocale();    // Set the mainwindow locale based on the OS seperator set in the prefs.
+        setWindowsLocale(); // Set the mainwindow locale based on the OS seperator set in the prefs.
 
         // Show the layout page that is selected in the Layout Pages dock.
         connect(ui->listWidget, &QListWidget::currentRowChanged, this, &MainWindow::showLayoutPages);
@@ -5235,7 +5235,7 @@ void MainWindow::ReadSettings()
     qApp->getUndoStack()->setUndoLimit(settings->GetUndoCount());
 
     // Text under tool button icon
-    ToolBarStyles();
+    initToolBarStyles();
 
     isToolOptionsDockVisible = ui->toolProperties_DockWidget->isVisible();
     isGroupsDockVisible      = ui->groups_DockWidget->isVisible();
@@ -6621,13 +6621,13 @@ QStringList MainWindow::GetUnlokedRestoreFileList() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void MainWindow::ToolBarStyles()
+void MainWindow::initToolBarStyles()
 {
-    ToolBarStyle(ui->draft_ToolBar);
-    ToolBarStyle(ui->mode_ToolBar);
-    ToolBarStyle(ui->edit_Toolbar);
-    ToolBarStyle(ui->zoom_ToolBar);
-    ToolBarStyle(ui->file_ToolBar);
+    initToolBarStyle(ui->draft_ToolBar);
+    initToolBarStyle(ui->mode_ToolBar);
+    initToolBarStyle(ui->edit_Toolbar);
+    initToolBarStyle(ui->zoom_ToolBar);
+    initToolBarStyle(ui->file_ToolBar);
 
     fontComboBox->setCurrentFont(qApp->Seamly2DSettings()->getPointNameFont());
     int index = fontSizeComboBox->findData(qApp->Seamly2DSettings()->getPointNameSize());
@@ -6669,19 +6669,8 @@ void MainWindow::Preferences()
         // QScopedPointer needs to be sure any exception will never block guard
         QScopedPointer<DialogPreferences> dialog(preferences);
         guard = preferences;
-        connect(dialog.data(), &DialogPreferences::updateProperties, this, &MainWindow::WindowsLocale); // Must be first
-        connect(dialog.data(), &DialogPreferences::updateProperties, this, &MainWindow::ToolBarStyles);
-        connect(dialog.data(), &DialogPreferences::updateProperties, this, &MainWindow::updateToolBarVisibility);
-        connect(dialog.data(), &DialogPreferences::updateProperties, this, &MainWindow::refreshLabels);
-        connect(dialog.data(), &DialogPreferences::updateProperties, this, &MainWindow::resetOrigins);
-        connect(dialog.data(), &DialogPreferences::updateProperties, this, &MainWindow::upDateScenes);
-        connect(dialog.data(), &DialogPreferences::updateProperties, this, &MainWindow::updateViewToolbar);
-        connect(dialog.data(), &DialogPreferences::updateProperties, this, &MainWindow::resetPanShortcuts);
-        connect(dialog.data(), &DialogPreferences::updateProperties, this, [this](){emit doc->FullUpdateFromFile();});
-        connect(dialog.data(), &DialogPreferences::updateProperties, this, &MainWindow::initPropertyEditor);
-        connect(dialog.data(), &DialogPreferences::updateProperties, this, &MainWindow::initBasePointComboBox);
-        connect(dialog.data(), &DialogPreferences::updateProperties, ui->view, &VMainGraphicsView::resetScrollBars);
-        connect(dialog.data(), &DialogPreferences::updateProperties, ui->view, &VMainGraphicsView::resetScrollAnimations);
+
+        connect(dialog.data(), &DialogPreferences::updateProperties, this, &MainWindow::updatePreferences);
 
         QGuiApplication::restoreOverrideCursor();
 
@@ -6690,6 +6679,29 @@ void MainWindow::Preferences()
             initializeAutoSave();
         }
     }
+}
+
+//-----------------------------------------------------------------------------
+/// @brief updatePreferences updates the Preferences
+///
+/// This method updates the gui whenever changes are made to the Preferences.
+//-----------------------------------------------------------------------------
+void MainWindow::updatePreferences()
+{
+    setWindowsLocale(); // Must be first
+    initToolBarStyles();
+    updateToolBarVisibility();
+    refreshLabels();
+    resetOrigins();
+    upDateScenes();
+    updateViewToolbar();
+    resetPanShortcuts();
+    initPropertyEditor();
+    initBasePointComboBox();
+    initPenToolBar();
+    ui->view->resetScrollBars();
+    ui->view->resetScrollAnimations();
+    emit doc->FullUpdateFromFile();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -172,10 +172,11 @@ private slots:
     void fullParseFile();
     void setGuiEnabled(bool enabled);
     void changeDraftBlockGlobally(const QString &patternPiece);
-    void ToolBarStyles();
+    void initToolBarStyles();
     void resetOrigins();
     void showLayoutPages(int index);
     void Preferences();
+    void updatePreferences();
 #if defined(Q_OS_MAC)
     void CreateMeasurements();
 #endif

--- a/src/app/seamlyme/tmainwindow.cpp
+++ b/src/app/seamlyme/tmainwindow.cpp
@@ -610,18 +610,18 @@ void TMainWindow::Preferences()
 		QScopedPointer<DialogSeamlyMePreferences> dlg(preferences);
 		guard = preferences;
 		// Must be first
-		connect(dlg.data(), &DialogSeamlyMePreferences::updateProperties, this, &TMainWindow::WindowsLocale);
-		connect(dlg.data(), &DialogSeamlyMePreferences::updateProperties, this, &TMainWindow::ToolBarStyles);
+		connect(dlg.data(), &DialogSeamlyMePreferences::updateProperties, this, &TMainWindow::setWindowsLocale);
+		connect(dlg.data(), &DialogSeamlyMePreferences::updateProperties, this, &TMainWindow::initToolBarStyles);
 		QGuiApplication::restoreOverrideCursor();
 		dlg->exec();
 	}
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void TMainWindow::ToolBarStyles()
+void TMainWindow::initToolBarStyles()
 {
-	ToolBarStyle(ui->toolBarGradation);
-	ToolBarStyle(ui->mainToolBar);
+	initToolBarStyle(ui->toolBarGradation);
+	initToolBarStyle(ui->mainToolBar);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -3038,7 +3038,7 @@ void TMainWindow::ReadSettings()
 	restoreState(settings->GetToolbarsState(), APP_VERSION);
 
 	// Text under tool button icon
-	ToolBarStyles();
+	initToolBarStyles();
 
 	// Stack limit
 	//qApp->getUndoStack()->setUndoLimit(settings->GetUndoCount());

--- a/src/app/seamlyme/tmainwindow.h
+++ b/src/app/seamlyme/tmainwindow.h
@@ -114,7 +114,7 @@ private slots:
     //void                handleBodyScanner1();
     void                handleBodyScanner2();
     void                Preferences();
-    void                ToolBarStyles();
+    void                initToolBarStyles();
 
     void                print();
     void                printPages(QPrinter *printer);

--- a/src/libs/ifc/ifcdef.cpp
+++ b/src/libs/ifc/ifcdef.cpp
@@ -66,6 +66,8 @@
 #include <QStringDataPtr>
 
 #include "../vmisc/diagnostic.h"
+#include "../vmisc/vabstractapplication.h"
+#include "../vmisc/vcommonsettings.h"
 
 const QString CustomMSign    = QStringLiteral("@");
 const QString CustomIncrSign = QStringLiteral("#");
@@ -278,96 +280,142 @@ QMap<QString, QString> lineWeightList()
 {
     QMap<QString, QString> map;
 
-    const QStringList lineWeights = QStringList() << "0"    << "0.05" << "0.09" << "0.13" << "0.15" << "0.18"
-                                                  << "0.2"  << "0.25" << "0.3"  << "0.35" << "0.4"  << "0.5"
-                                                  << "0.53" << "0.6"  << "0.7"  << "0.8"  << "0.9"  << "1"
-                                                  << "1.06" << "1.2"  << "1.4"  << "1.58" << "2"    << "2.11"
-                                                  << "3";
-
-    for (int i = 0; i < lineWeights.size(); ++i)
+    QStringList lineWeights;
+    QString name;
+    if (qApp->Settings()->showOnlyIso())
     {
-        QString name;
-        switch (i)
-        {
-            case 1:
-                name = "0.05mm";
-                break;
-            case 2:
-                name = "0.09";
-                break;
-            case 3:
-                name = "0.13mm (ISO)";
-                break;
-            case 4:
-                name = "0.15mm";
-                break;
-            case 5:
-                name = "0.18mm (ISO)";
-                break;
-            case 6:
-                name ="0.20mm";
-                break;
-            case 7:
-                name = "0.25mm (ISO)";
-                break;
-            case 8:
-                name = "0.30mm";
-                break;
-            case 9:
-                name = "0.35mm (ISO)";
-                break;
-            case 10:
-                name = "0.40mm";
-                break;
-            case 11:
-                name = "0.50mm (ISO)";
-                break;
-            case 12:
-                name ="0.53mm";
-                break;
-            case 13:
-                name = "0.60mm";
-                break;
-            case 14:
-                name = "0.70mm (ISO)";
-                break;
-            case 15:
-                name = "0.80mm";
-                break;
-            case 16:
-                name ="0.90mm";
-                break;
-            case 17:
-                name = "1.00mm (ISO)";
-                break;
-            case 18:
-                name = "1.06mm";
-                break;
-            case 19:
-                name = "1.20mm";
-                break;
-            case 20:
-                name = "1.40mm (ISO)";
-                break;
-            case 21:
-                name = "1.58mm";
-                break;
-            case 22:
-                name = "2.00mm (ISO)";
-                break;
-            case 23:
-                name = "2.11mm";
-                break;
-            case 24:
-                name = "3.00mm";
-                break;
-            case 0:
-            default:
-                name = "0.00mm";
-                break;
-        }
+        lineWeights = QStringList() << "0.13" << "0.18" << "0.25" << "0.35" << "0.5"
+                                    << "0.7"  << "1" << "1.4"   << "2";
 
-        map.insert(lineWeights.at(i), name);
+        for (int i = 0; i < lineWeights.size(); ++i)
+        {
+            switch (i)
+            {
+                case 1:
+                    name = "0.18mm (ISO)";
+                    break;
+                case 2:
+                    name = "0.25mm (ISO)";
+                    break;
+                case 3:
+                    name = "0.35mm (ISO)";
+                    break;
+                case 4:
+                    name = "0.50mm (ISO)";
+                    break;
+                case 5:
+                    name = "0.70mm (ISO)";
+                    break;
+                case 6:
+                    name = "1.00mm (ISO)";
+                    break;
+                case 7:
+                    name = "1.40mm (ISO)";
+                    break;
+                case 8:
+                    name = "2.00mm (ISO)";
+                    break;
+                default:
+                case 0:
+                    name = "0.13mm (ISO)";
+                    break;
+            }
+
+            map.insert(lineWeights.at(i), name);
+        }
+    }
+    else
+    {
+        lineWeights = QStringList() << "0"    << "0.05" << "0.09" << "0.13" << "0.15" << "0.18"
+                                    << "0.2"  << "0.25" << "0.3"  << "0.35" << "0.4"  << "0.5"
+                                    << "0.53" << "0.6"  << "0.7"  << "0.8"  << "0.9"  << "1"
+                                    << "1.06" << "1.2"  << "1.4"  << "1.58" << "2"    << "2.11" << "3";
+
+
+        for (int i = 0; i < lineWeights.size(); ++i)
+        {
+            switch (i)
+            {
+                case 1:
+                    name = "0.05mm";
+                    break;
+                case 2:
+                    name = "0.09";
+                    break;
+                case 3:
+                    name = "0.13mm (ISO)";
+                    break;
+                case 4:
+                    name = "0.15mm";
+                    break;
+                case 5:
+                    name = "0.18mm (ISO)";
+                    break;
+                case 6:
+                    name ="0.20mm";
+                    break;
+                case 7:
+                    name = "0.25mm (ISO)";
+                    break;
+                case 8:
+                    name = "0.30mm";
+                    break;
+                case 9:
+                    name = "0.35mm (ISO)";
+                    break;
+                case 10:
+                    name = "0.40mm";
+                    break;
+                case 11:
+                    name = "0.50mm (ISO)";
+                    break;
+                case 12:
+                    name ="0.53mm";
+                    break;
+                case 13:
+                    name = "0.60mm";
+                    break;
+                case 14:
+                    name = "0.70mm (ISO)";
+                    break;
+                case 15:
+                    name = "0.80mm";
+                    break;
+                case 16:
+                    name ="0.90mm";
+                    break;
+                case 17:
+                    name = "1.00mm (ISO)";
+                    break;
+                case 18:
+                    name = "1.06mm";
+                    break;
+                case 19:
+                    name = "1.20mm";
+                    break;
+                case 20:
+                    name = "1.40mm (ISO)";
+                    break;
+                case 21:
+                    name = "1.58mm";
+                    break;
+                case 22:
+                    name = "2.00mm (ISO)";
+                    break;
+                case 23:
+                    name = "2.11mm";
+                    break;
+                case 24:
+                    name = "3.00mm";
+                    break;
+                case 0:
+                default:
+                    name = "0.00mm";
+                    break;
+            }
+
+            map.insert(lineWeights.at(i), name);
+        }
     }
     return map;
 }

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -1,3 +1,4 @@
+//-----------------------------------------------------------------------------
 //  @file   vcommonsettings.cpp
 //  @author Douglas S Caskey
 //  @date   17 Sep, 2023
@@ -6,7 +7,7 @@
 //  @copyright
 //  This source code is part of the Seamly2D project, a pattern making
 //  program to create and model patterns of clothing.
-//  Copyright (C) 2017-2024 Seamly2D project
+//  Copyright (C) 2017-2025 Seamly2D project
 //  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
 //
 //  Seamly2D is free software: you can redistribute it and/or modify
@@ -21,34 +22,33 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
-/************************************************************************
- **
- **  @file   vcommonsettings.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   15 7, 2015
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vcommonsettings.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   15 7, 2015
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2015 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #include "vcommonsettings.h"
 
@@ -141,7 +141,8 @@ const QString settingGraphicsViewAngleDelta              = QStringLiteral("graph
 const QString settingGraphicsViewZoomModKey              = QStringLiteral("graphicsview/zoomModKey");
 const QString settingGraphicsViewZoomDoubleClick         = QStringLiteral("graphicsview/zoomDoubleClick");
 const QString settingGraphicsViewPanActiveSpaceKey       = QStringLiteral("graphicsview/panActiveSpaceKey");
-const QString settingGraphicsViewUseDefaultPen       = QStringLiteral("graphicsview/useCurrentPen");
+const QString settingGraphicsViewUseDefaultPen           = QStringLiteral("graphicsview/useCurrentPen");
+const QString settingGraphicsViewShowIsoOnly             = QStringLiteral("graphicsview/showOnlyIso");
 const QString settingGraphicsViewZoomSpeedFactor         = QStringLiteral("graphicsview/zoomSpeedFactor");
 const QString settingGraphicsViewExportQuality           = QStringLiteral("graphicsview/exportQuality");
 const QString settingGraphicsViewZoomRBPositiveColor     = QStringLiteral("graphicsview/zoomRBPositiveColor");
@@ -1082,6 +1083,18 @@ void VCommonSettings::setUseCurrentPen(const bool &value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+bool VCommonSettings::showOnlyIso() const
+{
+    return value(settingGraphicsViewShowIsoOnly, false).toBool();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VCommonSettings::setShowIsoOnly(const bool &value)
+{
+    setValue(settingGraphicsViewShowIsoOnly, value);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 int  VCommonSettings::getZoomSpeedFactor() const
 {
     return value(settingGraphicsViewZoomSpeedFactor, 16).toInt();
@@ -1180,7 +1193,7 @@ void VCommonSettings::setDefaultLineColor(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultLineWeight() const
 {
-    return value(settingGraphicsViewDefaultLineWeight, 1.20).toReal();
+    return value(settingGraphicsViewDefaultLineWeight, 1.00).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1853,7 +1866,7 @@ void VCommonSettings::setDefaultSeamLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultSeamLineweight() const
 {
-   return value(settingDefaultSeamLineweight, 1.20).toReal();
+   return value(settingDefaultSeamLineweight, 1.00).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1889,7 +1902,7 @@ void VCommonSettings::setDefaultCutLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultCutLineweight() const
 {
-   return value(settingDefaultCutLineweight, 1.20).toReal();
+   return value(settingDefaultCutLineweight, 1.00).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1925,7 +1938,7 @@ void VCommonSettings::setDefaultInternalLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultInternalLineweight() const
 {
-   return value(settingDefaultInternalLineweight, 1.20).toReal();
+   return value(settingDefaultInternalLineweight, 1.00).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1961,7 +1974,7 @@ void VCommonSettings::setDefaultCutoutLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultCutoutLineweight() const
 {
-   return value(settingDefaultCutoutLineweight, 1.20).toReal();
+   return value(settingDefaultCutoutLineweight, 1.00).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vmisc/vcommonsettings.h
+++ b/src/libs/vmisc/vcommonsettings.h
@@ -1,3 +1,4 @@
+//-----------------------------------------------------------------------------
 //  @file   vcommonsettings.h
 //  @author Douglas S Caskey
 //  @date   17 Sep, 2023
@@ -6,7 +7,7 @@
 //  @copyright
 //  This source code is part of the Seamly2D project, a pattern making
 //  program to create and model patterns of clothing.
-//  Copyright (C) 2017-2024 Seamly2D project
+//  Copyright (C) 2017-2025 Seamly2D project
 //  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
 //
 //  Seamly2D is free software: you can redistribute it and/or modify
@@ -21,34 +22,33 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
-/************************************************************************
- **
- **  @file   vcommonsettings.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   15 7, 2015
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Valentina project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vcommonsettings.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   15 7, 2015
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2015 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #ifndef VCOMMONSETTINGS_H
 #define VCOMMONSETTINGS_H
@@ -234,6 +234,9 @@ public:
 
     bool                 useCurrentPen() const;
     void                 setUseCurrentPen(const bool &value);
+
+    bool                 showOnlyIso() const;
+    void                 setShowIsoOnly(const bool &value);
 
     int                  getZoomSpeedFactor() const;
     void                 setZoomSpeedFactor(const int &factor);

--- a/src/libs/vwidgets/lineweight_combobox.cpp
+++ b/src/libs/vwidgets/lineweight_combobox.cpp
@@ -1,27 +1,33 @@
- /******************************************************************************
-  *   @file   lineweight_combobox.cpp
-  **  @author DS Caskey
-  **  @date   Nov 2, 2021
-  **
-  **  @brief
-  **  @copyright
-  **
-  **  Seamly2D is free software: you can redistribute it and/or modify
-  **  it under the terms of the GNU General Public License as published by
-  **  the Free Software Foundation, either version 3 of the License, or
-  **  (at your option) any later version.
-  **
-  **  Seamly2D is distributed in the hope that it will be useful,
-  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  **  GNU General Public License for more details.
-  **
-  **  You should have received a copy of the GNU General Public License
-  **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
-  **
-  *****************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   lineweight_combobox.cpp
+//  @author Douglas S Caskey
+//  @date   14 Mar, 2025
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2025 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #include "lineweight_combobox.h"
+
+#include "../vmisc/vabstractapplication.h"
+#include "../vmisc/vcommonsettings.h"
 
 #include <QAbstractItemView>
 #include <QPen>
@@ -29,9 +35,12 @@
 #include <QPainter>
 #include <QPixmap>
 
-/**
- * Constructor with name.
- */
+/// @brief LineWeightComboBox constructor
+///
+/// This constructor provides a name, and parent widget.
+///
+/// @param name of combobox.
+/// @param parent parent widget of combobox, default is null if not provided.
 LineWeightComboBox::LineWeightComboBox(QWidget *parent, const char *name)
 		: QComboBox(parent)
       	, m_currentWeight(0.35)
@@ -43,9 +52,14 @@ LineWeightComboBox::LineWeightComboBox(QWidget *parent, const char *name)
 		 init();
 }
 
-/**
- * Constructor that provides a width and height for the icon.
- */
+/// @brief LineWeightComboBox constructor
+///
+/// This constructor provides a width and height for the icon, name, and parent widget.
+///
+/// @param width width of icon.
+/// @param height width of icon.
+/// @param name of combobox.
+/// @param parent parent widget of combobox, default is null if not provided.
 LineWeightComboBox::LineWeightComboBox(int width, int height, QWidget *parent, const char *name)
 		: QComboBox(parent)
 		, m_currentWeight(0.35)
@@ -57,52 +71,76 @@ LineWeightComboBox::LineWeightComboBox(int width, int height, QWidget *parent, c
 		 init();
 }
 
-/**
- * Destructor
- */
+/// Destructor
 LineWeightComboBox::~LineWeightComboBox() {}
 
-/**
- * Initialisation called from constructor or manually but only once.
- */
+
+/// @brief init initalise combo box
+///
+/// This method intializes the combobox items list.
+///
+/// @Details
+///  - Initialisation called from constructor or manually, but only once.
+///  - Sets size of item icon and creates an icon for a given lineweight.
+///  - Adds the full item list of all pen weights, unless the showOnlyIso option is set in prefs
+///    which then omly adds the ISO pen weights.
 void LineWeightComboBox::init()
 {
+    // Block signals while we initialize combobox.
     this->blockSignals(true);
 
 #if defined(Q_OS_MAC)
-    setIconSize(QSize(m_iconWidth-= 2 ,m_iconHeight-= 2)); // On Mac pixmap should be little bit smaller.
-#else // Windows
+    // Mac
+    setIconSize(QSize(m_iconWidth-= 2, m_iconHeight-= 2)); // On Mac pixmap should be little bit smaller.
+#else
+    // Windows
     setIconSize(QSize(m_iconWidth, m_iconHeight));
 #endif
 
     this->view()->setTextElideMode(Qt::ElideNone);
 
-    addItem(createIcon(0.00), "0.00mm",       0.00);
-    addItem(createIcon(1.00), "0.05mm",       0.05);
-    addItem(createIcon(1.00), "0.09mm",       0.09);
-    addItem(createIcon(2.00), "0.13mm (ISO)", 0.13);
-    addItem(createIcon(2.00), "0.15mm",       0.15);
-    addItem(createIcon(2.00), "0.18mm (ISO)", 0.18);
-    addItem(createIcon(3.00), "0.20mm",       0.20);
-    addItem(createIcon(3.00), "0.25mm (ISO)", 0.25);
-    addItem(createIcon(3.00), "0.30mm",       0.30);
-    addItem(createIcon(3.00), "0.35mm (ISO)", 0.35);
-    addItem(createIcon(3.00), "0.40mm",       0.40);
-    addItem(createIcon(4.00), "0.50mm (ISO)", 0.50);
-    addItem(createIcon(4.00), "0.53mm",       0.53);
-    addItem(createIcon(4.00), "0.60mm",       0.60);
-    addItem(createIcon(4.00), "0.70mm (ISO)", 0.70);
-    addItem(createIcon(5.00), "0.80mm",       0.80);
-    addItem(createIcon(5.00), "0.90mm",       0.90);
-    addItem(createIcon(6.00), "1.00mm (ISO)", 1.00);
-    addItem(createIcon(6.00), "1.06mm",       1.06);
-    addItem(createIcon(6.00), "1.20mm",       1.20);
-    addItem(createIcon(7.00), "1.40mm (ISO)", 1.40);
-    addItem(createIcon(7.00), "1.58mm",       1.58);
-    addItem(createIcon(8.00), "2.00mm (ISO)", 2.00);
-    addItem(createIcon(8.00), "2.11mm",       2.11);
-    addItem(createIcon(9.00), "3.00mm",       3.00);
-    setMaxVisibleItems(25);
+    if (qApp->Settings()->showOnlyIso())
+    {
+        addItem(createIcon(2.00), "0.13mm (ISO)", 0.13);
+        addItem(createIcon(2.00), "0.18mm (ISO)", 0.18);
+        addItem(createIcon(3.00), "0.25mm (ISO)", 0.25);
+        addItem(createIcon(3.00), "0.35mm (ISO)", 0.35);
+        addItem(createIcon(4.00), "0.50mm (ISO)", 0.50);
+        addItem(createIcon(4.00), "0.70mm (ISO)", 0.70);
+        addItem(createIcon(6.00), "1.00mm (ISO)", 1.00);
+        addItem(createIcon(7.00), "1.40mm (ISO)", 1.40);
+        addItem(createIcon(8.00), "2.00mm (ISO)", 2.00);
+        setMaxVisibleItems(9);
+    }
+    else
+    {
+        addItem(createIcon(0.00), "0.00mm",       0.00);
+        addItem(createIcon(1.00), "0.05mm",       0.05);
+        addItem(createIcon(1.00), "0.09mm",       0.09);
+        addItem(createIcon(2.00), "0.13mm (ISO)", 0.13);
+        addItem(createIcon(2.00), "0.15mm",       0.15);
+        addItem(createIcon(2.00), "0.18mm (ISO)", 0.18);
+        addItem(createIcon(3.00), "0.20mm",       0.20);
+        addItem(createIcon(3.00), "0.25mm (ISO)", 0.25);
+        addItem(createIcon(3.00), "0.30mm",       0.30);
+        addItem(createIcon(3.00), "0.35mm (ISO)", 0.35);
+        addItem(createIcon(3.00), "0.40mm",       0.40);
+        addItem(createIcon(4.00), "0.50mm (ISO)", 0.50);
+        addItem(createIcon(4.00), "0.53mm",       0.53);
+        addItem(createIcon(4.00), "0.60mm",       0.60);
+        addItem(createIcon(4.00), "0.70mm (ISO)", 0.70);
+        addItem(createIcon(5.00), "0.80mm",       0.80);
+        addItem(createIcon(5.00), "0.90mm",       0.90);
+        addItem(createIcon(6.00), "1.00mm (ISO)", 1.00);
+        addItem(createIcon(6.00), "1.06mm",       1.06);
+        addItem(createIcon(6.00), "1.20mm",       1.20);
+        addItem(createIcon(7.00), "1.40mm (ISO)", 1.40);
+        addItem(createIcon(7.00), "1.58mm",       1.58);
+        addItem(createIcon(8.00), "2.00mm (ISO)", 2.00);
+        addItem(createIcon(8.00), "2.11mm",       2.11);
+        addItem(createIcon(9.00), "3.00mm",       3.00);
+        setMaxVisibleItems(25);
+    }
 
     this->blockSignals(false);
 		connect(this, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &LineWeightComboBox::updateLineWeight);
@@ -111,19 +149,33 @@ void LineWeightComboBox::init()
     updateLineWeight(currentIndex());
 }
 
+/// @brief getLineWeight get the current lineweight item.
+///
+/// This method gets the currently selected weight.
+///
+/// @return current line weight.
 qreal LineWeightComboBox::getLineWeight() const
 {
     return m_currentWeight;
 }
 
-/**
- * Sets the currently selected weight item to the given weight.
- */
+/// @brief setLineWeight set the current lineweight item.
+///
+/// This method sets the currently selected weight item to the given weight.
+///
+/// @param weight line weight to set as current item.
 void LineWeightComboBox::setLineWeight(const qreal &weight)
 {
     m_currentWeight = weight;
 
-    setCurrentIndex(findData(weight));
+    int index = findData(weight);
+
+    if (index = -1)
+    {
+        index = 6;
+    }
+
+    setCurrentIndex(index);
 
     if (currentIndex()!= count() -1 )
     {
@@ -131,10 +183,15 @@ void LineWeightComboBox::setLineWeight(const qreal &weight)
     }
 }
 
-/**
- * Called when the width has changed. This method sets the current width to the value chosen or even
- * offers a dialog to the user that allows him/ her to choose an individual width.
- */
+/// @brief setLineWeight set current lineweight item by index.
+///
+/// This method is called when the width has changed, and sets the current width to the value chosen
+/// or even offers a dialog to the user that allows him/ her to choose an individual width.
+///
+/// @param index index to set the current item to.
+///
+/// @Details
+///  - emits lineWeightChanged signal with the curren line weight.
 void LineWeightComboBox::updateLineWeight(int index)
 {
     QVariant weight = itemData(index);

--- a/src/libs/vwidgets/lineweight_combobox.h
+++ b/src/libs/vwidgets/lineweight_combobox.h
@@ -1,26 +1,28 @@
-/******************************************************************************
- *   @file   lineweight_combobox.h
- **  @author DS Caskey
- **  @date   Nov 2, 2021
- **
- **  @brief
- **  @copyright
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *****************************************************************************/
-
+ //-----------------------------------------------------------------------------
+ //  @file   lineweight_combobox.h
+ //  @author Douglas S Caskey
+ //  @date   14 Mar, 2025
+ //
+ //  @brief
+ //  @copyright
+ //  This source code is part of the Seamly2D project, a pattern making
+ //  program to create and model patterns of clothing.
+ //  Copyright (C) 2017-2025 Seamly2D project
+ //  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+ //
+ //  Seamly2D is free software: you can redistribute it and/or modify
+ //  it under the terms of the GNU General Public License as published by
+ //  the Free Software Foundation, either version 3 of the License, or
+ //  (at your option) any later version.
+ //
+ //  Seamly2D is distributed in the hope that it will be useful,
+ //  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ //  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ //  GNU General Public License for more details.
+ //
+ //  You should have received a copy of the GNU General Public License
+ //  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+ //-----------------------------------------------------------------------------
 
 #ifndef LINEWEIGHT_COMBOBOX_H
 #define LINEWEIGHT_COMBOBOX_H

--- a/src/libs/vwidgets/vabstractmainwindow.cpp
+++ b/src/libs/vwidgets/vabstractmainwindow.cpp
@@ -1,57 +1,54 @@
-/******************************************************************************
- *   @file   vabstractmainwindow.cpp
- **  @author Douglas S Caskey
- **  @date   13 May, 2023
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Seamly2D project, a pattern making
- **  program to create and model patterns of clothing.
- **  Copyright (C) 2017-2023 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vabstractmainwindow.cpp
+//  @author Douglas S Caskey
+//  @date   13 May, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2025 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
-/************************************************************************
- **
- **  @file
- **  @author Valentina Zhuravska <zhuravska19(at)gmail.com>
- **  @date   19 7, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Valentina project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vabstractmainwindow.cpp
+//  @author Valentina Zhuravska <zhuravska19(at)gmail.com>
+//  @date   19 7, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #include "vabstractmainwindow.h"
 #include "../vpropertyexplorer/checkablemessagebox.h"
@@ -100,7 +97,7 @@ bool VAbstractMainWindow::ContinueFormatRewrite(const QString &currentFormatVers
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VAbstractMainWindow::ToolBarStyle(QToolBar *bar)
+void VAbstractMainWindow::initToolBarStyle(QToolBar *bar)
 {
     SCASSERT(bar != nullptr)
     if (qApp->Settings()->getToolBarStyle())
@@ -114,7 +111,7 @@ void VAbstractMainWindow::ToolBarStyle(QToolBar *bar)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VAbstractMainWindow::WindowsLocale()
+void VAbstractMainWindow::setWindowsLocale()
 {
     qApp->Settings()->getOsSeparator() ? setLocale(QLocale()) : setLocale(QLocale::c());
 }

--- a/src/libs/vwidgets/vabstractmainwindow.h
+++ b/src/libs/vwidgets/vabstractmainwindow.h
@@ -1,57 +1,54 @@
-/******************************************************************************
- *   @file   vabstractmainwindow.h
- **  @author Douglas S Caskey
- **  @date   13 May, 2023
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Seamly2D project, a pattern making
- **  program to create and model patterns of clothing.
- **  Copyright (C) 2017-2023 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vabstractmainwindow.h
+//  @author Douglas S Caskey
+//  @date   13 May, 2023
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2025 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
-/************************************************************************
- **
- **  @file
- **  @author Valentina Zhuravska <zhuravska19(at)gmail.com>
- **  @date   19 7, 2016
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2016 Valentina project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vabstractmainwindow.h
+//  @author Valentina Zhuravska <zhuravska19(at)gmail.com>
+//  @date   19 7, 2016
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #ifndef VABSTRACTMAINWINDOW_H
 #define VABSTRACTMAINWINDOW_H
@@ -78,7 +75,7 @@ public slots:
     virtual void  zoomToSelected()=0;
 
 protected slots:
-    void          WindowsLocale();
+    void          setWindowsLocale();
     void          exportToCSV(QString &file);
 
 protected:
@@ -86,10 +83,10 @@ protected:
     QString       m_curFileFormatVersionStr;
 
     bool          ContinueFormatRewrite(const QString &currentFormatVersion, const QString &maxFormatVersion);
-    void          ToolBarStyle(QToolBar *bar);
+    void          initToolBarStyle(QToolBar *bar);
 
     virtual void  exportToCSVData(const QString &fileName, const DialogExportToCSV &dialog)=0;
-    
+
 private:
     Q_DISABLE_COPY(VAbstractMainWindow)
 };


### PR DESCRIPTION
This PR adds the following:

1. Check box in Preferences to only show ISO pen line weights in drop down boxes. 

![image](https://github.com/user-attachments/assets/d0f343a3-ebd1-46e7-a3f1-3c58d220b70b)

2.  Constructs lineweight drop down boxes according to preference.

Box checked:
![image](https://github.com/user-attachments/assets/85c6d7d9-bd9d-4b62-ab38-236d736c3531)

Box unchecked:
![image](https://github.com/user-attachments/assets/04203dc0-4165-4a62-acaf-951a93359715)

3. The default lineweight in the Preferences was changed from the non ISO 1.20mm to 1.00mm.

![image](https://github.com/user-attachments/assets/c4a917c3-bb3b-48ee-9668-f5b795c14535)

4. In the case where the app is set to display only ISO lineweights, and an existing pattern is loaded that uses non ISO lineweights, a default lineweight of 1.00mm (ISO) is used when editing a tool. 

This closes issue #1260 