### PR TITLE
feature:  update search in history and seamlyme

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -4317,6 +4317,26 @@ Chcete si ji stáhnout?</translation>
         <source>Can&apos;t create record.</source>
         <translation>Záznam nelze vytvořit.</translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation>Najít předchozí</translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation>Najít další</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Rozlišují se malá a velká písmena</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Hledejte podle celého slova</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>vyhledávání podle regulárního výrazu</translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -5352,10 +5372,6 @@ Program je poskytován TAK, JAK JE, BEZ JAKÉKOLI ZÁRUKY, VČETNĚ ZÁRUKY DESI
         <translation>Uložit</translation>
     </message>
     <message>
-        <source>Save</source>
-        <translation>Uložit</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Uložit střih</translation>
     </message>
@@ -6028,10 +6044,6 @@ Chcete uložit své změny?</translation>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation>Bod na křivce (O, C)</translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation>O programu Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11404,6 +11416,18 @@ SeamlyME jako obvykle.
     <message>
         <source>Convert 3DLook file:</source>
         <translation>Převést soubor 3DLook:</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Rozlišují se malá a velká písmena</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Hledejte podle celého slova</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>vyhledávání podle regulárního výrazu</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -4302,6 +4302,26 @@ Möchten Sie sie herunterladen?</translation>
         <source>ElArc_</source>
         <translation>ElBogen_</translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation>Vorheriges finden</translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation>Nächstes finden</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Groß- und Kleinschreibung beachten</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Suche nach vollständigem Wort</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Suche nach regulären Ausdrücken</translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -5337,10 +5357,6 @@ Das Programm wird WIE ES IST, OHNE GEWÄHRLEISTUNG JEGLICHER ART, EINSCHLIESSLIC
         <translation>Speichern</translation>
     </message>
     <message>
-        <source>Save</source>
-        <translation>Speichern</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Schnittmuster speichern</translation>
     </message>
@@ -6013,10 +6029,6 @@ Sollen die Änderungen gespeichert werden?</translation>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation>Punkt auf Kurve (O, C)</translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation>Über Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11389,6 +11401,18 @@ wie gewohnt in SeamlyME laden können.
     <message>
         <source>Convert 3DLook file:</source>
         <translation>3DLook-Datei konvertieren:</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Groß- und Kleinschreibung beachten</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Suche nach vollständigem Wort</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Suche nach regulären Ausdrücken</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -4321,6 +4321,26 @@ Do you want to download it?</source>
         <source>Can&apos;t create record.</source>
         <translation>Δεν είναι δυνατή η δημιουργία εγγραφής.</translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation>Εύρεση προηγούμενου</translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation>Εύρεση επόμενου</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Διάκριση πεζών-κεφαλαίων</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Αναζήτηση με πλήρη λέξη</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Αναζήτηση με κανονική έκφραση</translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -5356,10 +5376,6 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Αποθήκευση</translation>
     </message>
     <message>
-        <source>Save</source>
-        <translation>Αποθήκευση</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Αποθήκευση πατρόν</translation>
     </message>
@@ -6032,10 +6048,6 @@ Do you want to save your changes?</source>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation>Σημείο στην καμπύλη (O, C)</translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation>Σχετικά με το Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11408,6 +11420,18 @@ load in SeamlyME as usual.
     <message>
         <source>Convert 3DLook file:</source>
         <translation>Μετατροπή αρχείου 3DLook:</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Διάκριση πεζών-κεφαλαίων</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Αναζήτηση με πλήρη λέξη</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Αναζήτηση με κανονική έκφραση</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -4299,6 +4299,26 @@ Do you want to download it?</source>
         <source>Can&apos;t create record.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -5324,10 +5344,6 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Save</translation>
     </message>
     <message>
-        <source>Save</source>
-        <translation>Save</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Save pattern</translation>
     </message>
@@ -6000,10 +6016,6 @@ Do you want to save your changes?</translation>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation type="unfinished">About Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11368,6 +11380,18 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Convert 3DLook file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -4299,6 +4299,26 @@ Do you want to download it?</source>
         <source>Can&apos;t create record.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -5324,10 +5344,6 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5357,7 +5373,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
     </message>
     <message>
         <source>About Seamly2D</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">About Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -6000,10 +6016,6 @@ Do you want to save your changes?</translation>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation type="unfinished">About Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11368,6 +11380,18 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Convert 3DLook file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -4299,6 +4299,26 @@ Do you want to download it?</source>
         <source>Can&apos;t create record.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -5324,10 +5344,6 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>Save</translation>
     </message>
     <message>
-        <source>Save</source>
-        <translation>Save</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Save pattern</translation>
     </message>
@@ -6000,10 +6016,6 @@ Do you want to save your changes?</translation>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation type="unfinished">About Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11368,6 +11380,18 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Convert 3DLook file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -4299,6 +4299,26 @@ Do you want to download it?</source>
         <source>Can&apos;t create record.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -5324,10 +5344,6 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5357,7 +5373,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
     </message>
     <message>
         <source>About Seamly2D</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">About Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -6000,10 +6016,6 @@ Do you want to save your changes?</translation>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation type="unfinished">About Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11368,6 +11380,18 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Convert 3DLook file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -4339,6 +4339,26 @@ Do you want to download it?</source>
         <source>Can&apos;t create record.</source>
         <translation>No se puede crear el registro.</translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation>Buscar anterior</translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation>Buscar siguiente</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Distingue mayúsculas y minúsculas</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Buscar por palabra completa</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Búsqueda por expresión regular</translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -11438,6 +11458,18 @@ load in SeamlyME as usual.
     <message>
         <source>Convert 3DLook file:</source>
         <translation>Convertir archivo 3DLook:</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Distingue mayúsculas y minúsculas</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Buscar por palabra completa</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Búsqueda por expresión regular</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -3082,12 +3082,12 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Korjaa matemaattinen kaava</translation>
     </message>
     <message>
-        <source>&amp;Cancel</source>
-        <translation>Peru</translation>
-    </message>
-    <message>
         <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
         <translation>Kaavaa laskettaessa tapahtui virhe. Voit yrittää kumota viimeisimmän operaation tai korjata rikkinäisen kaavan.</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>Peruuttaa</translation>
     </message>
 </context>
 <context>
@@ -4318,6 +4318,26 @@ Haluatko ladata sen?</translation>
     <message>
         <source>Can&apos;t create record.</source>
         <translation>Tietuetta ei voida luoda.</translation>
+    </message>
+    <message>
+        <source>Find previous</source>
+        <translation>Etsi edellinen</translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation>Etsi seuraava</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Kirjainkoolla on merkitystä</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Hae koko sanalla</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Hae säännöllisen lausekkeen avulla</translation>
     </message>
 </context>
 <context>
@@ -6026,10 +6046,6 @@ Haluatko tallentaa muutokset?</translation>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation>Piste käyrällä (O, C)</translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation>Tietoja Seamly2Dsta</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11402,6 +11418,18 @@ Haluatko tallentaa muutokset?</translation>
         <source>female</source>
         <comment>gender</comment>
         <translation>nainen</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Kirjainkoolla on merkitystä</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Hae koko sanalla</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Hae säännöllisen lausekkeen avulla</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -3289,7 +3289,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Custom Variables</source>
-        <translation type="unfinished">Variables
+        <translation>Variables
 personnalisées</translation>
     </message>
     <message>
@@ -3310,7 +3310,7 @@ personnalisées</translation>
     </message>
     <message>
         <source> Control Point Lengths</source>
-        <translation type="unfinished"> Longueur des
+        <translation> Longueur des
 points de contrôle</translation>
     </message>
     <message>
@@ -4332,6 +4332,26 @@ Voulez-vous la télécharger ?</translation>
     <message>
         <source>Can&apos;t create record.</source>
         <translation>Impossible de créer un enregistrement.</translation>
+    </message>
+    <message>
+        <source>Find previous</source>
+        <translation>Rechercher le précédent</translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation>Trouver la suite</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Sensible aux majuscules et minuscules</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Recherche par mot complet</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Recherche par expression régulière</translation>
     </message>
 </context>
 <context>
@@ -6041,10 +6061,6 @@ Voulez-vous sauvegarder les changements?</translation>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation>Point sur la courbe (O, C)</translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation>À propos de Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11418,6 +11434,18 @@ charger dans SeamlyME comme d&apos;habitude.
     <message>
         <source>Convert 3DLook file:</source>
         <translation>Convertir le fichier 3DLook:</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Sensible aux majuscules et minuscules</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Recherche par mot complet</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Recherche par expression régulière</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -4299,6 +4299,26 @@ Do you want to download it?</source>
         <source>Can&apos;t create record.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -5321,10 +5341,6 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>שמור</translation>
     </message>
     <message>
-        <source>Save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>שמירת תבנית</translation>
     </message>
@@ -5995,10 +6011,6 @@ Do you want to save your changes?</source>
     </message>
     <message>
         <source>Point on Curve (O, C)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -11363,6 +11375,18 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Convert 3DLook file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -4319,6 +4319,26 @@ Apakah Anda ingin mengunduhnya?</translation>
         <source>Can&apos;t create record.</source>
         <translation>Tidak dapat membuat rekaman.</translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation>Temukan sebelumnya</translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation>Temukan berikutnya</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Peka huruf besar-kecil</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Cari berdasarkan kata lengkap</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Pencarian dengan ekspresi reguler</translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -5354,10 +5374,6 @@ Program ini disediakan SEBAGAIMANA ADANYA TANPA JAMINAN DALAM BENTUK APA PUN, TE
         <translation>Simpan</translation>
     </message>
     <message>
-        <source>Save</source>
-        <translation>Simpan</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Simpan pola</translation>
     </message>
@@ -6030,10 +6046,6 @@ Apakah anda ingin menyimpan perubahan anda?</translation>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation>Titik pada Kurva (O, C)</translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation>Mengenai Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11406,6 +11418,18 @@ unggah ke SeamlyME seperti biasa.
     <message>
         <source>Convert 3DLook file:</source>
         <translation>Konversi file 3DLook:</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Peka huruf besar-kecil</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Cari berdasarkan kata lengkap</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Pencarian dengan ekspresi reguler</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -3286,7 +3286,7 @@ di controllo</translation>
     </message>
     <message>
         <source> Control Point Lengths</source>
-        <translation type="unfinished"> Lunghezze dei
+        <translation> Lunghezze dei
 punti di controllo</translation>
     </message>
     <message>
@@ -4305,6 +4305,26 @@ Volete scaricarla?</translation>
     <message>
         <source>Can&apos;t create record.</source>
         <translation>Impossibile creare il record.</translation>
+    </message>
+    <message>
+        <source>Find previous</source>
+        <translation>Trova precedente</translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation>Trova il prossimo</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Maiuscole e minuscole</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Cerca per parola intera</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Ricerca tramite espressione regolare</translation>
     </message>
 </context>
 <context>
@@ -5342,10 +5362,6 @@ Il programma viene fornito così com&apos;è, senza alcuna garanzia di alcun tip
         <translation>Salva</translation>
     </message>
     <message>
-        <source>Save</source>
-        <translation>Salva</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Salva modello</translation>
     </message>
@@ -6018,10 +6034,6 @@ Vuoi salvare i cambiamenti?</translation>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation>Punto sulla curva (O, C)</translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation>Informazioni su Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11394,6 +11406,18 @@ caricare in SeamlyME come di consueto.
     <message>
         <source>Convert 3DLook file:</source>
         <translation>Convertire file 3DLook:</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Maiuscole e minuscole</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Cerca per parola intera</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Ricerca tramite espressione regolare</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -4302,6 +4302,26 @@ Wilt u deze downloaden?</translation>
         <source>Can&apos;t create record.</source>
         <translation>Kan geen record aanmaken.</translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation>Vind vorige</translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation>Vind volgende</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Hoofdlettergevoelig</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Zoek op volledig woord</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Zoeken op reguliere expressie</translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -6009,10 +6029,6 @@ Wil je de veranderingen opslaan?</translation>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation>Punt op de curve (O, C)</translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation>Over Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11386,6 +11402,18 @@ load in SeamlyME as usual.
     <message>
         <source>Convert 3DLook file:</source>
         <translation>3DLook-bestand converteren:</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Hoofdlettergevoelig</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Zoek op volledig woord</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Zoeken op reguliere expressie</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -4305,6 +4305,26 @@ Deseja descarregá-la?</translation>
         <source>Can&apos;t create record.</source>
         <translation>Nâo â possâvel criar registro.</translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation>Encontrar anterior</translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation>Encontre o prâximo</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Maiúsculas e minúsculas</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Pesquise por palavra completa</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Pesquisar por expressão regular</translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -5340,10 +5360,6 @@ O programa é fornecido NO ESTADO EM QUE SE ENCONTRA, SEM GARANTIA DE QUALQUER T
         <translation>Salvar</translation>
     </message>
     <message>
-        <source>Save</source>
-        <translation>Salvar</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Salvar padrâo</translation>
     </message>
@@ -6016,10 +6032,6 @@ Pretende guardar as suas alterações?</translation>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation>Ponto na curva (O, C)</translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation>Sobre Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11392,6 +11404,18 @@ carregar no SeamlyME como de costume.
     <message>
         <source>Convert 3DLook file:</source>
         <translation>Converter arquivo 3DLook:</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Maiúsculas e minúsculas</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Pesquise por palavra completa</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Pesquisar por expressão regular</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -4321,6 +4321,26 @@ Doriți să o descărcați?</translation>
         <source>Can&apos;t create record.</source>
         <translation>Nu se poate crea înregistrarea.</translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation>Găsește anterioară</translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation>Găsește următorul</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Caz sensibil</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Căutați după cuvânt complet</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Căutare prin expresie regulată</translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -5356,10 +5376,6 @@ Programul este furnizat CA ATARE, FĂRĂ NICIUN FEL DE GARANȚIE, INCLUSIV GARAN
         <translation>Salvează</translation>
     </message>
     <message>
-        <source>Save</source>
-        <translation>Salvează</translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation>Salvează tipar</translation>
     </message>
@@ -6032,10 +6048,6 @@ Doriți să salvați modificările?</translation>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation>Punct pe curbă (O, C)</translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation>Despre Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11407,6 +11419,18 @@ load in SeamlyME as usual.
     <message>
         <source>Convert 3DLook file:</source>
         <translation>Convertiți fișierul 3DLook:</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Caz sensibil</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Căutați după cuvânt complet</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Căutare prin expresie regulată</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -4323,6 +4323,26 @@ Do you want to download it?</source>
         <source>Can&apos;t create record.</source>
         <translation>Невозможно создать запись.</translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation>Найти предыдущий</translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation>Найти следующий</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>С учетом регистра</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Поиск по полному слову</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Поиск по регулярному выражению</translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -6026,10 +6046,6 @@ Do you want to save your changes?</source>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation>Точка на кривой (O, C)</translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation>О проекте Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11409,6 +11425,18 @@ load in SeamlyME as usual.
     <message>
         <source>Convert 3DLook file:</source>
         <translation>Конвертируйте файл 3DLook:</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>С учетом регистра</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Поиск по полному слову</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Поиск по регулярному выражению</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -4319,6 +4319,26 @@ Do you want to download it?</source>
         <source>Can&apos;t create record.</source>
         <translation>Kayıt oluşturulamıyor.</translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation>Öncekini bul</translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation>Sonrakini bul</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Büyük/küçük harfe duyarlı</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Tam kelimeye göre ara</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Düzenli ifadeye göre ara</translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -6026,10 +6046,6 @@ Do you want to save your changes?</translation>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation>Eğri Üzerindeki Nokta (O, C)</translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation>Seamly2D Hakkında</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11401,6 +11417,18 @@ load in SeamlyME as usual.
     <message>
         <source>Convert 3DLook file:</source>
         <translation>3DLook dosyasını dönüştür:</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Büyük/küçük harfe duyarlı</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Tam kelimeye göre ara</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Düzenli ifadeye göre ara</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -4321,6 +4321,26 @@ Do you want to download it?</source>
         <source>Can&apos;t create record.</source>
         <translation>Δεν είναι δυνατή η δημιουργία εγγραφής.</translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation>Εύρεση προηγούμενου</translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation>Εύρεση επόμενου</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Враховуючи регістр</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Пошук за повним словом</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Пошук за регулярним виразом</translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -6027,10 +6047,6 @@ Do you want to save your changes?</source>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation>Σημείο στην καμπύλη (O, C)</translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation>Pro Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11403,6 +11419,18 @@ load in SeamlyME as usual.
     <message>
         <source>Convert 3DLook file:</source>
         <translation>Μετατροπή αρχείου 3DLook:</translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation>Враховуючи регістр</translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation>Пошук за повним словом</translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation>Пошук за регулярним виразом</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -4299,6 +4299,26 @@ Do you want to download it?</source>
         <source>Can&apos;t create record.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Find previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Find next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ImageDialog</name>
@@ -5321,10 +5341,6 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
         <translation>保存</translation>
     </message>
     <message>
-        <source>Save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Save pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5354,7 +5370,7 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
     </message>
     <message>
         <source>About Seamly2D</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">关于Seamly2D</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -5996,10 +6012,6 @@ Do you want to save your changes?</source>
     <message>
         <source>Point on Curve (O, C)</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>About Seamly2D</source>
-        <translation type="unfinished">关于Seamly2D</translation>
     </message>
     <message>
         <source>Exit the Application</source>
@@ -11363,6 +11375,18 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Convert 3DLook file:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Case sensitive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search by full word</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seach by regular expression</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/app/seamly2d/dialogs/history_dialog.cpp
+++ b/src/app/seamly2d/dialogs/history_dialog.cpp
@@ -1,54 +1,54 @@
-/***************************************************************************
- **  @file   historyDialog.cpp
- **  @author Douglas S Caskey
- **  @date   17 Sep, 2023
- **
- **  @copyright
- **  Copyright (C) 2015 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   historyDialog.cpp
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @copyright
+//  Copyright (C) 2015 - 2023 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
- /************************************************************************
- **
- **  @file   dialoghistory.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   November 15, 2013
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//
+//  @file   dialoghistory.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   November 15, 2013
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2015 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//
+//-----------------------------------------------------------------------------
 
 #include "history_dialog.h"
 #include "ui_history_dialog.h"
@@ -61,6 +61,7 @@
 #include "../vgeometry/vpointf.h"
 #include "../vmisc/diagnostic.h"
 #include "../vmisc/vabstractapplication.h"
+#include "../vmisc/vtablesearch.h"
 #include "../vtools/tools/vabstracttool.h"
 #include "../vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.h"
 #include "../vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.h"
@@ -75,12 +76,11 @@
 #include <QScreen>
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief HistoryDialog create dialog
- * @param data container with data
- * @param doc dom document container
- * @param parent parent widget
- */
+/// @brief HistoryDialog create dialog
+/// @param data container with data
+/// @param doc dom document container
+/// @param parent parent widget
+//---------------------------------------------------------------------------------------------------------------------
 HistoryDialog::HistoryDialog(VContainer *data, VPattern *doc, QWidget *parent)
     : DialogTool(data, 0, parent)
     , ui(new Ui::HistoryDialog)
@@ -92,7 +92,7 @@ HistoryDialog::HistoryDialog(VContainer *data, VPattern *doc, QWidget *parent)
     setWindowFlags(Qt::Window);
     setWindowFlags((windowFlags() | Qt::WindowStaysOnTopHint | Qt::WindowMaximizeButtonHint) & ~Qt::WindowContextHelpButtonHint);
 
-    //Limit dialog height to 80% of screen size
+    // Limit dialog height to 80% of screen size
     setMaximumHeight(qRound(QGuiApplication::primaryScreen()->availableGeometry().height() * .8));
 
     ui->find_LineEdit->installEventFilter(this);
@@ -103,13 +103,31 @@ HistoryDialog::HistoryDialog(VContainer *data, VPattern *doc, QWidget *parent)
     initializeTable();
 
     ok_Button = ui->buttonBox->button(QDialogButtonBox::Ok);
-    connect(ok_Button,                &QPushButton::clicked,           this,  &HistoryDialog::DialogAccepted);
-    connect(ui->clipboard_ToolButton, &QToolButton::clicked,           this,  &HistoryDialog::copyToClipboard);
-    connect(ui->tableWidget,          &QTableWidget::cellClicked,      this,  &HistoryDialog::cellClicked);
-    connect(m_doc,                    &VPattern::ChangedCursor,        this,  &HistoryDialog::changedCursor);
-    connect(m_doc,                    &VPattern::patternChanged,       this,  &HistoryDialog::updateHistory);
-    connect(ui->find_LineEdit,        &QLineEdit::textEdited,          this,  &HistoryDialog::findText);
-    connect(this,                     &HistoryDialog::showHistoryTool, m_doc, [doc](quint32 id, bool enable)
+    connect(ok_Button,                &QPushButton::clicked, this,  &HistoryDialog::DialogAccepted);
+    connect(ui->clipboard_ToolButton, &QToolButton::clicked, this,  &HistoryDialog::copyToClipboard);
+
+
+    // Set up search
+    m_search = QSharedPointer<VTableSearch>(new VTableSearch(ui->tableWidget));
+    connect(ui->find_LineEdit,    &QLineEdit::textEdited,this,  &HistoryDialog::findText);
+    connect(ui->prev_PushButton,  &QToolButton::clicked, this,  &HistoryDialog::searchPrev);
+    connect(ui->next_PushButton,  &QToolButton::clicked, this,  &HistoryDialog::searchNext);
+    connect(ui->regex_ToolButton, &QToolButton::toggled, this,  &HistoryDialog::regexToggled);
+    connect(ui->case_ToolButton,  &QToolButton::toggled, this,  &HistoryDialog::caseToggled);
+    connect(ui->word_ToolButton,  &QToolButton::toggled, this,  &HistoryDialog::wordToggled);
+    connect(m_search.data(), &VTableSearch::hasResult, this, [this] (bool state)
+    {
+        ui->prev_PushButton->setEnabled(state);
+    });
+    connect(m_search.data(), &VTableSearch::hasResult, this, [this] (bool state)
+    {
+        ui->next_PushButton->setEnabled(state);
+    });
+
+    connect(ui->tableWidget, &QTableWidget::cellClicked,      this,  &HistoryDialog::cellClicked);
+    connect(m_doc,           &VPattern::ChangedCursor,        this,  &HistoryDialog::changedCursor);
+    connect(m_doc,           &VPattern::patternChanged,       this,  &HistoryDialog::updateHistory);
+    connect(this,            &HistoryDialog::showHistoryTool, m_doc, [doc](quint32 id, bool enable)
     {
         emit doc->ShowTool(id, enable);
     });
@@ -124,9 +142,8 @@ HistoryDialog::~HistoryDialog()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief DialogAccepted save data and emit signal about closed dialog.
- */
+/// @brief DialogAccepted save data and emit signal about closed dialog.
+//---------------------------------------------------------------------------------------------------------------------
 void HistoryDialog::DialogAccepted()
 {
     QTableWidgetItem *item = ui->tableWidget->item(m_cursorToolRecordRow, 0);
@@ -136,11 +153,10 @@ void HistoryDialog::DialogAccepted()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief cellClicked changed history record
- * @param row number row in table
- * @param column number column in table
- */
+/// @brief cellClicked changed history record
+/// @param row number row in table
+/// @param column number column in table
+//---------------------------------------------------------------------------------------------------------------------
 void HistoryDialog::cellClicked(int row, int column)
 {
     if (column == 0)
@@ -170,10 +186,9 @@ void HistoryDialog::cellClicked(int row, int column)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief changedCursor changed cursor of input. Cursor show after which record we will insert new object
- * @param id id of object
- */
+/// @brief changedCursor changed cursor of input. Cursor show after which record we will insert new object
+/// @param id id of object
+//---------------------------------------------------------------------------------------------------------------------
 void HistoryDialog::changedCursor(quint32 id)
 {
     for (qint32 i = 0; i< ui->tableWidget->rowCount(); ++i)
@@ -191,9 +206,8 @@ void HistoryDialog::changedCursor(quint32 id)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief updateHistory update history table
- */
+/// @brief updateHistory update history table
+//---------------------------------------------------------------------------------------------------------------------
 void HistoryDialog::updateHistory()
 {
     fillTable();
@@ -201,9 +215,8 @@ void HistoryDialog::updateHistory()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief fillTable fill table
- */
+/// @brief fillTable fill table
+//---------------------------------------------------------------------------------------------------------------------
 void HistoryDialog::fillTable()
 {
     ui->tableWidget->clear();
@@ -212,7 +225,8 @@ void HistoryDialog::fillTable()
     qint32 count = 0;
     ui->tableWidget->setRowCount(history.size());//Set Row count to number of Tool history records
 
-    for (qint32 i = 0; i< history.size(); ++i)
+    qint32 size = history.size();
+    for (qint32 i = 0; i < size; ++i)
     {
         const VToolRecord tool = history.at(i);
         const RowData rowData = record(tool);
@@ -259,14 +273,14 @@ void HistoryDialog::fillTable()
     ui->tableWidget->verticalHeader()->setDefaultSectionSize(24);//Set all row heights to 20px
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+
 QT_WARNING_PUSH
 QT_WARNING_DISABLE_GCC("-Wswitch-default")
-/**
- * @brief Record return description for record
- * @param tool record data
- * @return RowData
- */
+//---------------------------------------------------------------------------------------------------------------------
+/// @brief Record return description for record
+/// @param tool record data
+/// @return RowData
+//---------------------------------------------------------------------------------------------------------------------
 RowData HistoryDialog::record(const VToolRecord &tool)
 {
     // This check helps to find missed tools in the switch
@@ -621,9 +635,8 @@ RowData HistoryDialog::record(const VToolRecord &tool)
 QT_WARNING_POP
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief initializeTable set initial option of table
- */
+/// @brief initializeTable set initial option of table
+//---------------------------------------------------------------------------------------------------------------------
 void HistoryDialog::initializeTable()
 {
     ui->tableWidget->setSortingEnabled(false);
@@ -635,9 +648,8 @@ void HistoryDialog::initializeTable()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief showTool show selected point
- */
+/// @brief showTool show selected point
+//---------------------------------------------------------------------------------------------------------------------
 void HistoryDialog::showTool()
 {
     const QVector<VToolRecord> *history = m_doc->getHistory();
@@ -653,13 +665,12 @@ void HistoryDialog::showTool()
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief HistoryDialog::PointName return point name by id.
- *
- * Refacoring what hide ugly string getting point name by id.
- * @param pointId point if in data.
- * @return point name.
- */
+/// @brief HistoryDialog::PointName return point name by id.
+///
+/// Refacoring what hide ugly string getting point name by id.
+/// @param pointId point if in data.
+/// @return point name.
+//---------------------------------------------------------------------------------------------------------------------
 QString HistoryDialog::getPointName(quint32 pointId)
 {
     return data->GeometricObject<VPointF>(pointId)->name();
@@ -672,10 +683,9 @@ quint32 HistoryDialog::attrUInt(const QDomElement &domElement, const QString &na
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief closeEvent handle when windows is closing
- * @param event event
- */
+/// @brief closeEvent handle when windows is closing
+/// @param event event
+//---------------------------------------------------------------------------------------------------------------------
 void HistoryDialog::closeEvent(QCloseEvent *event)
 {
     QTableWidgetItem *item = ui->tableWidget->item(m_cursorToolRecordRow,1);
@@ -766,23 +776,12 @@ int HistoryDialog::cursorRow() const
 void HistoryDialog::findText(const QString &text)
 {
     updateHistory();
-    if (text.isEmpty())
-    {
-        return;
-    }
-
-    QList<QTableWidgetItem *> items = ui->tableWidget->findItems(text, Qt::MatchContains);
-
-    for (int i = 0; i < items.count(); ++i)
-    {
-        items.at(i)->setBackground(QColor("#b2cbe5"));
-    }
+    m_search->find(text);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief copyToClipboard copy dialog selection to clipboard as comma separated values.
- */
+/// @brief copyToClipboard copy dialog selection to clipboard as comma separated values.
+//---------------------------------------------------------------------------------------------------------------------
 void HistoryDialog::copyToClipboard()
 {
     QItemSelectionModel *model = ui->tableWidget->selectionModel();
@@ -816,4 +815,66 @@ void HistoryDialog::copyToClipboard()
 
     QClipboard *clipboard = QApplication::clipboard();
     clipboard->setText(clipboardString);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void HistoryDialog::searchPrev()
+{
+    m_search->findPrevious();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void HistoryDialog::searchNext()
+{
+    m_search->findNext();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void HistoryDialog::regexToggled(bool checked)
+{
+    if (checked)
+    {
+        ui->case_ToolButton->blockSignals(true);
+        ui->case_ToolButton->setChecked(false);
+        ui->case_ToolButton->blockSignals(false);
+        m_search->setMatchCase(false);
+
+        ui->word_ToolButton->blockSignals(true);
+        ui->word_ToolButton->setChecked(false);
+        ui->word_ToolButton->blockSignals(false);
+        m_search->setMatchWord(false);
+    }
+
+    m_search->setMatchRegEx(checked);
+    m_search->find(ui->find_LineEdit->text());
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void HistoryDialog::caseToggled(bool checked)
+{
+    if (checked)
+    {
+        ui->regex_ToolButton->blockSignals(true);
+        ui->regex_ToolButton->setChecked(false);
+        ui->regex_ToolButton->blockSignals(false);
+        m_search->setMatchRegEx(false);
+    }
+
+    m_search->setMatchCase(checked);
+    m_search->find(ui->find_LineEdit->text());
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void HistoryDialog::wordToggled(bool checked)
+{
+    if (checked)
+    {
+        ui->regex_ToolButton->blockSignals(true);
+        ui->regex_ToolButton->setChecked(false);
+        ui->regex_ToolButton->blockSignals(false);
+        m_search->setMatchRegEx(false);
+    }
+
+    m_search->setMatchWord(checked);
+    m_search->find(ui->find_LineEdit->text());
 }

--- a/src/app/seamly2d/dialogs/history_dialog.h
+++ b/src/app/seamly2d/dialogs/history_dialog.h
@@ -1,54 +1,54 @@
-/***************************************************************************
- **  @file   historyDialog.h
- **  @author Douglas S Caskey
- **  @date   Mar 11, 2023
- **
- **  @copyright
- **  Copyright (C) 2015 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   historyDialog.h
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @copyright
+//  Copyright (C) 2015 - 2023 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
- /************************************************************************
- **
- **  @file   dialoghistory.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   November 15, 2013
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//
+//  @file   dialoghistory.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   November 15, 2013
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2015 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//
+//-----------------------------------------------------------------------------
 
 #ifndef HISTORY_DIALOG_H
 #define HISTORY_DIALOG_H
@@ -58,6 +58,7 @@
 #include <QDomElement>
 
 class VPattern;
+class VTableSearch;
 
 namespace Ui
 {
@@ -72,46 +73,43 @@ struct RowData
      QString tool{QString()};
 };
 
-/**
- * @brief The HistoryDialog class show dialog history.
- */
 class HistoryDialog : public DialogTool
 {
     Q_OBJECT
 public:
                            HistoryDialog(VContainer *data, VPattern *doc, QWidget *parent = nullptr);
-    virtual               ~HistoryDialog() Q_DECL_OVERRIDE;
+    virtual               ~HistoryDialog() override;
 
 public slots:
-    virtual void            DialogAccepted() Q_DECL_OVERRIDE;
-    /** TODO ISSUE 79 : create real function
-    * @brief DialogApply apply data and emit signal about applied dialog.
-    */
-    virtual void            DialogApply() Q_DECL_OVERRIDE {}
+    virtual void            DialogAccepted() override;
+
+    // TODO ISSUE 79 : create real function
+    /// @brief DialogApply apply data and emit signal about applied dialog.
+    virtual void            DialogApply() override {}
+
     void                    cellClicked(int row, int column);
     void                    changedCursor(quint32 id);
     void                    updateHistory();
 
 signals:
-    /**
-     * @brief showHistoryTool signal change color of selected in records tool
-     * @param id id of tool
-     * @param enable true enable selection, false disable selection
-     */
+     /// @brief showHistoryTool signal change color of selected in records tool
+     /// @param id id of tool
+     /// @param enable true enable selection, false disable selection
     void                    showHistoryTool(quint32 id, bool enable);
 
 protected:
-    virtual void            closeEvent ( QCloseEvent * event ) Q_DECL_OVERRIDE;
-    virtual void            changeEvent(QEvent* event) Q_DECL_OVERRIDE;
-    virtual bool            eventFilter(QObject *object, QEvent *event) Q_DECL_OVERRIDE;
+    virtual void            closeEvent ( QCloseEvent *event ) override;
+    virtual void            changeEvent(QEvent *event) override;
+    virtual bool            eventFilter(QObject *object, QEvent *event) override;
 
 private:
     Q_DISABLE_COPY(HistoryDialog)
 
-    Ui::HistoryDialog      *ui;                    /** @brief ui keeps information about user interface */
-    VPattern               *m_doc;                 /** @brief doc dom document container */
-    qint32                  m_cursorRow;           /** @brief cursorRow save number of row where is cursor */
-    qint32                  m_cursorToolRecordRow; /** @brief cursorToolRecordRow save number of row selected record */
+    Ui::HistoryDialog      *ui;                    /// @brief ui keeps information about user interface */
+    VPattern               *m_doc;                 /// @brief doc dom document container */
+    qint32                  m_cursorRow;           /// @brief cursorRow save number of row where is cursor */
+    qint32                  m_cursorToolRecordRow; /// @brief cursorToolRecordRow save number of row selected record */
+    QSharedPointer<VTableSearch> m_search{};
 
     void                    fillTable();
     RowData                 record(const VToolRecord &tool);
@@ -123,6 +121,11 @@ private:
     int                     cursorRow() const;
     void                    findText(const QString &text);
     void                    copyToClipboard();
+    void                    searchPrev();
+    void                    searchNext();
+    void                    regexToggled(bool checked);
+    void                    caseToggled(bool checked);
+    void                    wordToggled(bool checked);
 };
 
 #endif // HISTORY_DIALOG_H

--- a/src/app/seamly2d/dialogs/history_dialog.ui
+++ b/src/app/seamly2d/dialogs/history_dialog.ui
@@ -187,6 +187,211 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QPushButton" name="prev_PushButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>30</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>30</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Search previous</string>
+         </property>
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../../libs/vmisc/share/resources/theme.qrc">
+           <normaloff>:/icons/win.icon.theme/32x32/actions/go-previous.png</normaloff>:/icons/win.icon.theme/32x32/actions/go-previous.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>24</width>
+           <height>18</height>
+          </size>
+         </property>
+         <property name="flat">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="next_PushButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>30</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>30</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Seach Next</string>
+         </property>
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../../libs/vmisc/share/resources/theme.qrc">
+           <normaloff>:/icons/win.icon.theme/32x32/actions/go-next.png</normaloff>:/icons/win.icon.theme/32x32/actions/go-next.png</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>24</width>
+           <height>18</height>
+          </size>
+         </property>
+         <property name="flat">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="regex_ToolButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>30</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>30</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Seach by RegEx</string>
+         </property>
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
+           <normaloff>:/icon/svg/regex.svg</normaloff>:/icon/svg/regex.svg</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>24</width>
+           <height>18</height>
+          </size>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="case_ToolButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>30</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>30</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Casse sensitive</string>
+         </property>
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
+           <normaloff>:/icon/svg/case.svg</normaloff>:/icon/svg/case.svg</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>24</width>
+           <height>18</height>
+          </size>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="word_ToolButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>30</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>30</width>
+           <height>24</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Serach by full word</string>
+         </property>
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../../libs/vmisc/share/resources/icon.qrc">
+           <normaloff>:/icon/svg/word.svg</normaloff>:/icon/svg/word.svg</iconset>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>24</width>
+           <height>18</height>
+          </size>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
      <item>
@@ -308,9 +513,6 @@
           <pointsize>10</pointsize>
          </font>
         </property>
-        <property name="textAlignment">
-         <set>AlignCenter</set>
-        </property>
         <property name="background">
          <color>
           <red>255</red>
@@ -360,6 +562,7 @@
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>
+  <include location="../../../libs/vmisc/share/resources/theme.qrc"/>
   <include location="../../../libs/vmisc/share/resources/icon.qrc"/>
  </resources>
  <connections>

--- a/src/app/seamly2d/dialogs/history_dialog.ui
+++ b/src/app/seamly2d/dialogs/history_dialog.ui
@@ -208,7 +208,7 @@
           </size>
          </property>
          <property name="toolTip">
-          <string>Search previous</string>
+          <string>Find previous</string>
          </property>
          <property name="text">
           <string notr="true"/>
@@ -249,7 +249,7 @@
           </size>
          </property>
          <property name="toolTip">
-          <string>Seach Next</string>
+          <string>Find next</string>
          </property>
          <property name="text">
           <string notr="true"/>
@@ -290,7 +290,7 @@
           </size>
          </property>
          <property name="toolTip">
-          <string>Seach by RegEx</string>
+          <string>Seach by regular expression</string>
          </property>
          <property name="text">
           <string notr="true"/>
@@ -331,7 +331,7 @@
           </size>
          </property>
          <property name="toolTip">
-          <string>Casse sensitive</string>
+          <string>Case sensitive</string>
          </property>
          <property name="text">
           <string notr="true"/>
@@ -372,7 +372,7 @@
           </size>
          </property>
          <property name="toolTip">
-          <string>Serach by full word</string>
+          <string>Search by full word</string>
          </property>
          <property name="text">
           <string notr="true"/>

--- a/src/app/seamlyme/tmainwindow.cpp
+++ b/src/app/seamlyme/tmainwindow.cpp
@@ -126,7 +126,7 @@ TMainWindow::TMainWindow(QWidget *parent)
 	  gradationSizes(nullptr),
 	  comboBoxUnits(nullptr),
 	  lock(nullptr),
-	  search(),
+	  m_search(),
 	  labelGradationHeights(nullptr),
 	  labelGradationSizes(nullptr),
 	  labelPatternUnit(nullptr),
@@ -142,17 +142,17 @@ TMainWindow::TMainWindow(QWidget *parent)
 
 	qApp->Settings()->getOsSeparator() ? setLocale(QLocale()) : setLocale(QLocale::c());
 
-	ui->lineEditFind->setClearButtonEnabled(true);
+	ui->find_LineEdit->setClearButtonEnabled(true);
 	ui->lineEditName->setClearButtonEnabled(true);
 	ui->lineEditFullName->setClearButtonEnabled(true);
 	ui->lineEditGivenName->setClearButtonEnabled(true);
 	ui->lineEditFamilyName->setClearButtonEnabled(true);
 	ui->lineEditEmail->setClearButtonEnabled(true);
 
-	ui->lineEditFind->installEventFilter(this);
+	ui->find_LineEdit->installEventFilter(this);
 	ui->plainTextEditFormula->installEventFilter(this);
 
-	search = QSharedPointer<VTableSearch>(new VTableSearch(ui->tableWidget));
+	m_search = QSharedPointer<VTableSearch>(new VTableSearch(ui->tableWidget));
 	ui->tabWidget->setVisible(false);
 
 	ui->mainToolBar->setContextMenuPolicy(Qt::PreventContextMenu);
@@ -204,7 +204,7 @@ void TMainWindow::RetranslateTable()
 		const int row = ui->tableWidget->currentRow();
 		RefreshTable();
 		ui->tableWidget->selectRow(row);
-		search->RefreshList(ui->lineEditFind->text());
+		m_search->refreshList(ui->find_LineEdit->text());
 	}
 }
 
@@ -1363,9 +1363,9 @@ void TMainWindow::Remove()
 
 	MeasurementsWasSaved(false);
 
-	search->RemoveRow(row);
+	m_search->removeRow(row);
 	RefreshData();
-	search->RefreshList(ui->lineEditFind->text());
+	m_search->refreshList(ui->find_LineEdit->text());
 
 	if (ui->tableWidget->rowCount() > 0)
 	{
@@ -1433,7 +1433,7 @@ void TMainWindow::MoveTop()
 	individualMeasurements->MoveTop(nameField->data(Qt::UserRole).toString());
 	MeasurementsWasSaved(false);
 	RefreshData();
-	search->RefreshList(ui->lineEditFind->text());
+	m_search->refreshList(ui->find_LineEdit->text());
 	ui->tableWidget->selectRow(0);
 }
 
@@ -1451,7 +1451,7 @@ void TMainWindow::MoveUp()
 	individualMeasurements->MoveUp(nameField->data(Qt::UserRole).toString());
 	MeasurementsWasSaved(false);
 	RefreshData();
-	search->RefreshList(ui->lineEditFind->text());
+	m_search->refreshList(ui->find_LineEdit->text());
 	ui->tableWidget->selectRow(row-1);
 }
 
@@ -1469,7 +1469,7 @@ void TMainWindow::MoveDown()
 	individualMeasurements->MoveDown(nameField->data(Qt::UserRole).toString());
 	MeasurementsWasSaved(false);
 	RefreshData();
-	search->RefreshList(ui->lineEditFind->text());
+	m_search->refreshList(ui->find_LineEdit->text());
 	ui->tableWidget->selectRow(row+1);
 }
 
@@ -1487,7 +1487,7 @@ void TMainWindow::MoveBottom()
 	individualMeasurements->MoveBottom(nameField->data(Qt::UserRole).toString());
 	MeasurementsWasSaved(false);
 	RefreshData();
-	search->RefreshList(ui->lineEditFind->text());
+	m_search->refreshList(ui->find_LineEdit->text());
 	ui->tableWidget->selectRow(ui->tableWidget->rowCount()-1);
 }
 
@@ -1536,7 +1536,7 @@ void TMainWindow::Fx()
 
 		RefreshData();
 
-		search->RefreshList(ui->lineEditFind->text());
+		m_search->refreshList(ui->find_LineEdit->text());
 
 		ui->tableWidget->selectRow(row);
 	}
@@ -1561,9 +1561,9 @@ void TMainWindow::AddCustom()
 		individualMeasurements->AddEmptyAfter(nameField->data(Qt::UserRole).toString(), name);
 	}
 
-	search->AddRow(currentRow);
+	m_search->addRow(currentRow);
 	RefreshData();
-	search->RefreshList(ui->lineEditFind->text());
+	m_search->refreshList(ui->find_LineEdit->text());
 
 	ui->tableWidget->selectRow(currentRow);
 
@@ -1595,7 +1595,7 @@ void TMainWindow::AddKnown()
 					individualMeasurements->addEmpty(list.at(i));
 				}
 
-				search->AddRow(currentRow);
+				m_search->addRow(currentRow);
 			}
 		}
 		else
@@ -1613,13 +1613,13 @@ void TMainWindow::AddKnown()
 				{
 					individualMeasurements->AddEmptyAfter(after, list.at(i));
 				}
-				search->AddRow(currentRow);
+				m_search->addRow(currentRow);
 				after = list.at(i);
 			}
 		}
 
 		RefreshData();
-		search->RefreshList(ui->lineEditFind->text());
+		m_search->refreshList(ui->find_LineEdit->text());
 
 		ui->tableWidget->selectRow(currentRow);
 
@@ -1701,7 +1701,7 @@ void TMainWindow::ImportFromPattern()
 
 	RefreshData();
 
-	search->RefreshList(ui->lineEditFind->text());
+	m_search->refreshList(ui->find_LineEdit->text());
 
 	ui->tableWidget->selectRow(currentRow);
 
@@ -1714,7 +1714,7 @@ void TMainWindow::ChangedSize(int index)
 	const int row = ui->tableWidget->currentRow();
     currentSize = gradationSizes->itemText(index).toInt();
 	RefreshData();
-	search->RefreshList(ui->lineEditFind->text());
+	m_search->refreshList(ui->find_LineEdit->text());
 	ui->tableWidget->selectRow(row);
 }
 
@@ -1724,7 +1724,7 @@ void TMainWindow::ChangedHeight(int index)
 	const int row = ui->tableWidget->currentRow();
     currentHeight = gradationHeights->itemText(index).toInt();
 	RefreshData();
-	search->RefreshList(ui->lineEditFind->text());
+	m_search->refreshList(ui->find_LineEdit->text());
 	ui->tableWidget->selectRow(row);
 }
 
@@ -1910,7 +1910,7 @@ void TMainWindow::SaveMName(const QString &text)
 		individualMeasurements->SetMName(nameField->text(), newName);
 		MeasurementsWasSaved(false);
 		RefreshData();
-		search->RefreshList(ui->lineEditFind->text());
+		m_search->refreshList(ui->find_LineEdit->text());
 
 		ui->tableWidget->blockSignals(true);
 		ui->tableWidget->selectRow(row);
@@ -1990,7 +1990,7 @@ void TMainWindow::SaveMValue()
 	const QTextCursor cursor = ui->plainTextEditFormula->textCursor();
 
 	RefreshData();
-	search->RefreshList(ui->lineEditFind->text());
+	m_search->refreshList(ui->find_LineEdit->text());
 
 	ui->tableWidget->blockSignals(true);
 	ui->tableWidget->selectRow(row);
@@ -2015,7 +2015,7 @@ void TMainWindow::SaveMBaseValue(double value)
 	MeasurementsWasSaved(false);
 
 	RefreshData();
-	search->RefreshList(ui->lineEditFind->text());
+	m_search->refreshList(ui->find_LineEdit->text());
 
 	ui->tableWidget->blockSignals(true);
 	ui->tableWidget->selectRow(row);
@@ -2040,7 +2040,7 @@ void TMainWindow::SaveMSizeIncrease(double value)
 	MeasurementsWasSaved(false);
 
 	RefreshData();
-	search->RefreshList(ui->lineEditFind->text());
+	m_search->refreshList(ui->find_LineEdit->text());
 
 	ui->tableWidget->blockSignals(true);
 	ui->tableWidget->selectRow(row);
@@ -2065,7 +2065,7 @@ void TMainWindow::SaveMHeightIncrease(double value)
 	MeasurementsWasSaved(false);
 
 	RefreshData();
-	search->RefreshList(ui->lineEditFind->text());
+	m_search->refreshList(ui->find_LineEdit->text());
 
 	ui->tableWidget->blockSignals(true);
 	ui->tableWidget->selectRow(row);
@@ -2387,16 +2387,62 @@ void TMainWindow::InitWindow()
 	connect(ui->comboBoxPMSystem, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
 			&TMainWindow::SavePMSystem);
 
-	connect(ui->lineEditFind, &QLineEdit::textChanged, [this] (const QString &term){search->Find(term);});
-	connect(ui->toolButtonFindPrevious, &QToolButton::clicked, [this] (){search->FindPrevious();});
-	connect(ui->toolButtonFindNext, &QToolButton::clicked, [this] (){search->FindNext();});
+	connect(ui->find_LineEdit, &QLineEdit::textChanged, [this] (const QString &text){m_search->find(text);});
+	connect(ui->toolButtonFindPrevious, &QToolButton::clicked, [this] (){m_search->findPrevious();});
+	connect(ui->toolButtonFindNext, &QToolButton::clicked, [this] (){m_search->findNext();});
+    connect(ui->regex_ToolButton, &QToolButton::toggled, [this] (const bool &checked)
+    {
+        if (checked)
+        {
+            ui->case_ToolButton->blockSignals(true);
+            ui->case_ToolButton->setChecked(false);
+            ui->case_ToolButton->blockSignals(false);
+            m_search->setMatchCase(false);
 
-	connect(search.data(), &VTableSearch::HasResult, this, [this] (bool state)
+            ui->word_ToolButton->blockSignals(true);
+            ui->word_ToolButton->setChecked(false);
+            ui->word_ToolButton->blockSignals(false);
+            m_search->setMatchWord(false);
+        }
+
+        m_search->setMatchRegEx(checked);
+        m_search->find(ui->find_LineEdit->text());
+    });
+    
+    connect(ui->case_ToolButton,  &QToolButton::toggled, [this] (const bool &checked)
+    {
+        if (checked)
+        {
+            ui->regex_ToolButton->blockSignals(true);
+            ui->regex_ToolButton->setChecked(false);
+            ui->regex_ToolButton->blockSignals(false);
+            m_search->setMatchRegEx(false);
+        }
+
+        m_search->setMatchCase(checked);
+        m_search->find(ui->find_LineEdit->text());
+    });
+
+    connect(ui->word_ToolButton,  &QToolButton::toggled, [this] (const bool &checked)
+    {
+        if (checked)
+        {
+            ui->regex_ToolButton->blockSignals(true);
+            ui->regex_ToolButton->setChecked(false);
+            ui->regex_ToolButton->blockSignals(false);
+            m_search->setMatchRegEx(false);
+        }
+
+        m_search->setMatchWord(checked);
+        m_search->find(ui->find_LineEdit->text());
+    });
+
+	connect(m_search.data(), &VTableSearch::hasResult, this, [this] (bool state)
 	{
 		ui->toolButtonFindPrevious->setEnabled(state);
 	});
     connect(ui->clipboard_ToolButton, &QToolButton::clicked, this, &TMainWindow::copyToClipboard);
-	connect(search.data(), &VTableSearch::HasResult, this, [this] (bool state)
+	connect(m_search.data(), &VTableSearch::hasResult, this, [this] (bool state)
 	{
 		ui->toolButtonFindNext->setEnabled(state);
 	});
@@ -2843,8 +2889,8 @@ void TMainWindow::MFields(bool enabled)
 		ui->toolButtonExpr->setEnabled(enabled);
 	}
 
-	ui->lineEditFind->setEnabled(enabled);
-	if (enabled && !ui->lineEditFind->text().isEmpty())
+	ui->find_LineEdit->setEnabled(enabled);
+	if (enabled && !ui->find_LineEdit->text().isEmpty())
 	{
 		ui->toolButtonFindPrevious->setEnabled(enabled);
 		ui->toolButtonFindNext->setEnabled(enabled);
@@ -3072,7 +3118,7 @@ void TMainWindow::updatePatternUnit()
 
 	RefreshTable();
 
-	search->RefreshList(ui->lineEditFind->text());
+	m_search->refreshList(ui->find_LineEdit->text());
 
 	ui->tableWidget->selectRow(row);
 }

--- a/src/app/seamlyme/tmainwindow.h
+++ b/src/app/seamlyme/tmainwindow.h
@@ -179,7 +179,7 @@ private:
     QComboBox          *comboBoxUnits;
 
     std::shared_ptr<VLockGuard<char>> lock;
-    QSharedPointer<VTableSearch>      search;
+    QSharedPointer<VTableSearch>      m_search;
     QLabel             *labelGradationHeights;
     QLabel             *labelGradationSizes;
     QLabel             *labelPatternUnit;

--- a/src/app/seamlyme/tmainwindow.ui
+++ b/src/app/seamlyme/tmainwindow.ui
@@ -82,7 +82,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QLineEdit" name="lineEditFind">
+           <widget class="QLineEdit" name="find_LineEdit">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -131,6 +131,66 @@
             </property>
             <property name="autoExclusive">
              <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="regex_ToolButton">
+            <property name="text">
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="../../libs/vmisc/share/resources/icon.qrc">
+              <normaloff>:/icon/svg/regex.svg</normaloff>:/icon/svg/regex.svg</iconset>
+            </property>
+            <property name="iconSize">
+             <size>
+              <width>24</width>
+              <height>18</height>
+             </size>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="case_ToolButton">
+            <property name="text">
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="../../libs/vmisc/share/resources/icon.qrc">
+              <normaloff>:/icon/svg/case.svg</normaloff>:/icon/svg/case.svg</iconset>
+            </property>
+            <property name="iconSize">
+             <size>
+              <width>24</width>
+              <height>18</height>
+             </size>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="word_ToolButton">
+            <property name="text">
+             <string notr="true"/>
+            </property>
+            <property name="icon">
+             <iconset resource="../../libs/vmisc/share/resources/icon.qrc">
+              <normaloff>:/icon/svg/word.svg</normaloff>:/icon/svg/word.svg</iconset>
+            </property>
+            <property name="iconSize">
+             <size>
+              <width>24</width>
+              <height>18</height>
+             </size>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -1623,8 +1683,8 @@
  <layoutdefault spacing="6" margin="11"/>
  <resources>
   <include location="share/resources/seamlymeicon.qrc"/>
-  <include location="../../libs/vmisc/share/resources/icon.qrc"/>
   <include location="../../libs/vmisc/share/resources/theme.qrc"/>
+  <include location="../../libs/vmisc/share/resources/icon.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/app/seamlyme/tmainwindow.ui
+++ b/src/app/seamlyme/tmainwindow.ui
@@ -136,6 +136,9 @@
           </item>
           <item>
            <widget class="QToolButton" name="regex_ToolButton">
+            <property name="toolTip">
+             <string>Seach by regular expression</string>
+            </property>
             <property name="text">
              <string notr="true"/>
             </property>
@@ -156,6 +159,9 @@
           </item>
           <item>
            <widget class="QToolButton" name="case_ToolButton">
+            <property name="toolTip">
+             <string>Case sensitive</string>
+            </property>
             <property name="text">
              <string notr="true"/>
             </property>
@@ -176,6 +182,9 @@
           </item>
           <item>
            <widget class="QToolButton" name="word_ToolButton">
+            <property name="toolTip">
+             <string>Search by full word</string>
+            </property>
             <property name="text">
              <string notr="true"/>
             </property>

--- a/src/libs/vmisc/share/resources/icon.qrc
+++ b/src/libs/vmisc/share/resources/icon.qrc
@@ -166,5 +166,8 @@
         <file>icon/32x32/units_mm_hover.png</file>
         <file>icon/32x32/units_mm_on.png</file>
         <file>icon/32x32/backup_files.png</file>
+        <file>icon/svg/word.svg</file>
+        <file>icon/svg/case.svg</file>
+        <file>icon/svg/regex.svg</file>
     </qresource>
 </RCC>

--- a/src/libs/vmisc/share/resources/icon/svg/case.svg
+++ b/src/libs/vmisc/share/resources/icon/svg/case.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="500mm"
+   height="400mm"
+   viewBox="0 0 500 400"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="case.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.24748737"
+     inkscape:cx="-327.87425"
+     inkscape:cy="898.55721"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1366"
+     inkscape:window-height="745"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,103)">
+    <g
+       aria-label="Aa"
+       style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-size:314.09106445px;line-height:2.45000005;font-family:Arial;-inkscape-font-specification:'Arial Heavy';letter-spacing:0px;word-spacing:0px;stroke-width:0.26458329"
+       id="text825">
+      <path
+         d="M 189.72764,170.46173 H 110.59142 L 99.702519,207.576 H 28.694627 L 113.19862,-17.25676 h 75.7622 L 273.46481,207.576 h -72.6949 z M 175.15799,121.84509 150.3129,41.021856 125.62117,121.84509 Z"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-family:Arial;-inkscape-font-specification:'Arial Heavy';stroke-width:0.26458329"
+         id="path818"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 348.30682,97.460094 -59.6589,-6.287956 q 3.37403,-15.643207 9.66198,-24.538365 6.44132,-9.048521 18.40378,-15.643207 8.58842,-4.754308 23.61817,-7.361509 15.02975,-2.607201 32.51334,-2.607201 28.06575,0 45.08924,3.22066 17.02349,3.067295 28.37248,13.036006 7.97497,6.901415 12.57592,19.630692 4.60094,12.575911 4.60094,24.078266 v 71.92808 q 0,11.50236 1.38028,18.09705 1.53365,6.44132 6.44132,16.56339 h -58.58534 q -3.52739,-6.28795 -4.60095,-9.50861 -1.07355,-3.37403 -2.1471,-10.42881 -12.26919,11.80909 -24.385,16.87013 -16.5634,6.74805 -38.49456,6.74805 -29.13931,0 -44.32242,-13.4961 -15.02975,-13.4961 -15.02975,-33.28016 0,-18.55714 10.8889,-30.51959 10.8889,-11.96245 40.18157,-17.79031 35.12053,-7.05478 45.54934,-9.81535 10.4288,-2.91393 22.08453,-7.514873 0,-11.502359 -4.75431,-16.103302 -4.75431,-4.600943 -16.71676,-4.600943 -15.33648,0 -23.00472,4.907673 -5.98122,3.834119 -9.66198,14.416289 z m 54.13777,32.820066 q -12.88264,4.60094 -26.83884,8.12833 -19.01723,5.06104 -24.07827,9.96871 -5.2144,5.06104 -5.2144,11.50236 0,7.36151 5.06104,12.11582 5.2144,4.60094 15.18311,4.60094 10.4288,0 19.32396,-5.06104 9.04852,-5.06104 12.72928,-12.26918 3.83412,-7.36151 3.83412,-19.01723 z"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-family:Arial;-inkscape-font-specification:'Arial Heavy';stroke-width:0.26458329"
+         id="path820"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/src/libs/vmisc/share/resources/icon/svg/regex.svg
+++ b/src/libs/vmisc/share/resources/icon/svg/regex.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="500mm"
+   height="400mm"
+   viewBox="0 0 500 400"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="regex.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.24748737"
+     inkscape:cx="361.04979"
+     inkscape:cy="898.55721"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1366"
+     inkscape:window-height="745"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,103)">
+    <g
+       aria-label=".*"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:308.30062866px;line-height:2.45000005;font-family:Arial;-inkscape-font-specification:Arial;letter-spacing:0px;word-spacing:0px;stroke-width:0.26458332"
+       id="text817">
+      <path
+         d="m 81.22444,146.84726 h 65.48378 v 61.41927 H 81.22444 Z"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-family:Arial;-inkscape-font-specification:'Arial Heavy';stroke-width:0.26458332"
+         id="path827"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 279.02851,-21.530153 h 60.98896 l -4.96742,41.671186 q -1.65582,15.178247 -6.89921,34.496017 10.48678,-5.243393 13.7984,-7.175171 11.59066,-6.347268 17.66197,-9.106949 l 38.35957,-18.213897 19.0418,58.229277 -42.49909,8.830982 q -11.59067,2.207744 -34.49602,3.035648 15.45421,12.1426 24.56116,22.07745 l 28.70069,31.1844 -49.67426,37.2557 -20.42164,-37.2557 q -4.4155,-8.00308 -14.35035,-31.1844 -10.76276,25.38907 -14.35034,31.1844 l -20.69761,37.2557 -51.05411,-37.2557 30.90843,-31.1844 q 12.97051,-12.9705 25.38907,-22.07745 -12.69453,-1.103873 -33.39215,-4.967425 L 202.8613,78.37031 222.73101,20.141033 261.09058,37.527026 q 6.0713,2.759681 30.08053,17.110024 -5.24339,-23.181324 -6.62324,-34.496017 z"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-family:Arial;-inkscape-font-specification:'Arial Heavy';stroke-width:0.26458332"
+         id="path829"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/src/libs/vmisc/share/resources/icon/svg/word.svg
+++ b/src/libs/vmisc/share/resources/icon/svg/word.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="500mm"
+   height="400mm"
+   viewBox="0 0 500 400"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
+   sodipodi:docname="word.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.24748737"
+     inkscape:cx="-295.54937"
+     inkscape:cy="898.55721"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1366"
+     inkscape:window-height="745"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,103)">
+    <g
+       aria-label="W"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:310.11270142px;line-height:2.45000005;font-family:Arial;-inkscape-font-specification:Arial;letter-spacing:0px;word-spacing:0px;stroke-width:0.26458332"
+       id="text821">
+      <path
+         d="m 94.792227,-13.992478 h 65.111553 l 23.47044,124.014798 34.22143,-124.014798 h 64.96013 l 34.37284,124.014798 23.47044,-124.014798 h 64.80871 L 356.2984,207.99249 H 289.06693 L 250.15142,68.229786 211.38733,207.99249 h -67.23146 z"
+         style="font-style:normal;font-variant:normal;font-weight:900;font-stretch:normal;font-family:Arial;-inkscape-font-specification:'Arial Heavy';stroke-width:0.26458332"
+         id="path819"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/src/libs/vmisc/vtablesearch.cpp
+++ b/src/libs/vmisc/vtablesearch.cpp
@@ -1,57 +1,60 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//-----------------------------------------------------------------------------
+//  @file   vtablesearch.cpp
+//  @author Douglas S Caskey
+//  @date   12 Jun, 2025
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2025 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
- ************************************************************************
- **
- **  @file   vtablesearch.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   15 9, 2015
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vtablesearch.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   15 9, 2015
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentine project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2015 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #include "vtablesearch.h"
 
+#include <QColor>
 #include <QPalette>
+#include <QRegularExpression>
 #include <QTableWidget>
 #include <QTableWidgetItem>
 #include <Qt>
@@ -60,25 +63,186 @@
 
 //---------------------------------------------------------------------------------------------------------------------
 VTableSearch::VTableSearch(QTableWidget *table, QObject *parent)
-    : QObject(parent),
-      table(table),
-      searchIndex(-1),
-      searchList()
+    : QObject(parent)
+    , m_table(table)
+    , m_searchIndex(-1)
+    , m_searchList()
+    , m_matchRegEx(false)
+    , m_matchCase(false)
+    , m_matchWord(false)
 {
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VTableSearch::Clear()
+void VTableSearch::find(const QString &text)
 {
-    SCASSERT(table != nullptr)
+    SCASSERT(m_table != nullptr)
 
-    for(int i = 0; i < table->rowCount(); ++i)
+    clear();
+
+    if (!text.isEmpty())
     {
-        for(int j = 0; j < table->columnCount(); ++j)
+        m_searchList = findItems(text);
+
+        if (!m_searchList.isEmpty())
         {
-            if (QTableWidgetItem *item = table->item(i, j))
+            for (QTableWidgetItem *item : m_searchList)
             {
-                if (item->row() % 2 != 0 && table->alternatingRowColors())
+                item->setBackground(QColor("#FFDEDE"));
+            }
+
+            m_searchIndex = 0;
+            QTableWidgetItem *item = m_searchList.at(m_searchIndex);
+            item->setBackground(QColor("#FFBABA"));
+            m_table->scrollToItem(item);
+
+            emit hasResult(true);
+        }
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VTableSearch::findPrevious()
+{
+    int newIndex = m_searchIndex - 1;
+
+    if (newIndex < 0)
+    {
+        newIndex = m_searchList.size() - 1;
+    }
+
+    showNext(newIndex);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VTableSearch::findNext()
+{
+    int newIndex = m_searchIndex + 1;
+
+    if (newIndex >= m_searchList.size())
+    {
+        newIndex = 0;
+    }
+
+    showNext(newIndex);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VTableSearch::removeRow(int row)
+{
+    if (m_searchIndex < 0 || m_searchIndex >= m_searchList.size())
+    {
+        return;
+    }
+
+    const int indexRow = m_searchList.at(m_searchIndex)->row();
+
+    if (row <= indexRow)
+    {
+        for (QTableWidgetItem *item : m_searchList)
+        {
+            if (item->row() == row)
+            {
+                --m_searchIndex;
+            }
+        }
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VTableSearch::addRow(int row)
+{
+    if (m_searchIndex < 0 || m_searchIndex >= m_searchList.size())
+    {
+        return;
+    }
+
+    const int indexRow = m_searchList.at(m_searchIndex)->row();
+
+    if (row <= indexRow)
+    {
+        for (QTableWidgetItem *item : m_searchList)
+        {
+            if (item->row() == row)
+            {
+                ++m_searchIndex;
+            }
+        }
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VTableSearch::refreshList(const QString &text)
+{
+    SCASSERT(m_table != nullptr)
+
+    if (text.isEmpty())
+    {
+        return;
+    }
+
+    m_searchList = findItems(text);
+
+    for (QTableWidgetItem *item : m_searchList)
+    {
+        item->setBackground(QColor("#FFDEDE"));
+    }
+
+    if (!m_searchList.isEmpty())
+    {
+        if (m_searchIndex < 0)
+        {
+           m_searchIndex = m_searchList.size() - 1;
+        }
+        else if (m_searchIndex >= m_searchList.size())
+        {
+           m_searchIndex = 0;
+        }
+
+        QTableWidgetItem *item = m_searchList.at(m_searchIndex);
+        item->setBackground(QColor("#FFBABA"));
+        m_table->scrollToItem(item);
+
+        emit hasResult(true);
+    }
+    else
+    {
+        emit hasResult(false);
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VTableSearch::setMatchRegEx(bool value)
+{
+    m_matchRegEx = value;
+    m_matchWord = false;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VTableSearch::setMatchCase(bool value)
+{
+    m_matchCase = value;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VTableSearch::setMatchWord(bool value)
+{
+    m_matchWord = value;
+    m_matchRegEx = false;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VTableSearch::clear()
+{
+    SCASSERT(m_table != nullptr)
+
+    for (int i = 0; i < m_table->rowCount(); ++i)
+    {
+        for (int j = 0; j < m_table->columnCount(); ++j)
+        {
+            if (QTableWidgetItem *item = m_table->item(i, j))
+            {
+                if (item->row() % 2 != 0 && m_table->alternatingRowColors())
                 {
                     item->setBackground(QPalette().alternateBase());
                 }
@@ -90,165 +254,62 @@ void VTableSearch::Clear()
         }
     }
 
-    searchList.clear();
-    searchIndex = -1;
+    m_searchList.clear();
+    m_searchIndex = -1;
 
-    emit HasResult(false);
+    emit hasResult(false);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VTableSearch::ShowNext(int newIndex)
+void VTableSearch::showNext(int newIndex)
 {
-    if (not searchList.isEmpty())
+    if (!m_searchList.isEmpty())
     {
-        QTableWidgetItem *item = searchList.at(searchIndex);
-        item->setBackground(Qt::yellow);
+        QTableWidgetItem *item = m_searchList.at(m_searchIndex);
+        item->setBackground(QColor("#FFDEDE"));
 
-        item = searchList.at(newIndex);
-        item->setBackground(Qt::red);
-        table->scrollToItem(item);
-        searchIndex = newIndex;
+        item = m_searchList.at(newIndex);
+        item->setBackground(QColor("#FFBABA"));
+        m_table->scrollToItem(item);
+        m_searchIndex = newIndex;
     }
     else
     {
-        Clear();
+        clear();
     }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void VTableSearch::Find(const QString &term)
+QList<QTableWidgetItem *> VTableSearch::findItems(const QString &text)
 {
-    SCASSERT(table != nullptr)
-
-    Clear();
-
-    if (not term.isEmpty())
+    if (m_matchWord && !m_matchCase)
     {
-        searchList = table->findItems(term, Qt::MatchContains);
-
-        if (not searchList.isEmpty())
+        m_table->findItems(text,  Qt::MatchFixedString);
+    }
+    else if (m_matchWord && m_matchCase)
+    {
+        m_table->findItems(text,  Qt::MatchFixedString | Qt::MatchCaseSensitive);
+    }
+    else if (m_matchRegEx && !m_matchCase)
+    {
+        QRegularExpression regex(text, QRegularExpression::CaseInsensitiveOption);
+        if (regex.isValid())
         {
-            foreach(QTableWidgetItem *item, searchList)
-            {
-                item->setBackground(Qt::yellow);
-            }
-
-            searchIndex = 0;
-            QTableWidgetItem *item = searchList.at(searchIndex);
-            item->setBackground(Qt::red);
-            table->scrollToItem(item);
-
-            emit HasResult(true);
+            return m_table->findItems(regex.pattern(), Qt::MatchRegularExpression);
         }
     }
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-void VTableSearch::FindPrevious()
-{
-    int newIndex = searchIndex - 1;
-
-    if (newIndex < 0)
+    else if (m_matchRegEx && m_matchCase)
     {
-        newIndex = searchList.size() - 1;
-    }
-
-    ShowNext(newIndex);
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-void VTableSearch::FindNext()
-{
-    int newIndex = searchIndex + 1;
-
-    if (newIndex >= searchList.size())
-    {
-        newIndex = 0;
-    }
-
-    ShowNext(newIndex);
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-void VTableSearch::RemoveRow(int row)
-{
-    if (searchIndex < 0 || searchIndex >= searchList.size())
-    {
-        return;
-    }
-
-    const int indexRow = searchList.at(searchIndex)->row();
-
-    if (row <= indexRow)
-    {
-        foreach(QTableWidgetItem *item, searchList)
+        QRegularExpression regex(text);
+        if (regex.isValid())
         {
-            if (item->row() == row)
-            {
-                --searchIndex;
-            }
+            return m_table->findItems(regex.pattern(), Qt::MatchRegularExpression);
         }
     }
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-void VTableSearch::AddRow(int row)
-{
-    if (searchIndex < 0 || searchIndex >= searchList.size())
+    else if (m_matchCase)
     {
-        return;
+        return m_table->findItems(text, Qt::MatchContains | Qt::MatchCaseSensitive);
     }
 
-    const int indexRow = searchList.at(searchIndex)->row();
-
-    if (row <= indexRow)
-    {
-        foreach(QTableWidgetItem *item, searchList)
-        {
-            if (item->row() == row)
-            {
-                ++searchIndex;
-            }
-        }
-    }
-}
-
-//---------------------------------------------------------------------------------------------------------------------
-void VTableSearch::RefreshList(const QString &term)
-{
-    SCASSERT(table != nullptr)
-
-    if (term.isEmpty())
-    {
-        return;
-    }
-
-    searchList = table->findItems(term, Qt::MatchContains);
-
-    foreach(QTableWidgetItem *item, searchList)
-    {
-        item->setBackground(Qt::yellow);
-    }
-
-    if (not searchList.isEmpty())
-    {
-        if (searchIndex < 0)
-        {
-           searchIndex = searchList.size() - 1;
-        }
-        else if (searchIndex >= searchList.size())
-        {
-           searchIndex = 0;
-        }
-
-        QTableWidgetItem *item = searchList.at(searchIndex);
-        item->setBackground(Qt::red);
-        table->scrollToItem(item);
-
-        emit HasResult(true);
-    }
-    else
-    {
-        emit HasResult(false);
-    }
+    return m_table->findItems(text, Qt::MatchContains);
 }

--- a/src/libs/vmisc/vtablesearch.h
+++ b/src/libs/vmisc/vtablesearch.h
@@ -1,53 +1,54 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//-----------------------------------------------------------------------------
+//  @file   vtablesearch.h
+//  @author Douglas S Caskey
+//  @date   12 Jun, 2025
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2013-2025 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
- ************************************************************************
- **
- **  @file   vtablesearch.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   15 9, 2015
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   vtablesearch.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   15 9, 2015
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentine project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2015 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
 
 #ifndef VTABLESEARCH_H
 #define VTABLESEARCH_H
@@ -64,25 +65,33 @@ class VTableSearch: public QObject
 public:
     explicit VTableSearch(QTableWidget *table, QObject *parent = nullptr);
 
-    void Find(const QString &term);
-    void FindPrevious();
-    void FindNext();
-    void RemoveRow(int row);
-    void AddRow(int row);
-    void RefreshList(const QString &term);
+    void find(const QString &term);
+    void findPrevious();
+    void findNext();
+    void removeRow(int row);
+    void addRow(int row);
+    void refreshList(const QString &term);
+
+    void setMatchRegEx(bool value);
+    void setMatchCase(bool value);
+    void setMatchWord(bool value);
 
 signals:
-    void HasResult(bool state);
+    void hasResult(bool state);
 
 private:
     Q_DISABLE_COPY(VTableSearch)
 
-    QTableWidget *table;
-    int           searchIndex;
-    QList<QTableWidgetItem *> searchList;
+    QTableWidget              *m_table;
+    int                        m_searchIndex;
+    QList<QTableWidgetItem *>  m_searchList;
+    bool                       m_matchRegEx;
+    bool                       m_matchCase;
+    bool                       m_matchWord;
 
-    void Clear();
-    void ShowNext(int newIndex);
+    void                       clear();
+    void                       showNext(int newIndex);
+    QList<QTableWidgetItem *>  findItems(const QString &text);
 };
 
 #endif // VTABLESEARCH_H


### PR DESCRIPTION
This PR addresses issue #1300 

Adds the following to the History Dialog: 

- Search Previous and Next buttons.
- Search by RegEx. A regular expression can be used as the search text.
- Search by Case sensivity.
- Search by Word. Searches by fixed word. 

![Screenshot 2025-06-13 221043](https://github.com/user-attachments/assets/f856b5fd-15ff-46b4-9f30-21e824821a73)

Adds the following to the Seamly Me measurments table:

- Search by RegEx. A regular expression can be used as the search text.
- Search by Case sensivity.
- Search by Word. Searches by fixed word. 

![Screenshot 2025-06-12 175926](https://github.com/user-attachments/assets/17c401f0-27ed-45d9-a719-5e5137b422ad)

lupdate

Closes issue #1300 
