### PR TITLE
fix: enable variables table in piece mode

### DIFF
--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -4678,7 +4678,7 @@ void MainWindow::setWidgetsEnabled(bool enable)
     ui->loadIndividual_Action->setEnabled(enable && designStage);
     ui->loadMultisize_Action->setEnabled(enable && designStage);
     ui->unloadMeasurements_Action->setEnabled(enable && designStage);
-    ui->table_Action->setEnabled(enable && draftStage);
+    ui->table_Action->setEnabled(enable && designStage);
 
     //enable history menu actions
     ui->history_Action->setEnabled(enable && draftStage);


### PR DESCRIPTION
This RR enables the Variables Table in Piece Mode. 

Closes issue #1299 