### PR TITLE
Various bug fixes

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -3082,8 +3082,8 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Opravit vzorec</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>Z&amp;rušit</translation>
+        <source>Cancel</source>
+        <translation>Zrušit</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5313,7 +5313,7 @@ Program je poskytován TAK, JAK JE, BEZ JAKÉKOLI ZÁRUKY, VČETNĚ ZÁRUKY DESI
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Soubor</translation>
+        <translation>Soubor</translation>
     </message>
     <message>
         <source>&amp;Help</source>
@@ -5352,16 +5352,16 @@ Program je poskytován TAK, JAK JE, BEZ JAKÉKOLI ZÁRUKY, VČETNĚ ZÁRUKY DESI
         <translation>Uložit</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Uložit</translation>
+        <source>Save</source>
+        <translation>Uložit</translation>
     </message>
     <message>
         <source>Save pattern</source>
         <translation>Uložit střih</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Uložit j&amp;ako...</translation>
+        <source>Save As...</source>
+        <translation>Uložit jako...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5384,12 +5384,12 @@ Program je poskytován TAK, JAK JE, BEZ JAKÉKOLI ZÁRUKY, VČETNĚ ZÁRUKY DESI
         <translation>O &amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;O programu Seamly2D</translation>
+        <source>About Seamly2D</source>
+        <translation>O programu Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
-        <translation>&amp;Ukončit</translation>
+        <translation>Ukončit</translation>
     </message>
     <message>
         <source>Preferences</source>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -3067,8 +3067,8 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Formel festlegen</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Abbrechen</translation>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5337,16 +5337,16 @@ Das Programm wird WIE ES IST, OHNE GEWÄHRLEISTUNG JEGLICHER ART, EINSCHLIESSLIC
         <translation>Speichern</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Speichern</translation>
+        <source>Save</source>
+        <translation>Speichern</translation>
     </message>
     <message>
         <source>Save pattern</source>
         <translation>Schnittmuster speichern</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Speichern &amp;als...</translation>
+        <source>Save As...</source>
+        <translation>Speichern als...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5369,8 +5369,8 @@ Das Programm wird WIE ES IST, OHNE GEWÄHRLEISTUNG JEGLICHER ART, EINSCHLIESSLIC
         <translation>Über &amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;Über Seamly2D</translation>
+        <source>About Seamly2D</source>
+        <translation>Über Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -5808,7 +5808,7 @@ Sollen die Änderungen gespeichert werden?</translation>
     </message>
     <message>
         <source>&amp;Operations</source>
-        <translation>&amp;Abläufe</translation>
+        <translation>Abläufe</translation>
     </message>
     <message>
         <source>Piece</source>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -3082,8 +3082,8 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Επιδιόρθωση φόρμουλας</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Ακύρωση</translation>
+        <source>Cancel</source>
+        <translation>Ακύρωση</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5356,16 +5356,16 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Αποθήκευση</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Αποθήκευση</translation>
+        <source>Save</source>
+        <translation>Αποθήκευση</translation>
     </message>
     <message>
         <source>Save pattern</source>
         <translation>Αποθήκευση πατρόν</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Αποθήκευση &amp;ως...</translation>
+        <source>Save As...</source>
+        <translation>Αποθήκευση ως...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5388,8 +5388,8 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Σχετικά &amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;Σχετικά με το Seamly2D</translation>
+        <source>About Seamly2D</source>
+        <translation>Σχετικά με το Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -3067,8 +3067,8 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Fix formula</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancel</translation>
+        <source>Cancel</source>
+        <translation>Cancel</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5324,16 +5324,16 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Save</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Save</translation>
+        <source>Save</source>
+        <translation>Save</translation>
     </message>
     <message>
         <source>Save pattern</source>
         <translation>Save pattern</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Save &amp;As...</translation>
+        <source>Save As...</source>
+        <translation>Save As...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5356,8 +5356,8 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>About &amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;About Seamly2D</translation>
+        <source>About Seamly2D</source>
+        <translation>About Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
+        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5324,7 +5324,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Save</source>
+        <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5332,7 +5332,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
+        <source>Save As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5356,7 +5356,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
+        <source>About Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -3067,8 +3067,8 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Fix formula</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancel</translation>
+        <source>Cancel</source>
+        <translation>Cancel</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5324,16 +5324,16 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Save</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Save</translation>
+        <source>Save</source>
+        <translation>Save</translation>
     </message>
     <message>
         <source>Save pattern</source>
         <translation>Save pattern</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Save &amp;As...</translation>
+        <source>Save As...</source>
+        <translation>Save As...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5356,8 +5356,8 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>About &amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;About Seamly2D</translation>
+        <source>About Seamly2D</source>
+        <translation>About Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
+        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5324,7 +5324,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Save</source>
+        <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5332,7 +5332,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
+        <source>Save As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5356,7 +5356,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
+        <source>About Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -3100,8 +3100,8 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Reparar fórmula</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5335,11 +5335,11 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Archivo</translation>
+        <translation>Archivo</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>&amp;Ayuda</translation>
+        <translation>Ayuda</translation>
     </message>
     <message>
         <source>Measurements</source>
@@ -5363,7 +5363,7 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;Abrir</translation>
+        <translation>Abrir</translation>
     </message>
     <message>
         <source>Open file with pattern</source>
@@ -5374,16 +5374,12 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
         <translation>Guardar</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Guardar</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Guardar patrón</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Guardar &amp;Como...</translation>
+        <source>Save As...</source>
+        <translation>Guardar Como...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5406,12 +5402,12 @@ El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LA
         <translation>Sobre &amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;Sobre Seamly2D</translation>
+        <source>About Seamly2D</source>
+        <translation>Sobre Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
-        <translation>&amp;Salida</translation>
+        <translation>S&amp;alida</translation>
     </message>
     <message>
         <source>Preferences</source>
@@ -6050,10 +6046,6 @@ Do you want to save your changes?</source>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation>Punto en Curva (O, C)</translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation>Sobre Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -3083,7 +3083,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>&amp;Cancel</source>
-        <translation>&amp;Peru</translation>
+        <translation>Peru</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5319,7 +5319,7 @@ Ohjelma toimitetaan SELLAISENAAN ILMAN MINKÄÄNLAISTA TAKUUTA, MUKAAN LUKIEN SU
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>&amp;Apua</translation>
+        <translation>Apua</translation>
     </message>
     <message>
         <source>Measurements</source>
@@ -5343,7 +5343,7 @@ Ohjelma toimitetaan SELLAISENAAN ILMAN MINKÄÄNLAISTA TAKUUTA, MUKAAN LUKIEN SU
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;Avaa</translation>
+        <translation>Avaa</translation>
     </message>
     <message>
         <source>Open file with pattern</source>
@@ -5351,19 +5351,15 @@ Ohjelma toimitetaan SELLAISENAAN ILMAN MINKÄÄNLAISTA TAKUUTA, MUKAAN LUKIEN SU
     </message>
     <message>
         <source>Save</source>
-        <translation>Talenna</translation>
-    </message>
-    <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Tallenna</translation>
+        <translation>Tallenna</translation>
     </message>
     <message>
         <source>Save pattern</source>
         <translation>Tallenna kaava</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Tallenna &amp;nimellä...</translation>
+        <source>Save As...</source>
+        <translation>Tallenna nimellä...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5386,8 +5382,8 @@ Ohjelma toimitetaan SELLAISENAAN ILMAN MINKÄÄNLAISTA TAKUUTA, MUKAAN LUKIEN SU
         <translation>Tietoja &amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;Tietoja Seamly2Dsta</translation>
+        <source>About Seamly2D</source>
+        <translation>Tietoja Seamly2Dsta</translation>
     </message>
     <message>
         <source>E&amp;xit</source>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -3084,15 +3084,15 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>&amp;Undo</source>
-        <translation>&amp;Annuler</translation>
+        <translation>Annuler</translation>
     </message>
     <message>
         <source>&amp;Fix formula</source>
         <translation>&amp;Corriger la formule</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Annuler</translation>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5334,7 +5334,7 @@ Le programme est fourni &quot;TEL QUEL&quot;sans aucune garantie, y compris la g
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>&amp;Aide</translation>
+        <translation>Aide</translation>
     </message>
     <message>
         <source>Measurements</source>
@@ -5369,16 +5369,12 @@ Le programme est fourni &quot;TEL QUEL&quot;sans aucune garantie, y compris la g
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Enregistrer</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Enregistrer le patron</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Enregistrer &amp;Sous...</translation>
+        <source>Save As...</source>
+        <translation>Enregistrer Sous...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5401,8 +5397,8 @@ Le programme est fourni &quot;TEL QUEL&quot;sans aucune garantie, y compris la g
         <translation>À propos de &amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>À propos de &amp;Seamly2D</translation>
+        <source>About Seamly2D</source>
+        <translation>À propos de Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -5476,7 +5472,7 @@ Voulez-vous sauvegarder les changements?</translation>
     </message>
     <message>
         <source>&amp;Undo</source>
-        <translation>&amp;Annuler</translation>
+        <translation>Annuler</translation>
     </message>
     <message>
         <source>&amp;Redo</source>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
+        <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5321,7 +5321,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>שמור</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
+        <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5329,7 +5329,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>שמירת תבנית</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
+        <source>Save As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5353,7 +5353,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
+        <source>About Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -3082,8 +3082,8 @@ p, li { spasi: pra-bungkus; }
         <translation>&amp;Perbaiki rumus</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Batalkan</translation>
+        <source>Cancel</source>
+        <translation>Batalkan</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5354,16 +5354,16 @@ Program ini disediakan SEBAGAIMANA ADANYA TANPA JAMINAN DALAM BENTUK APA PUN, TE
         <translation>Simpan</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Simpan</translation>
+        <source>Save</source>
+        <translation>Simpan</translation>
     </message>
     <message>
         <source>Save pattern</source>
         <translation>Simpan pola</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Simpan &amp;Sebagai...</translation>
+        <source>Save As...</source>
+        <translation>Simpan Sebagai...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5386,12 +5386,12 @@ Program ini disediakan SEBAGAIMANA ADANYA TANPA JAMINAN DALAM BENTUK APA PUN, TE
         <translation>Tentang &amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;Tentang Seamly2D</translation>
+        <source>About Seamly2D</source>
+        <translation>Tentang Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
-        <translation>&amp;Keluar</translation>
+        <translation>Keluar</translation>
     </message>
     <message>
         <source>Preferences</source>
@@ -5821,7 +5821,7 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation>&amp;Alat</translation>
+        <translation>Alat</translation>
     </message>
     <message>
         <source>&amp;Operations</source>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -3067,8 +3067,8 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Correggi formula</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancel</translation>
+        <source>Cancel</source>
+        <translation>Cancel</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5331,7 +5331,7 @@ Il programma viene fornito così com&apos;è, senza alcuna garanzia di alcun tip
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;Apri</translation>
+        <translation>Apri</translation>
     </message>
     <message>
         <source>Open file with pattern</source>
@@ -5342,16 +5342,16 @@ Il programma viene fornito così com&apos;è, senza alcuna garanzia di alcun tip
         <translation>Salva</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Salva</translation>
+        <source>Save</source>
+        <translation>Salva</translation>
     </message>
     <message>
         <source>Save pattern</source>
         <translation>Salva modello</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Salva &amp;Come...</translation>
+        <source>Save As...</source>
+        <translation>Salva Come...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5374,8 +5374,8 @@ Il programma viene fornito così com&apos;è, senza alcuna garanzia di alcun tip
         <translation>About &amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;About Seamly2D</translation>
+        <source>About Seamly2D</source>
+        <translation>About Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -3067,8 +3067,8 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Verbeter formule</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Stop</translation>
+        <source>Cancel</source>
+        <translation>Stop</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5337,16 +5337,12 @@ Het programma wordt geleverd in de staat waarin het zich bevindt, zonder enige g
         <translation>Opslaan</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Opslaan</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Opslaan patroon</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Opslaan &amp;als...</translation>
+        <source>Save As...</source>
+        <translation>Opslaan als...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5369,8 +5365,8 @@ Het programma wordt geleverd in de staat waarin het zich bevindt, zonder enige g
         <translation>Over &amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;Over Seamly2D</translation>
+        <source>About Seamly2D</source>
+        <translation>Over Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -3067,8 +3067,8 @@ p, li { white-space: pre-wrap; }
         <translation>Fârmula &amp;Fix</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Cancelar</translation>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5301,11 +5301,11 @@ O programa é fornecido NO ESTADO EM QUE SE ENCONTRA, SEM GARANTIA DE QUALQUER T
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Arquivo</translation>
+        <translation>Arquivo</translation>
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>&amp;Ajuda</translation>
+        <translation>Ajuda</translation>
     </message>
     <message>
         <source>Measurements</source>
@@ -5329,7 +5329,7 @@ O programa é fornecido NO ESTADO EM QUE SE ENCONTRA, SEM GARANTIA DE QUALQUER T
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;Abrir</translation>
+        <translation>Abrir</translation>
     </message>
     <message>
         <source>Open file with pattern</source>
@@ -5340,16 +5340,16 @@ O programa é fornecido NO ESTADO EM QUE SE ENCONTRA, SEM GARANTIA DE QUALQUER T
         <translation>Salvar</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Salvar</translation>
+        <source>Save</source>
+        <translation>Salvar</translation>
     </message>
     <message>
         <source>Save pattern</source>
         <translation>Salvar padrâo</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Salvar &amp;Como...</translation>
+        <source>Save As...</source>
+        <translation>Salvar Como...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5372,12 +5372,12 @@ O programa é fornecido NO ESTADO EM QUE SE ENCONTRA, SEM GARANTIA DE QUALQUER T
         <translation>Sobre &amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;Sobre Seamly2D</translation>
+        <source>About Seamly2D</source>
+        <translation>Sobre Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
-        <translation>&amp;Saâda</translation>
+        <translation>Saâda</translation>
     </message>
     <message>
         <source>Preferences</source>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -3075,15 +3075,15 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>&amp;Undo</source>
-        <translation>&amp;Anulare</translation>
+        <translation>Anulare</translation>
     </message>
     <message>
         <source>&amp;Fix formula</source>
         <translation>&amp;Repară formula</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Anulare</translation>
+        <source>Cancel</source>
+        <translation>Anulare</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5321,7 +5321,7 @@ Programul este furnizat CA ATARE, FĂRĂ NICIUN FEL DE GARANȚIE, INCLUSIV GARAN
     </message>
     <message>
         <source>&amp;Help</source>
-        <translation>&amp;Ajutor</translation>
+        <translation>Ajutor</translation>
     </message>
     <message>
         <source>Measurements</source>
@@ -5356,16 +5356,16 @@ Programul este furnizat CA ATARE, FĂRĂ NICIUN FEL DE GARANȚIE, INCLUSIV GARAN
         <translation>Salvează</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Salvează</translation>
+        <source>Save</source>
+        <translation>Salvează</translation>
     </message>
     <message>
         <source>Save pattern</source>
         <translation>Salvează tipar</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Salvează &amp;Ca și.....</translation>
+        <source>Save As...</source>
+        <translation>Salvează Ca și.....</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5388,8 +5388,8 @@ Programul este furnizat CA ATARE, FĂRĂ NICIUN FEL DE GARANȚIE, INCLUSIV GARAN
         <translation>Despre&amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;Despre Seamly2D</translation>
+        <source>About Seamly2D</source>
+        <translation>Despre Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -5463,7 +5463,7 @@ Doriți să salvați modificările?</translation>
     </message>
     <message>
         <source>&amp;Undo</source>
-        <translation>&amp;Anulare</translation>
+        <translation>Anulare</translation>
     </message>
     <message>
         <source>&amp;Redo</source>
@@ -5823,7 +5823,7 @@ Doriți să salvați modificările?</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation>&amp;Instrumente</translation>
+        <translation>Instrumente</translation>
     </message>
     <message>
         <source>&amp;Operations</source>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -3082,8 +3082,8 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Исправить формулу</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Отмена</translation>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5359,16 +5359,12 @@ Seamly2D — это бесплатное программное обеспече
         <translation>Сохранить</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Сохранить</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Сохранить выкройку</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Сохранить &amp;как...</translation>
+        <source>Save As...</source>
+        <translation>Сохранить как...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5391,8 +5387,8 @@ Seamly2D — это бесплатное программное обеспече
         <translation>Про &amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;Про Seamly2D</translation>
+        <source>About Seamly2D</source>
+        <translation>Про Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -3082,8 +3082,8 @@ p, li { boşluk: ön sarma; }
         <translation>&amp;Formülü düzelt</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;İptal</translation>
+        <source>Cancel</source>
+        <translation>İptal</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5343,7 +5343,7 @@ Program, TASARIM, SATILABİLİRLİK VE BELİRLİ BİR AMACA UYGUNLUK GARANTİSİ
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;Aç</translation>
+        <translation>Aç</translation>
     </message>
     <message>
         <source>Open file with pattern</source>
@@ -5354,16 +5354,12 @@ Program, TASARIM, SATILABİLİRLİK VE BELİRLİ BİR AMACA UYGUNLUK GARANTİSİ
         <translation>Kaydet</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Kaydet</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Deseni kaydet</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>&amp;Farklı Kaydet...</translation>
+        <source>Save As...</source>
+        <translation>Farklı Kaydet...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5383,11 +5379,11 @@ Program, TASARIM, SATILABİLİRLİK VE BELİRLİ BİR AMACA UYGUNLUK GARANTİSİ
     </message>
     <message>
         <source>About &amp;Qt</source>
-        <translation>&amp;Qt Hakkında</translation>
+        <translation>Qt Hakkında</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;Seamly2D Hakkında</translation>
+        <source>About Seamly2D</source>
+        <translation>Seamly2D Hakkında</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -5821,7 +5817,7 @@ Do you want to save your changes?</translation>
     </message>
     <message>
         <source>&amp;Tools</source>
-        <translation>&amp;Araçlar</translation>
+        <translation>Araçlar</translation>
     </message>
     <message>
         <source>&amp;Operations</source>
@@ -10936,7 +10932,7 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
     </message>
     <message>
         <source>About &amp;Qt</source>
-        <translation>&amp;Qt Hakkında</translation>
+        <translation>Qt Hakkında</translation>
     </message>
     <message>
         <source>About SeamlyMe</source>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -3082,8 +3082,8 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Виправити формулу</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;Відмінити</translation>
+        <source>Cancel</source>
+        <translation>Відмінити</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5356,16 +5356,12 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Зберегти</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
-        <translation>&amp;Зберегти</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Зберегти лекало</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation>Зберегти &amp;як...</translation>
+        <source>Save As...</source>
+        <translation>Зберегти як...</translation>
     </message>
     <message>
         <source>Save not yet saved pattern</source>
@@ -5388,12 +5384,12 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Про &amp;Qt</translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
-        <translation>&amp;Про Seamly2D</translation>
+        <source>About Seamly2D</source>
+        <translation>Про Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
-        <translation>&amp;Вихід</translation>
+        <translation>Вихід</translation>
     </message>
     <message>
         <source>Preferences</source>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -3067,8 +3067,8 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>&amp;取消</translation>
+        <source>Cancel</source>
+        <translation>取消</translation>
     </message>
     <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
@@ -5321,7 +5321,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>保存</translation>
     </message>
     <message>
-        <source>&amp;Save</source>
+        <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5329,7 +5329,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
+        <source>Save As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5353,7 +5353,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;About Seamly2D</source>
+        <source>About Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.ui
@@ -26,7 +26,7 @@
    <string notr="true">Configuration</string>
   </property>
   <property name="styleSheet">
-   <string notr="true">background-color: rgb(240, 240, 240);</string>
+   <string notr="true"/>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_13">
    <item>
@@ -444,7 +444,7 @@
                </font>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -1049,7 +1049,7 @@
                </font>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
@@ -221,21 +221,22 @@ PreferencesGraphicsViewPage::PreferencesGraphicsViewPage (QWidget *parent)
 
     // Font preferences
     // Pattern piece labels font
-    ui->labelFont_ComboBox->setCurrentFont(qApp->Seamly2DSettings()->getLabelFont());
+    QFont labelFont = qApp->Seamly2DSettings()->getLabelFont();
+    labelFont.setPointSize(12);
+    ui->labelFont_ComboBox->setCurrentFont(labelFont);
+    ui->label_Label->setFont(labelFont);
+
+    connect(ui->labelFont_ComboBox,
+            static_cast<void(QFontComboBox::*)(const QFont &)>(&QFontComboBox::currentFontChanged),
+            this, [this](QFont labelFont)
+    {
+        labelFont.setPointSize(12);
+        ui->label_Label->setFont(labelFont);
+    });
 
     // Point name font
     QFont nameFont = qApp->Seamly2DSettings()->getPointNameFont();
     ui->pointNameFont_ComboBox->setCurrentFont(nameFont);
-    nameFont.setPointSize(12);
-    ui->pointName_Label->setFont(nameFont);
-
-    connect(ui->pointNameFont_ComboBox,
-            static_cast<void(QFontComboBox::*)(const QFont &)>(&QFontComboBox::currentFontChanged),
-            this, [this](QFont nameFont)
-    {
-        nameFont.setPointSize(12);
-        ui->pointName_Label->setFont(nameFont);
-    });
 
     index = ui->pointNameFontSize_ComboBox->findText(QString().setNum(qApp->Seamly2DSettings()->getPointNameSize()));
     if (index != -1)
@@ -243,25 +244,51 @@ PreferencesGraphicsViewPage::PreferencesGraphicsViewPage (QWidget *parent)
         ui->pointNameFontSize_ComboBox->setCurrentIndex(index);
     }
 
+    nameFont.setPointSize(ui->pointNameFontSize_ComboBox->currentText().toInt());
+    ui->pointName_Label->setFont(nameFont);
+
+    connect(ui->pointNameFont_ComboBox,
+            static_cast<void(QFontComboBox::*)(const QFont &)>(&QFontComboBox::currentFontChanged),
+            this, [this](QFont nameFont)
+    {
+        nameFont.setPointSize(ui->pointNameFontSize_ComboBox->currentText().toInt());
+        ui->pointName_Label->setFont(nameFont);
+    });
+
+    connect(ui->pointNameFontSize_ComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]()
+    {
+        QFont labelFont = ui->pointName_Label->font();
+        labelFont.setPointSize(ui->pointNameFontSize_ComboBox->currentText().toInt());
+        ui->pointName_Label->setFont(labelFont);
+    });
+
     // GUI font
     QFont guiFont = qApp->Seamly2DSettings()->getGuiFont();
     ui->guiFont_ComboBox->setCurrentFont(guiFont);
-    guiFont.setPointSize(12);
-    ui->gui_Label->setFont(guiFont);
-
-    connect(ui->guiFont_ComboBox,
-            static_cast<void(QFontComboBox::*)(const QFont &)>(&QFontComboBox::currentFontChanged),
-            this, [this](QFont guiFont)
-    {
-        guiFont.setPointSize(12);
-        ui->gui_Label->setFont(guiFont);
-    });
 
     index = ui->guiFontSize_ComboBox->findText(QString().setNum(qApp->Seamly2DSettings()->getGuiFontSize()));
     if (index != -1)
     {
         ui->guiFontSize_ComboBox->setCurrentIndex(index);
     }
+
+    guiFont.setPointSize(ui->guiFontSize_ComboBox->currentText().toInt());
+    ui->gui_Label->setFont(guiFont);
+
+    connect(ui->guiFont_ComboBox,
+            static_cast<void(QFontComboBox::*)(const QFont &)>(&QFontComboBox::currentFontChanged),
+            this, [this](QFont guiFont)
+    {
+        guiFont.setPointSize(ui->guiFontSize_ComboBox->currentText().toInt());
+        ui->gui_Label->setFont(guiFont);
+    });
+
+    connect(ui->guiFontSize_ComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]()
+    {
+        QFont guiFont = ui->gui_Label->font();
+        guiFont.setPointSize(ui->guiFontSize_ComboBox->currentText().toInt());
+        ui->gui_Label->setFont(guiFont);
+    });
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
@@ -37,7 +37,7 @@
    <string notr="true">Configuration</string>
   </property>
   <property name="styleSheet">
-   <string notr="true">background-color: rgb(240, 240, 240);</string>
+   <string notr="true"/>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -93,7 +93,7 @@
          <property name="minimumSize">
           <size>
            <width>0</width>
-           <height>0</height>
+           <height>170</height>
           </size>
          </property>
          <property name="maximumSize">
@@ -115,7 +115,7 @@
           <item>
            <widget class="QCheckBox" name="toolBarStyle_CheckBox">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -160,7 +160,7 @@
              <item row="0" column="0">
               <widget class="QCheckBox" name="toolsToolbar_CheckBox">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -184,7 +184,7 @@
              <item row="0" column="1">
               <widget class="QCheckBox" name="curveToolbar_CheckBox">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -208,7 +208,7 @@
              <item row="0" column="2">
               <widget class="QCheckBox" name="pieceToolbar_CheckBox">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -232,7 +232,7 @@
              <item row="1" column="0">
               <widget class="QCheckBox" name="pointToolbar_CheckBox">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -256,7 +256,7 @@
              <item row="1" column="1">
               <widget class="QCheckBox" name="arcToolbar_CheckBox">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -280,7 +280,7 @@
              <item row="1" column="2">
               <widget class="QCheckBox" name="detailsToolbar_CheckBox">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -304,7 +304,7 @@
              <item row="2" column="0">
               <widget class="QCheckBox" name="lineToolbar_CheckBox">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -328,7 +328,7 @@
              <item row="2" column="1">
               <widget class="QCheckBox" name="operationToolbar_CheckBox">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -352,7 +352,7 @@
              <item row="2" column="2">
               <widget class="QCheckBox" name="layoutToolbar_CheckBox">
                <property name="sizePolicy">
-                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                  <horstretch>0</horstretch>
                  <verstretch>0</verstretch>
                 </sizepolicy>
@@ -406,6 +406,12 @@
            <layout class="QVBoxLayout" name="verticalLayout_24">
             <item>
              <widget class="QCheckBox" name="useSecondMonitor_CheckBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="text">
                <string>Open on second monitor if available</string>
               </property>
@@ -444,7 +450,7 @@
                    <item>
                     <widget class="QRadioButton" name="ul_RadioButton">
                      <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                        <horstretch>0</horstretch>
                        <verstretch>0</verstretch>
                       </sizepolicy>
@@ -460,7 +466,7 @@
                    <item>
                     <widget class="QRadioButton" name="ur_RadioButton">
                      <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                        <horstretch>0</horstretch>
                        <verstretch>0</verstretch>
                       </sizepolicy>
@@ -476,7 +482,7 @@
                    <item>
                     <widget class="QRadioButton" name="center_RadioButton">
                      <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                        <horstretch>0</horstretch>
                        <verstretch>0</verstretch>
                       </sizepolicy>
@@ -495,7 +501,7 @@
                    <item>
                     <widget class="QRadioButton" name="ll_RadioButton">
                      <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                        <horstretch>0</horstretch>
                        <verstretch>0</verstretch>
                       </sizepolicy>
@@ -511,7 +517,7 @@
                    <item>
                     <widget class="QRadioButton" name="lr_RadioButton">
                      <property name="sizePolicy">
-                      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                        <horstretch>0</horstretch>
                        <verstretch>0</verstretch>
                       </sizepolicy>
@@ -526,6 +532,12 @@
                    </item>
                    <item>
                     <widget class="QRadioButton" name="offset_RadioButton">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
                      <property name="text">
                       <string>Offset</string>
                      </property>
@@ -562,11 +574,20 @@
                    </item>
                    <item row="0" column="1">
                     <widget class="QSpinBox" name="xOffset_SpinBox">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
                      <property name="minimumSize">
                       <size>
                        <width>50</width>
                        <height>0</height>
                       </size>
+                     </property>
+                     <property name="autoFillBackground">
+                      <bool>false</bool>
                      </property>
                      <property name="alignment">
                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -594,11 +615,20 @@
                    </item>
                    <item row="1" column="1">
                     <widget class="QSpinBox" name="yOffset_SpinBox">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
                      <property name="minimumSize">
                       <size>
                        <width>50</width>
                        <height>0</height>
                       </size>
+                     </property>
+                     <property name="autoFillBackground">
+                      <bool>false</bool>
                      </property>
                      <property name="alignment">
                       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -623,7 +653,7 @@
        <item>
         <widget class="QGroupBox" name="outputGroupBox">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -631,7 +661,7 @@
          <property name="minimumSize">
           <size>
            <width>0</width>
-           <height>0</height>
+           <height>60</height>
           </size>
          </property>
          <property name="maximumSize">
@@ -656,7 +686,7 @@
           <item>
            <widget class="QCheckBox" name="graphicsOutput_CheckBox">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
@@ -712,7 +742,7 @@
        <item>
         <widget class="QGroupBox" name="labelFont_GroupBox">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -720,7 +750,7 @@
          <property name="minimumSize">
           <size>
            <width>420</width>
-           <height>0</height>
+           <height>120</height>
           </size>
          </property>
          <property name="font">
@@ -739,7 +769,7 @@
               <property name="minimumSize">
                <size>
                 <width>85</width>
-                <height>0</height>
+                <height>20</height>
                </size>
               </property>
               <property name="maximumSize">
@@ -763,203 +793,21 @@
             </item>
             <item row="0" column="1">
              <widget class="QFontComboBox" name="labelFont_ComboBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="minimumSize">
                <size>
                 <width>0</width>
-                <height>0</height>
+                <height>20</height>
                </size>
-              </property>
-              <property name="font">
-               <font>
-                <pointsize>8</pointsize>
-               </font>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="fontSize_Label">
-              <property name="minimumSize">
-               <size>
-                <width>85</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>Size:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QComboBox" name="labelFontSize_ComboBox">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="currentText">
-               <string notr="true">6</string>
-              </property>
-              <item>
-               <property name="text">
-                <string notr="true">6</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">7</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">8</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">9</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">10</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">10.5</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">11</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">12</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">13</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">14</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">15</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">16</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">18</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">20</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">22</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">24</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">26</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">28</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">32</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">36</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">40</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">44</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">48</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">54</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">60</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">66</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">72</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">80</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string notr="true">96</string>
-               </property>
-              </item>
              </widget>
             </item>
            </layout>
@@ -972,6 +820,11 @@
               <height>0</height>
              </size>
             </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
             <property name="text">
              <string>The quick brown fox jumps over the lazy dog</string>
             </property>
@@ -983,7 +836,7 @@
        <item>
         <widget class="QGroupBox" name="pointNameFont_GroupBox">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -991,7 +844,7 @@
          <property name="minimumSize">
           <size>
            <width>420</width>
-           <height>0</height>
+           <height>120</height>
           </size>
          </property>
          <property name="font">
@@ -1010,7 +863,7 @@
               <property name="minimumSize">
                <size>
                 <width>85</width>
-                <height>0</height>
+                <height>20</height>
                </size>
               </property>
               <property name="maximumSize">
@@ -1034,17 +887,23 @@
             </item>
             <item row="0" column="1">
              <widget class="QFontComboBox" name="pointNameFont_ComboBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="minimumSize">
                <size>
                 <width>200</width>
-                <height>0</height>
+                <height>20</height>
                </size>
               </property>
               <property name="font">
                <font/>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
              </widget>
             </item>
@@ -1053,7 +912,7 @@
               <property name="minimumSize">
                <size>
                 <width>85</width>
-                <height>0</height>
+                <height>20</height>
                </size>
               </property>
               <property name="maximumSize">
@@ -1061,6 +920,11 @@
                 <width>16777215</width>
                 <height>16777215</height>
                </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+               </font>
               </property>
               <property name="text">
                <string>Size:</string>
@@ -1072,11 +936,28 @@
             </item>
             <item row="1" column="1">
              <widget class="QComboBox" name="pointNameFontSize_ComboBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>20</height>
+               </size>
+              </property>
               <property name="maximumSize">
                <size>
                 <width>16777215</width>
                 <height>16777215</height>
                </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+               </font>
               </property>
               <property name="currentText">
                <string notr="true">96</string>
@@ -1241,6 +1122,11 @@
               <height>0</height>
              </size>
             </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
             <property name="text">
              <string>The quick brown fox jumps over the lazy dog</string>
             </property>
@@ -1252,7 +1138,7 @@
        <item>
         <widget class="QGroupBox" name="pointNameFont_GroupBox_2">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -1260,7 +1146,7 @@
          <property name="minimumSize">
           <size>
            <width>420</width>
-           <height>0</height>
+           <height>120</height>
           </size>
          </property>
          <property name="font">
@@ -1279,7 +1165,7 @@
               <property name="minimumSize">
                <size>
                 <width>85</width>
-                <height>0</height>
+                <height>20</height>
                </size>
               </property>
               <property name="maximumSize">
@@ -1303,17 +1189,23 @@
             </item>
             <item row="0" column="1">
              <widget class="QFontComboBox" name="guiFont_ComboBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="minimumSize">
                <size>
                 <width>200</width>
-                <height>0</height>
+                <height>20</height>
                </size>
               </property>
               <property name="font">
                <font/>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
              </widget>
             </item>
@@ -1322,7 +1214,7 @@
               <property name="minimumSize">
                <size>
                 <width>85</width>
-                <height>0</height>
+                <height>20</height>
                </size>
               </property>
               <property name="maximumSize">
@@ -1330,6 +1222,11 @@
                 <width>16777215</width>
                 <height>16777215</height>
                </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+               </font>
               </property>
               <property name="text">
                <string>Size:</string>
@@ -1341,11 +1238,28 @@
             </item>
             <item row="1" column="1">
              <widget class="QComboBox" name="guiFontSize_ComboBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>20</height>
+               </size>
+              </property>
               <property name="maximumSize">
                <size>
                 <width>16777215</width>
                 <height>16777215</height>
                </size>
+              </property>
+              <property name="font">
+               <font>
+                <pointsize>9</pointsize>
+               </font>
               </property>
               <property name="currentText">
                <string notr="true">32</string>
@@ -1510,6 +1424,11 @@
               <height>0</height>
              </size>
             </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
             <property name="text">
              <string>The quick brown fox jumps over the lazy dog</string>
             </property>
@@ -1612,7 +1531,7 @@
                </size>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="maxVisibleItems">
                <number>15</number>
@@ -1673,7 +1592,7 @@
                </size>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="maxVisibleItems">
                <number>15</number>
@@ -1765,7 +1684,7 @@
                </size>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="maxVisibleItems">
                <number>15</number>
@@ -1826,7 +1745,7 @@
                </size>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="maxVisibleItems">
                <number>15</number>
@@ -1918,7 +1837,7 @@
                </size>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="maxVisibleItems">
                <number>15</number>
@@ -2003,7 +1922,7 @@
                </size>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="maxVisibleItems">
                <number>15</number>
@@ -2064,7 +1983,7 @@
                </size>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="maxVisibleItems">
                <number>15</number>
@@ -2125,7 +2044,7 @@
                </size>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="maxVisibleItems">
                <number>15</number>
@@ -2266,7 +2185,7 @@
                </font>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -2323,7 +2242,7 @@
                <string>Scrolling animation duration</string>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -2380,7 +2299,7 @@
                <string>Time in milliseconds between each animation update</string>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -2912,7 +2831,7 @@ border-radius: 4px;
                </font>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp
@@ -61,6 +61,7 @@
 #include <QDate>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QDoubleSpinBox>
 #include <QTime>
 
 namespace
@@ -284,6 +285,8 @@ void PreferencesPatternPage::initializeLabelsTab()
     ui->showPatternLabels_CheckBox->setChecked(qApp->Seamly2DSettings()->showPatternLabels());
     ui->showPieceLabels_CheckBox->setChecked(qApp->Seamly2DSettings()->showPieceLabels());
 
+    setMaxByUnits(ui->defaultLabelWidth_DoubleSpinBox, 20.000);
+    setMaxByUnits(ui->defaultLabelHeight_DoubleSpinBox, 20.000);
     ui->defaultLabelWidth_DoubleSpinBox->setValue(qApp->Seamly2DSettings()->getDefaultLabelWidth());
     ui->defaultLabelWidth_DoubleSpinBox->setSuffix(" " + UnitsToStr(StrToUnits(qApp->Seamly2DSettings()->getUnit()), true));
     ui->defaultLabelHeight_DoubleSpinBox->setValue(qApp->Seamly2DSettings()->getDefaultLabelHeight());
@@ -315,28 +318,8 @@ void PreferencesPatternPage::initializeLabelsTab()
 void PreferencesPatternPage::initNotches()
 {
     const Unit units = StrToUnits(qApp->Seamly2DSettings()->getUnit());
-    switch (units)
-    {
-        case Unit::Cm:
-            {
-                ui->defaultNotchLength_DoubleSpinBox->setMaximum(4);
-                ui->defaultNotchWidth_DoubleSpinBox->setMaximum(1.25);
-                break;
-            }
-        case Unit::Mm:
-            {
-                ui->defaultNotchLength_DoubleSpinBox->setMaximum(40);
-                ui->defaultNotchWidth_DoubleSpinBox->setMaximum(12.50);
-                break;
-            }
-        case Unit::Inch:
-        default:
-            {
-                ui->defaultNotchLength_DoubleSpinBox->setMaximum(1.50);
-                ui->defaultNotchWidth_DoubleSpinBox->setMaximum(.50);
-                break;
-            }
-    }
+    setMaxByUnits(ui->defaultNotchLength_DoubleSpinBox, 1.50);
+    setMaxByUnits(ui->defaultNotchWidth_DoubleSpinBox, 0.50);
 
     ui->defaultNotchType_ComboBox->addItem(QIcon(), tr("Slit"),       "slit");
     ui->defaultNotchType_ComboBox->addItem(QIcon(), tr("T Notch"),    "tNotch");
@@ -369,6 +352,8 @@ void PreferencesPatternPage::initNotches()
 //---------------------------------------------------------------------------------------------------------------------
 void PreferencesPatternPage::initGrainlines()
 {
+    setMaxByUnits(ui->defaultGrainlineLength_DoubleSpinBox, 20.000);
+
     ui->showGrainlines_CheckBox->setChecked(qApp->Seamly2DSettings()->getDefaultGrainlineVisibilty());
 
     ui->defaultGrainlineLength_DoubleSpinBox->setValue(qApp->Seamly2DSettings()->getDefaultGrainlineLength());
@@ -430,4 +415,29 @@ void PreferencesPatternPage::callDateTimeFormatEditor(const T &type, const QStri
             box->setCurrentIndex(0);
         }
     }
+}
+
+void PreferencesPatternPage::setMaxByUnits(QDoubleSpinBox *box, const qreal &value)
+{
+    const Unit units = StrToUnits(qApp->Seamly2DSettings()->getUnit());
+    switch (units)
+    {
+        case Unit::Cm:
+            {
+                box->setMaximum(value * 2.54);
+                break;
+            }
+        case Unit::Mm:
+            {
+                box->setMaximum(value * 25.40);
+                break;
+            }
+        case Unit::Inch:
+        default:
+            {
+                box->setMaximum(value);
+                break;
+            }
+    }
+
 }

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.h
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.h
@@ -64,6 +64,7 @@ namespace Ui
 }
 
 class QComboBox;
+class QDoubleSpinBox;
 
 class PreferencesPatternPage : public QWidget
 {
@@ -95,6 +96,8 @@ private:
     template <typename T>
     void          callDateTimeFormatEditor(const T &type, const QStringList &predefinedFormats,
                                            const QStringList &userDefinedFormats, QComboBox *box);
+
+    void          setMaxByUnits(QDoubleSpinBox *box, const qreal &value);
 };
 
 #endif // PREFERENCESPATTERNPAGE_H

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
@@ -31,8 +31,11 @@
   <property name="windowTitle">
    <string notr="true">Pattern</string>
   </property>
+  <property name="autoFillBackground">
+   <bool>false</bool>
+  </property>
   <property name="styleSheet">
-   <string notr="true">background-color: rgb(240, 240, 240);</string>
+   <string notr="true"/>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_25">
    <item>
@@ -342,6 +345,9 @@
                   <pointsize>9</pointsize>
                  </font>
                 </property>
+                <property name="styleSheet">
+                 <string notr="true"/>
+                </property>
                 <property name="currentIndex">
                  <number>-1</number>
                 </property>
@@ -395,6 +401,9 @@
                 </property>
                 <property name="font">
                  <font/>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true"/>
                 </property>
                </widget>
               </item>
@@ -474,7 +483,7 @@
                  </font>
                 </property>
                 <property name="styleSheet">
-                 <string notr="true">background-color: rgb(255, 255, 255);</string>
+                 <string notr="true"/>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -572,7 +581,7 @@
                  </font>
                 </property>
                 <property name="styleSheet">
-                 <string notr="true">background-color: rgb(255, 255, 255);</string>
+                 <string notr="true"/>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -639,7 +648,7 @@
          <x>10</x>
          <y>10</y>
          <width>420</width>
-         <height>174</height>
+         <height>180</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -651,7 +660,7 @@
        <property name="minimumSize">
         <size>
          <width>420</width>
-         <height>160</height>
+         <height>180</height>
         </size>
        </property>
        <property name="maximumSize">
@@ -756,7 +765,7 @@
              </font>
             </property>
             <property name="styleSheet">
-             <string notr="true">background-color: rgb(255, 255, 255);</string>
+             <string notr="true"/>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -841,6 +850,9 @@
               <pointsize>9</pointsize>
              </font>
             </property>
+            <property name="styleSheet">
+             <string notr="true"/>
+            </property>
            </widget>
           </item>
           <item>
@@ -912,6 +924,9 @@
               <pointsize>9</pointsize>
              </font>
             </property>
+            <property name="styleSheet">
+             <string notr="true"/>
+            </property>
            </widget>
           </item>
           <item>
@@ -946,6 +961,17 @@
               <height>0</height>
              </size>
             </property>
+            <property name="maximumSize">
+             <size>
+              <width>120</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+             </font>
+            </property>
             <property name="text">
              <string>Arrow length:</string>
             </property>
@@ -959,8 +985,11 @@
             <property name="minimumSize">
              <size>
               <width>200</width>
-              <height>0</height>
+              <height>20</height>
              </size>
+            </property>
+            <property name="styleSheet">
+             <string notr="true"/>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -1096,7 +1125,7 @@
              </font>
             </property>
             <property name="styleSheet">
-             <string notr="true">background-color: rgb(255, 255, 255);</string>
+             <string notr="true"/>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -1245,6 +1274,9 @@
                   <pointsize>9</pointsize>
                  </font>
                 </property>
+                <property name="styleSheet">
+                 <string notr="true"/>
+                </property>
                </widget>
               </item>
               <item>
@@ -1309,6 +1341,9 @@
                  <font>
                   <pointsize>9</pointsize>
                  </font>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true"/>
                 </property>
                </widget>
               </item>
@@ -1380,6 +1415,9 @@
                  <font>
                   <pointsize>9</pointsize>
                  </font>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true"/>
                 </property>
                </widget>
               </item>
@@ -2179,7 +2217,7 @@
                </font>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -2277,7 +2315,7 @@
                </font>
               </property>
               <property name="styleSheet">
-               <string notr="true">background-color: rgb(255, 255, 255);</string>
+               <string notr="true"/>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -2349,6 +2387,9 @@
                <font>
                 <pointsize>9</pointsize>
                </font>
+              </property>
+              <property name="styleSheet">
+               <string notr="true"/>
               </property>
              </widget>
             </item>
@@ -2449,6 +2490,9 @@
                   <pointsize>9</pointsize>
                  </font>
                 </property>
+                <property name="styleSheet">
+                 <string notr="true"/>
+                </property>
                </widget>
               </item>
               <item>
@@ -2531,6 +2575,9 @@
                  <font>
                   <pointsize>9</pointsize>
                  </font>
+                </property>
+                <property name="styleSheet">
+                 <string notr="true"/>
                 </property>
                </widget>
               </item>
@@ -2619,7 +2666,11 @@
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QLineEdit" name="patternTemplate_LineEdit"/>
+             <widget class="QLineEdit" name="patternTemplate_LineEdit">
+              <property name="styleSheet">
+               <string notr="true"/>
+              </property>
+             </widget>
             </item>
             <item row="0" column="2">
              <widget class="QToolButton" name="patternTemplate_ToolButton">
@@ -2654,7 +2705,11 @@
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QLineEdit" name="pieceTemplate_LineEdit"/>
+             <widget class="QLineEdit" name="pieceTemplate_LineEdit">
+              <property name="styleSheet">
+               <string notr="true"/>
+              </property>
+             </widget>
             </item>
             <item row="1" column="2">
              <widget class="QToolButton" name="pieceTemplate_ToolButton">

--- a/src/app/seamly2d/mainwindow.ui
+++ b/src/app/seamly2d/mainwindow.ui
@@ -2681,7 +2681,7 @@
     <string>Save</string>
    </property>
    <property name="iconText">
-    <string>&amp;Save</string>
+    <string>Save</string>
    </property>
    <property name="toolTip">
     <string>Save pattern</string>
@@ -2702,7 +2702,7 @@
      <normaloff>.</normaloff>.</iconset>
    </property>
    <property name="text">
-    <string>Save &amp;As...</string>
+    <string>Save As...</string>
    </property>
    <property name="toolTip">
     <string>Save not yet saved pattern</string>
@@ -3320,7 +3320,7 @@
     <string>Spline - Interactive (Alt+S)</string>
    </property>
    <property name="shortcut">
-    <string notr="true">Alt+S</string>
+    <string>Alt+S</string>
    </property>
   </action>
   <action name="pointAlongSpline_Action">
@@ -3568,7 +3568,7 @@
      <normaloff>:/icon/logos/seamly_logo_32.png</normaloff>:/icon/logos/seamly_logo_32.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;About Seamly2D</string>
+    <string>About Seamly2D</string>
    </property>
    <property name="toolTip">
     <string>About Seamly2D</string>

--- a/src/libs/ifc/xml/vabstractpattern.cpp
+++ b/src/libs/ifc/xml/vabstractpattern.cpp
@@ -71,6 +71,7 @@
 #include "../vmisc/vabstractapplication.h"
 #include "../vpatterndb/vcontainer.h"
 #include "../vpatterndb/vpiecenode.h"
+#include "../vtools/tools/vabstracttool.h"
 #include "../vtools/tools/vdatatool.h"
 
 #include <QDomNode>
@@ -2835,6 +2836,9 @@ QDomElement VAbstractPattern::removeGroupItem(quint32 toolId, quint32 objectId, 
                         if (!groups.isNull())
                         {
                             parseGroups(groups);
+
+                            VAbstractTool *tool = qobject_cast<VAbstractTool *>(VAbstractPattern::getTool(toolId));
+                            tool->GroupVisibility(objectId, true);
                         }
 
                         return item;

--- a/src/libs/vgeometry/vabstractcubicbezierpath.cpp
+++ b/src/libs/vgeometry/vabstractcubicbezierpath.cpp
@@ -58,6 +58,7 @@
 #include "../ifc/exception/vexception.h"
 #include "vpointf.h"
 #include "vspline.h"
+#include "vsplinepoint.h"
 
 //---------------------------------------------------------------------------------------------------------------------
 VAbstractCubicBezierPath::VAbstractCubicBezierPath(const GOType &type, const quint32 &idObject, const Draw &mode)
@@ -226,7 +227,36 @@ QPointF VAbstractCubicBezierPath::CutSplinePath(qreal length, qint32 &p1, qint32
         {
             p1 = i-1;
             p2 = i;
-            return spl.CutSpline(length - (fullLength - splLength), spl1p2, spl1p3, spl2p2, spl2p3);
+            const QPointF point = spl.CutSpline(length - (fullLength - splLength), spl1p2, spl1p3, spl2p2, spl2p3);
+            const QVector<VSplinePoint> points = GetSplinePath();
+
+            if (p1 > 0)
+            {
+                const VSplinePoint &splP1 = points.at(p1);
+                QLineF const line(splP1.P().toQPointF(), spl1p2);
+                if (qFuzzyIsNull(line.length()))
+                {
+                    spl1p2.rx() += ToPixel(0.1, Unit::Mm);
+                    QLineF line(splP1.P().toQPointF(), spl1p2);
+                    line.setLength(ToPixel(0.1, Unit::Mm));
+                    line.setAngle(splP1.Angle1() + 180);
+                    spl1p2 = line.p2();
+                }
+            }
+
+            if (p2 < points.size() - 1)
+            {
+                const VSplinePoint &splP2 = points.at(p2);
+                QLineF const line(splP2.P().toQPointF(), spl2p3);
+                if (qFuzzyIsNull(line.length()))
+                {
+                    spl2p3.rx() += ToPixel(0.1, Unit::Mm);
+                    QLineF line(splP2.P().toQPointF(), spl2p3);
+                    line.setAngle(splP2.Angle2() + 180);
+                    spl2p3 = line.p2();
+                }
+            }
+            return point;
         }
     }
     p1 = p2 = -1;

--- a/src/libs/vtools/dialogs/support/dialogundo.ui
+++ b/src/libs/vtools/dialogs/support/dialogundo.ui
@@ -55,7 +55,7 @@
        <item>
         <widget class="QPushButton" name="pushButtonCancel">
          <property name="text">
-          <string>&amp;Cancel</string>
+          <string>Cancel</string>
          </property>
         </widget>
        </item>

--- a/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.cpp
@@ -1280,9 +1280,9 @@ VPiecePath InternalPathDialog::createPath() const
     const bool isInternalPath = (getType() == PiecePathType::InternalPath);
     path.setType(getType());
     path.setName(ui->pathName_LineEdit->text());
-    path.setLineColor(isInternalPath ? getLineColor() : "Black");
+    path.setLineColor(isInternalPath ? getLineColor() : "black");
     path.setLineType(isInternalPath ? getLineType() : Qt::SolidLine);
-    path.setLineWeight(isInternalPath ? getLineWeight() :"1.00");
+    path.setLineWeight(isInternalPath ? getLineWeight() :"1");
     path.setCutPath(isInternalPath ? isCutPath() : false);
     path.setExtendStartPoint(isInternalPath ? ui->extendStartPoint_CheckBox->isChecked() : false);
     path.setExtendEndPoint(isInternalPath ? ui->extendEndPoint_CheckBox->isChecked() : false);

--- a/src/libs/vtools/undocommands/remove_groupitem.cpp
+++ b/src/libs/vtools/undocommands/remove_groupitem.cpp
@@ -69,7 +69,7 @@ void RemoveGroupItem::undo()
         emit qApp->getCurrentDocument()->patternChanged(true);
 
         QDomElement groups = doc->createGroups();
-        if (not groups.isNull())
+        if (!groups.isNull())
         {
             doc->parseGroups(groups);
         } else
@@ -78,7 +78,8 @@ void RemoveGroupItem::undo()
             return;
         }
 
-        emit updateGroups();
+        //emit updateGroups();
+        emit NeedFullParsing();
     }
     else
     {
@@ -116,7 +117,7 @@ void RemoveGroupItem::redo()
         tool->GroupVisibility(objectId,true);
 
         QDomElement groups = doc->createGroups();
-        if (not groups.isNull())
+        if (!groups.isNull())
         {
             doc->parseGroups(groups);
         } else
@@ -125,7 +126,8 @@ void RemoveGroupItem::redo()
             return;
         }
 
-        emit updateGroups();
+        //emit updateGroups();
+        emit NeedFullParsing();
     }
     else
     {


### PR DESCRIPTION
This PR fixes the following bugs:

- Overloaded Shortcuts... specifically Alt+S
- Point - On Spline segments
- Doublespin box max values for cm and mm units
- Application preferences when system Dark mode is used
- Line attributes when a Custom Seam Allowance is used
- Fixes visibilty of objects removed from a hidden group

This closes issue #1228, issue #1295, issue #1294, issue #1293, issue #1296, issue #1297

