### PR TITLE
fix: Pattern piece tool shape method

### DIFF
--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -948,9 +948,14 @@ QRectF PatternPieceTool::boundingRect() const
 //---------------------------------------------------------------------------------------------------------------------
 QPainterPath PatternPieceTool::shape() const
 {
+    const VPiece piece = VAbstractTool::data.GetPiece(m_id);
     if (m_mainPath == QPainterPath() && m_cutPath == QPainterPath())
     {
         return QGraphicsPathItem::shape();
+    }
+    else if (piece.isHideSeamLine())
+    {
+        return itemShapeFromPath(m_cutPath, pen());
     }
     else
     {


### PR DESCRIPTION
This PR fixes the issue of the selection area (shape) for a pattern piece that has a zero seam allowance edge, and the seam line hidden when attempting to use the context menu. 

This closes issue #1264 