### PR TITLE
fix: pattern units combobox update

### DIFF
--- a/src/app/seamlyme/application_me.cpp
+++ b/src/app/seamlyme/application_me.cpp
@@ -709,7 +709,7 @@ void ApplicationME::parseCommandLine(const SocketConnection &connection, const Q
 
             if (flagUnit)
             {
-                mainWindow()->SetPUnit(unit);
+                mainWindow()->setPUnit(unit);
             }
         }
     }

--- a/src/app/seamlyme/tmainwindow.cpp
+++ b/src/app/seamlyme/tmainwindow.cpp
@@ -239,10 +239,11 @@ void TMainWindow::SetBaseMSize(int size)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void TMainWindow::SetPUnit(Unit unit)
+void TMainWindow::setPUnit(Unit unit)
 {
 	pUnit = unit;
-	UpdatePatternUnit();
+    setCurrentPatternUnits();
+	updatePatternUnit();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -2147,11 +2148,11 @@ void TMainWindow::SaveMFullName()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void TMainWindow::PatternUnitChanged(int index)
+void TMainWindow::patternUnitsChanged(int index)
 {
 	pUnit = static_cast<Unit>(comboBoxUnits->itemData(index).toInt());
 
-	UpdatePatternUnit();
+	updatePatternUnit();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -3060,7 +3061,7 @@ QStringList TMainWindow::FilterMeasurements(const QStringList &mNew, const QStri
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void TMainWindow::UpdatePatternUnit()
+void TMainWindow::updatePatternUnit()
 {
 	const int row = ui->tableWidget->currentRow();
 
@@ -3380,6 +3381,7 @@ void TMainWindow::initUnits()
 
 	comboBoxUnits = new QComboBox(this);
 	InitComboBoxUnits();
+    setCurrentPatternUnits();
 
 	// set default unit
 	const qint32 indexUnit = comboBoxUnits->findData(static_cast<int>(pUnit));
@@ -3389,9 +3391,23 @@ void TMainWindow::initUnits()
 	}
 
 	connect(comboBoxUnits, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
-			&TMainWindow::PatternUnitChanged);
+			&TMainWindow::patternUnitsChanged);
 
 	ui->toolBarGradation->addWidget(comboBoxUnits);
+}
+
+void TMainWindow::setCurrentPatternUnits()
+{
+    if (comboBoxUnits)
+    {
+        comboBoxUnits->blockSignals(true);
+        const qint32 indexUnit = comboBoxUnits->findData(static_cast<int>(pUnit));
+        if (indexUnit != -1)
+        {
+            comboBoxUnits->setCurrentIndex(indexUnit);
+        }
+        comboBoxUnits->blockSignals(false);
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/app/seamlyme/tmainwindow.h
+++ b/src/app/seamlyme/tmainwindow.h
@@ -88,7 +88,7 @@ public:
 
     void                SetBaseMHeight(int height);
     void                SetBaseMSize(int size);
-    void                SetPUnit(Unit unit);
+    void                setPUnit(Unit unit);
 
     bool                LoadFile(const QString &path);
 
@@ -161,7 +161,7 @@ private slots:
     void                SaveMDescription();
     void                SaveMFullName();
 
-    void                PatternUnitChanged(int index);
+    void                patternUnitsChanged(int index);
 
 private:
     Q_DISABLE_COPY(TMainWindow)
@@ -197,6 +197,7 @@ private:
     void                initializeTable();
     void                SetDecimals();
     void                initUnits();
+    void                setCurrentPatternUnits();
     void                InitComboBoxUnits();
     void                InitGender(QComboBox *gender);
 
@@ -240,7 +241,7 @@ private:
 
     QStringList         FilterMeasurements(const QStringList &mNew, const QStringList &mFilter);
 
-    void                UpdatePatternUnit();
+    void                updatePatternUnit();
 
     bool                LoadFromExistingFile(const QString &path);
 


### PR DESCRIPTION
This PR fixes the updating of the pattern Units combobox in SeamlyMe. 


Closes issue #1280 