### PR TITLE
fix: Prevent inserting duplicate point nodes

### DIFF
--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -220,13 +220,14 @@ void PatternPieceTool::insertNodes(const QVector<VPieceNode> &nodes, quint32 pie
             return;
         }
 
-        VPiece newPiece = oldPiece;
+        QVector<VPieceNode> newNodes = removeDuplicateNodePoints(oldPiece, nodes, data);
 
-        for (auto node : nodes)
+        VPiece newPiece = oldPiece;
+        for (auto node : newNodes)
         {
             const quint32 id = PrepareNode(node, scene, doc, data);
-            if (id == NULL_ID)
-            {
+                if (id == NULL_ID)
+                {
                 return;
             }
 
@@ -1959,6 +1960,41 @@ void PatternPieceTool::initializeNode(const VPieceNode &node, VMainGraphicsScene
             qDebug() << "Get wrong tool type. Ignore.";
             break;
     }
+}
+
+/// @brief removeDuplicateNodePoints remove duplcate node points
+///
+///  This method creates a list of nodes that removes duplicate point nodes from a list of selected modes.
+///  Curve nodes are not removed.
+///
+/// @param piece Pattern piece that selected nodes are to be inserted into.
+/// @param nodes List of selected nodes.
+/// @param data Pointer to data container.
+/// @return uniqueNodes Vector of nodes with unique point nodes.
+QVector<VPieceNode> PatternPieceTool::removeDuplicateNodePoints(const VPiece &piece, const QVector<VPieceNode> &nodes,
+                                                                VContainer *data)
+{
+    QVector<quint32> pieceNodeObjIds;
+    const QVector<VPieceNode> pieceNodes = piece.GetPath().GetNodes();
+    for (auto node : pieceNodes)
+    {
+        quint32 id = node.GetId();
+        QSharedPointer<VGObject> object = data->GetGObject(id);
+        const quint32 objectId = object->getIdObject();
+        pieceNodeObjIds.append(objectId);
+    }
+
+    QVector<VPieceNode> uniqueNodes;
+    for (auto node : nodes)
+    {
+        quint32 id = node.GetId();
+        if (node.GetTypeTool() != Tool::NodePoint ||
+           (!pieceNodeObjIds.contains(id) && node.GetTypeTool() == Tool::NodePoint))
+        {
+            uniqueNodes.append(node);
+        }
+    }
+    return uniqueNodes;
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/tools/pattern_piece_tool.h
+++ b/src/libs/vtools/tools/pattern_piece_tool.h
@@ -206,6 +206,8 @@ private:
     static void           initializeNode(const VPieceNode &node, VMainGraphicsScene *scene, VContainer *data,
                                    VAbstractPattern *doc, PatternPieceTool *parent);
 
+    static QVector<VPieceNode>   removeDuplicateNodePoints(const VPiece &piece, const QVector<VPieceNode> &nodes, VContainer *data);
+
     void                  InitCSAPaths(const VPiece &piece);
     void                  InitInternalPaths(const VPiece &piece);
     void                  initializeAnchorPoints(const VPiece &piece);


### PR DESCRIPTION
This PR prevents users from inserting duplicate point nodes when using the Insert Nodes tool. This has no effect on inserting Curve nodes. 

This closes issue #1263 