### PR TITLE
feature: add piece names as svg group ids

### DIFF
--- a/src/app/seamly2d/mainwindowsnogui.cpp
+++ b/src/app/seamly2d/mainwindowsnogui.cpp
@@ -898,11 +898,11 @@ void MainWindowsNoGUI::exportSVG(const QString &name, QGraphicsRectItem *paper, 
 {
     SvgGenerator svgGenerator(paper, name, doc->GetDescription(), static_cast<int>(PrintDPI));
 
-    for (int pieceNb=0; pieceNb<pieces.size(); pieceNb++)
+    for (int piece = 0; piece < pieces.size(); piece++)
     {
         QGraphicsScene *scene = new VMainGraphicsScene();
-        scene->addItem(pieces.at(pieceNb));
-        svgGenerator.addSvgFromScene(scene);
+        scene->addItem(pieces.at(piece));
+        svgGenerator.addSvgFromScene(scene, pieces.at(piece));
     }
 
     svgGenerator.generate();

--- a/src/libs/vformat/svg_generator.cpp
+++ b/src/libs/vformat/svg_generator.cpp
@@ -35,6 +35,7 @@
 #include <QPainter>
 #include <QBuffer>
 
+static const int ObjectName = 0;
 
 //---------------------------------------------------------------------------------------------------------------------
 SvgGenerator::SvgGenerator(QGraphicsRectItem *paper, QString name, QString description, int resolution):
@@ -44,7 +45,6 @@ SvgGenerator::SvgGenerator(QGraphicsRectItem *paper, QString name, QString descr
     m_resolution(resolution)
 {
 }
-
 
 //---------------------------------------------------------------------------------------------------------------------
 /**
@@ -152,28 +152,45 @@ void SvgGenerator::removeEmptyOriginPath(QDomElement &mainGroup)
     }
 }
 
-
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Clean the SVG
- * @return void
- * @details This function cleans the SVG by removing empty groups and the origin M0,0 path
- */
+//-----------------------------------------------------------------------------
+/// @brief Clean the SVG
+/// @return void
+/// @details This function cleans the SVG by removing empty groups and the origin M0,0 path
+//-----------------------------------------------------------------------------
 void SvgGenerator::cleanSvg(QDomElement &mainGroup)
 {
     removeEmptyGroups(mainGroup);
     removeEmptyOriginPath(mainGroup);
 }
 
+//-----------------------------------------------------------------------------
+/// @brief setAttribute set an attribute in the svg
+///
+/// This method sets an attibute for the 1st elemnent by tag in the svg document.
+///
+/// @param element : the dom document element.
+/// @param attr : attribute name.
+/// @param value : value of the attibute.
+/// @return void
+//-----------------------------------------------------------------------------
+void SvgGenerator::setAttribute(QDomElement element, const QString &attr, const QString &value)
+{
+    if (!element.isNull() && !value.isEmpty())
+    {
+        element.setAttribute(attr, value);
+    }
+}
+
 //---------------------------------------------------------------------------------------------------------------------
 /**
- * @brief Add a new SVG to the list of SVGs to be merged into a single SVG
- * @param scene : the scene that must be converted to SVG
+ * @brief Add a new SVG to the list of SVGs to be merged into a single SVG.
+ * @param scene : the scene that must be converted to SVG.
+ * @param item : graphic item that SVg is being cretaed from. Needed for IS name.
  * @return void
  * @details This function creates a SVG from the given scene and converts it into
             a DOM that is added to the m_domList list of SVGs to be merged.
 */
-void SvgGenerator::addSvgFromScene(QGraphicsScene *scene)
+void SvgGenerator::addSvgFromScene(QGraphicsScene *scene, QGraphicsItem *item)
 {
     QByteArray byteArray;
     QBuffer buffer(&byteArray);
@@ -196,9 +213,20 @@ void SvgGenerator::addSvgFromScene(QGraphicsScene *scene)
     painter.end();
 
     QDomDocument domDoc;
-    if (domDoc.setContent(byteArray)) {
+    if (domDoc.setContent(byteArray))
+    {
+        // set pattern piece name as parent group id name
+        if (item != nullptr)
+        {
+            QDomNodeList list = domDoc.elementsByTagName("g");
+            if (!list.isEmpty())
+            {
+                setAttribute(list.at(0).toElement(), "id", item->data(ObjectName).toString());
+            }
+        }
         m_domList.append(domDoc);
-    } else {
+    } else
+    {
         qDebug() << "Error : Impossible to load the SVG content in the QDomDocument.";
     }
 
@@ -215,8 +243,6 @@ void SvgGenerator::addSvgFromScene(QGraphicsScene *scene)
 */
 void SvgGenerator::generate()
 {
-
-
     QDomDocument mergedSvg = mergeSvgDoms();
 
     QFile outputFile(m_filepath);

--- a/src/libs/vformat/svg_generator.h
+++ b/src/libs/vformat/svg_generator.h
@@ -38,9 +38,8 @@ class SvgGenerator
 {
 public:
     SvgGenerator(QGraphicsRectItem *paper, QString name, QString description, int resolution);
-    void addSvgFromScene(QGraphicsScene *scene);
+    void addSvgFromScene(QGraphicsScene *scene, QGraphicsItem *item = nullptr);
     void generate();
-
 
 private:
     QDomDocument mergeSvgDoms();
@@ -48,6 +47,7 @@ private:
     void removeEmptyGroups(QDomElement &mainGroup);
     void removeEmptyOriginPath(QDomElement &mainGroup);
     void cleanSvg(QDomElement &mainGroup);
+    void setAttribute(QDomElement element, const QString &attr, const QString &value);
 
     QGraphicsRectItem *m_paper;
     QString m_filepath;

--- a/src/libs/vlayout/vlayoutpiece.cpp
+++ b/src/libs/vlayout/vlayoutpiece.cpp
@@ -79,6 +79,8 @@
 #include "vtextmanager.h"
 #include "vgraphicsfillitem.h"
 
+static const int ObjectName = 0;
+
 namespace
 {
 //---------------------------------------------------------------------------------------------------------------------
@@ -1089,6 +1091,8 @@ QPainterPath VLayoutPiece::LayoutAllowancePath() const
 QGraphicsItem *VLayoutPiece::GetItem(bool textAsPaths) const
 {
     QGraphicsPathItem *item = createMainItem();
+    item->setData(ObjectName, GetName());
+
     createAllowanceItem(item);
     createNotchesItem(item);
 
@@ -1186,6 +1190,7 @@ void VLayoutPiece::createLabelItem(QGraphicsItem *parent, const QVector<QPointF>
                 path.addText(0, - static_cast<qreal>(fm.ascent())/6., fnt, qsText);
 
                 QGraphicsPathItem* item = new QGraphicsPathItem(parent);
+                item->setData(ObjectName, QString("label"));
                 item->setPath(path);
                 item->setPen(QPen(color, widthHairLine));
                 item->setBrush(QBrush(Qt::NoBrush));
@@ -1196,6 +1201,7 @@ void VLayoutPiece::createLabelItem(QGraphicsItem *parent, const QVector<QPointF>
             else
             {
                 QGraphicsSimpleTextItem* item = new QGraphicsSimpleTextItem(parent);
+                item->setData(ObjectName, QString("label"));
                 item->setFont(fnt);
                 item->setText(qsText);
                 item->setTransform(labelTransform);
@@ -1219,6 +1225,8 @@ void VLayoutPiece::createGrainlineItem(QGraphicsItem *parent, bool textAsPaths) 
         return;
     }
     VGraphicsFillItem* item = new VGraphicsFillItem(color, textAsPaths, parent);
+    item->setData(ObjectName, QString("grainline"));
+
     QPainterPath path;
 
     QVector<QPointF> gPoints = getGrainline();
@@ -1262,6 +1270,7 @@ QGraphicsPathItem *VLayoutPiece::createMainItem() const
         lineWeight = ToPixel(qApp->Settings()->getDefaultCutLineweight(), Unit::Mm);
     }
     QGraphicsPathItem *item = new QGraphicsPathItem();
+    item->setData(ObjectName, QString("seamline"));
     item->setPath(createMainPath());
     item->setPen(QPen(color, lineWeight, lineTypeToPenStyle(lineType), Qt::RoundCap, Qt::RoundJoin));
     return item;
@@ -1275,6 +1284,7 @@ void VLayoutPiece::createAllowanceItem(QGraphicsItem *parent) const
     qreal   lineWeight = ToPixel(qApp->Settings()->getDefaultCutLineweight(), Unit::Mm);
 
     QGraphicsPathItem *item = new QGraphicsPathItem(parent);
+    item->setData(ObjectName, QString("cutline"));
     item->setPath(createAllowancePath());
     item->setPen(QPen(color, lineWeight, lineTypeToPenStyle(lineType), Qt::RoundCap, Qt::RoundJoin));
 }
@@ -1286,6 +1296,7 @@ void VLayoutPiece::createNotchesItem(QGraphicsItem *parent) const
     qreal  lineWeight = ToPixel(qApp->Settings()->getDefaultCutLineweight(), Unit::Mm);
 
     QGraphicsPathItem *item = new QGraphicsPathItem(parent);
+    item->setData(ObjectName, QString("notches"));
     item->setPath(createNotchesPath());
     item->setPen(QPen(color, lineWeight, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
 }


### PR DESCRIPTION
This PR adds the pattern piece names as a parent group id when exporting an SVG. 

Without pattern piece names:
![Screenshot 2025-05-25 201241](https://github.com/user-attachments/assets/da96657d-03c2-430a-825a-d09102c050f2)

With pattern piece names:
![Screenshot 2025-05-25 200831](https://github.com/user-attachments/assets/ed47ddb3-624a-4e75-9f8f-b8d443186f7b)


This closes issue #1278 