### PR TITLE
fix: use only scalable fonts

### DIFF
--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -2404,6 +2404,7 @@ void MainWindow::initializeModesToolBar()
 void MainWindow::initializePointNameToolBar()
 {
     fontComboBox = new QFontComboBox ;
+    fontComboBox->setFontFilters(QFontComboBox::ScalableFonts);
     fontComboBox->setCurrentFont(qApp->Seamly2DSettings()->getPointNameFont());
     ui->pointName_ToolBar->insertWidget(ui->showPointNames_Action,fontComboBox);
     fontComboBox->setSizeAdjustPolicy(QComboBox::AdjustToContents);


### PR DESCRIPTION
This PR filters the QFontComboBox to use only scalable fonts, thus removing the bitmap .fon fonts that may cause issues with DirectWrite in Windows. 

Closes issue #1315 

