### PR TITLE
feature: Set background color

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -9111,6 +9111,14 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation>V rozbalovacích nabídkách zobrazovat pouze tloušťky čar ISO</translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Pracovní prostor</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Pozadí:</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11876,10 +11884,6 @@ SeamlyME jako obvykle.
         <translation>Světle ocelově modrá</translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation>Béžová</translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation>Bodlák</translation>
     </message>
@@ -11910,6 +11914,10 @@ SeamlyME jako obvykle.
     <message>
         <source>Tan</source>
         <translation>Opálení</translation>
+    </message>
+    <message>
+        <source>Beige</source>
+        <translation>Béžový</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -9097,6 +9097,14 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
         <source>Show only ISO line weights in drop down boxes</source>
         <translation>Nur ISO-Liniengewichte in Dropdown-Boxen anzeigen</translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Arbeitsplatz</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Hintergrund:</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11862,11 +11870,6 @@ wie gewohnt in SeamlyME laden können.
         <translation>Helles Stahlblau</translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translatorcomment>ist schon deutsch</translatorcomment>
-        <translation>Beige</translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation>Distelfarben</translation>
     </message>
@@ -11898,6 +11901,10 @@ wie gewohnt in SeamlyME laden können.
         <source>Tan</source>
         <translatorcomment>oder auch Gelbbraun</translatorcomment>
         <translation>Hellbraun</translation>
+    </message>
+    <message>
+        <source>Beige</source>
+        <translation>Beige</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -9115,6 +9115,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation>Εμφάνιση μόνο των βαρών γραμμών ISO στα αναπτυσσόμενα πλαίσια</translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Χώρος εργασίας</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Φόντο:</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11880,10 +11888,6 @@ load in SeamlyME as usual.
         <translation>Ανοιχτό μπλε ατσάλι</translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation>Μπεζ</translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation>Γαϊδουράγκαθο</translation>
     </message>
@@ -11914,6 +11918,10 @@ load in SeamlyME as usual.
     <message>
         <source>Tan</source>
         <translation>Μαύρο</translation>
+    </message>
+    <message>
+        <source>Beige</source>
+        <translation>Μπεζ</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -9082,6 +9082,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11841,10 +11849,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11874,6 +11878,10 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Tan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beige</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -9082,6 +9082,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11841,10 +11849,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11874,6 +11878,10 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Tan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beige</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -9082,6 +9082,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11841,10 +11849,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11874,6 +11878,10 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Tan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beige</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -9082,6 +9082,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11841,10 +11849,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11874,6 +11878,10 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Tan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beige</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -9151,6 +9151,14 @@ actualización:</translation>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation>Mostrar sólo los pesos de línea ISO en los cuadros desplegables</translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Espacio de trabajo</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Fondo:</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11918,10 +11926,6 @@ load in SeamlyME as usual.
         <translation>Azul grisáceo muy claro</translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation>Biege</translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation>Lila muy claro</translation>
     </message>
@@ -11952,6 +11956,10 @@ load in SeamlyME as usual.
     <message>
         <source>Tan</source>
         <translation>beige oscuro</translation>
+    </message>
+    <message>
+        <source>Beige</source>
+        <translation>Beige</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -9113,6 +9113,14 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
         <source>Show only ISO line weights in drop down boxes</source>
         <translation>Näytä alasvetovalikoissa vain ISO-viivan paksuudet</translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Työtila</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Tausta:</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11878,10 +11886,6 @@ Haluatko tallentaa muutokset?</translation>
         <translation>Vaalean teräksensininen</translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation>Biège</translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation>Ohdake</translation>
     </message>
@@ -11912,6 +11916,10 @@ Haluatko tallentaa muutokset?</translation>
     <message>
         <source>Tan</source>
         <translation>Rusketus</translation>
+    </message>
+    <message>
+        <source>Beige</source>
+        <translation>Beige</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -9128,6 +9128,14 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
         <source>Show only ISO line weights in drop down boxes</source>
         <translation>Afficher uniquement les Épaisseur de ligne ISO</translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Espace de travail</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Arrière-plan:</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11894,10 +11902,6 @@ charger dans SeamlyME comme d&apos;habitude.
         <translation>Bleu acier clair</translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation>Beige</translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation>Chardon</translation>
     </message>
@@ -11928,6 +11932,10 @@ charger dans SeamlyME comme d&apos;habitude.
     <message>
         <source>Tan</source>
         <translation>Bronzage</translation>
+    </message>
+    <message>
+        <source>Beige</source>
+        <translation>Beige</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -9078,6 +9078,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11836,10 +11844,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11869,6 +11873,10 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Tan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beige</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -9113,6 +9113,14 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation>Tampilkan hanya bobot garis ISO di kotak drop down</translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Ruang kerja</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Latar belakang:</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11878,10 +11886,6 @@ unggah ke SeamlyME seperti biasa.
         <translation>Baja Biru Muda</translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation>Biege</translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation>Bunga thistle</translation>
     </message>
@@ -11912,6 +11916,10 @@ unggah ke SeamlyME seperti biasa.
     <message>
         <source>Tan</source>
         <translation>Coklat</translation>
+    </message>
+    <message>
+        <source>Beige</source>
+        <translation>Krem</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -9101,6 +9101,14 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation>Mostra solo i pesi delle linee ISO nelle caselle a discesa</translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Area di lavoro</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Sfondo:</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11866,10 +11874,6 @@ caricare in SeamlyME come di consueto.
         <translation>Blu acciaio chiaro</translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation>Beige</translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation>Cardo</translation>
     </message>
@@ -11900,6 +11904,10 @@ caricare in SeamlyME come di consueto.
     <message>
         <source>Tan</source>
         <translation>Abbronzatura</translation>
+    </message>
+    <message>
+        <source>Beige</source>
+        <translation>Beige</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -9096,6 +9096,14 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation>Toon alleen ISO-lijndiktes in vervolgkeuzelijsten</translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Werkruimte</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Achtergrond:</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11862,10 +11870,6 @@ load in SeamlyME as usual.
         <translation>Licht staalblauw</translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation>Beige</translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation>Distel</translation>
     </message>
@@ -11896,6 +11900,10 @@ load in SeamlyME as usual.
     <message>
         <source>Tan</source>
         <translation>Zonnebruin</translation>
+    </message>
+    <message>
+        <source>Beige</source>
+        <translation>Beige</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -9099,6 +9099,14 @@ Prima enter para o adicionar temporariamente à lista.</translation>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation>Mostrar apenas espessuras de linha ISO em caixas suspensas</translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Espaço de trabalho</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Fundo:</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11864,10 +11872,6 @@ carregar no SeamlyME como de costume.
         <translation>Azul Aâo Claro</translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation>Preto</translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation>Cardo</translation>
     </message>
@@ -11898,6 +11902,10 @@ carregar no SeamlyME como de costume.
     <message>
         <source>Tan</source>
         <translation>bronzeado</translation>
+    </message>
+    <message>
+        <source>Beige</source>
+        <translation>Bege</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -9115,6 +9115,14 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation>Afișează doar grosimile de linie ISO în casetele derulante</translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Spațiu de lucru</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Fundal:</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11879,10 +11887,6 @@ load in SeamlyME as usual.
         <translation>Albastru deschis de oțel</translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation>Bianc</translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation>Ciulin</translation>
     </message>
@@ -11913,6 +11917,10 @@ load in SeamlyME as usual.
     <message>
         <source>Tan</source>
         <translation>Bronz</translation>
+    </message>
+    <message>
+        <source>Beige</source>
+        <translation>Bej</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -9120,6 +9120,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation>Показывать только веса линий ISO в раскрывающихся списках</translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Рабочее пространство</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Фон:</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11885,10 +11893,6 @@ load in SeamlyME as usual.
         <translation>Светло-стальной синий</translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation>Бежевый</translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation>Чертополох</translation>
     </message>
@@ -11919,6 +11923,10 @@ load in SeamlyME as usual.
     <message>
         <source>Tan</source>
         <translation>Светло-Бежевый</translation>
+    </message>
+    <message>
+        <source>Beige</source>
+        <translation>Бежевый</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -9113,6 +9113,14 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation>Açılır kutularda yalnızca ISO çizgi kalınlıklarını göster</translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Çalışma alanı</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Arka plan:</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11877,10 +11885,6 @@ load in SeamlyME as usual.
         <translation>Açık Çelik Mavisi</translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation>Bej</translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation>Deve Dikeni</translation>
     </message>
@@ -11911,6 +11915,10 @@ load in SeamlyME as usual.
     <message>
         <source>Tan</source>
         <translation>Bronz</translation>
+    </message>
+    <message>
+        <source>Beige</source>
+        <translation>Bej</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -9114,6 +9114,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation>Εμφάνιση μόνο των βαρών γραμμών ISO στα αναπτυσσόμενα πλαίσια</translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation>Робочий простір</translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation>Передумова:</translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11879,10 +11887,6 @@ load in SeamlyME as usual.
         <translation>Ανοιχτό μπλε ατσάλι</translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation>Μπεζ</translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation>Γαϊδουράγκαθο</translation>
     </message>
@@ -11913,6 +11917,10 @@ load in SeamlyME as usual.
     <message>
         <source>Tan</source>
         <translation>Μαύρο</translation>
+    </message>
+    <message>
+        <source>Beige</source>
+        <translation>Бежевий</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -9078,6 +9078,14 @@ Press enter to temporarily add it to the list.</source>
         <source>Show only ISO line weights in drop down boxes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Background:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PreferencesPathPage</name>
@@ -11836,10 +11844,6 @@ load in SeamlyME as usual.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Biege</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Thistle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11869,6 +11873,10 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>Tan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Beige</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
@@ -36,6 +36,7 @@
 #include <QAbstractButton>
 #include <QButtonGroup>
 #include <QCheckBox>
+#include <QComboBox>
 #include <QDir>
 #include <QDirIterator>
 #include <QDoubleSpinBox>
@@ -50,15 +51,6 @@ Q_LOGGING_CATEGORY(vGraphicsViewConfig, "vgraphicsviewconfig")
 PreferencesGraphicsViewPage::PreferencesGraphicsViewPage (QWidget *parent)
     : QWidget(parent)
     , ui(new Ui::PreferencesGraphicsViewPage)
-    , m_bgColorChanged(false)
-    , m_zrbPositiveColorChanged(false)
-    , m_zrbNegativeColorChanged(false)
-    , m_pointNameColorChanged(false)
-    , m_pointNameHoverColorChanged(false)
-    , m_orginAxisColorChanged(false)
-    , m_primarySupportColorChanged(false)
-    , m_secondarySupportColorChanged(false)
-    , m_tertiarySupportColorChanged(false)
 {
     ui->setupUi(this);
     // Appearance preferences
@@ -98,103 +90,28 @@ PreferencesGraphicsViewPage::PreferencesGraphicsViewPage (QWidget *parent)
     ui->graphicsOutput_CheckBox->setChecked(qApp->Seamly2DSettings()->GetGraphicalOutput());
 
     // Color preferences
-    //-----------------------  Background Color
+    // Background Color
     ui->bgColor_ComboBox->setItems(VAbstractTool::backgroundColorsList());
-    int index = ui->bgColor_ComboBox->findText(qApp->Seamly2DSettings()->getBackgroundColor());
-    if (index != -1)
-    {
-        ui->bgColor_ComboBox->setCurrentIndex(index);
-    }
-    connect(ui->bgColor_ComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, [this]()
-    {
-        m_bgColorChanged = true;
-    });
+    setIndex(ui->bgColor_ComboBox, qApp->Seamly2DSettings()->getBackgroundColor());
 
     // Zoom Rubberband colors
-    index = ui->zrbPositiveColor_ComboBox->findText(qApp->Seamly2DSettings()->getZoomRBPositiveColor());
-    if (index != -1)
-    {
-        ui->zrbPositiveColor_ComboBox->setCurrentIndex(index);
-    }
-    connect(ui->zrbPositiveColor_ComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]()
-    {
-        m_zrbPositiveColorChanged = true;
-    });
+    setIndex(ui->zrbPositiveColor_ComboBox, qApp->Seamly2DSettings()->getZoomRBPositiveColor());
+    setIndex(ui->zrbNegativeColor_ComboBox, qApp->Seamly2DSettings()->getZoomRBNegativeColor());
 
-    index = ui->zrbNegativeColor_ComboBox->findText(qApp->Seamly2DSettings()->getZoomRBNegativeColor());
-    if (index != -1)
-    {
-        ui->zrbNegativeColor_ComboBox->setCurrentIndex(index);
-    }
-    connect(ui->zrbNegativeColor_ComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]()
-    {
-        m_zrbNegativeColorChanged = true;
-    });
+    // Point name colors
+    setIndex(ui->pointNameColor_ComboBox, qApp->Seamly2DSettings()->getPointNameColor());
+    setIndex(ui->pointNameHoverColor_ComboBox, qApp->Seamly2DSettings()->getPointNameHoverColor());
 
-    index = ui->pointNameColor_ComboBox->findText(qApp->Seamly2DSettings()->getPointNameColor());
-    if (index != -1)
-    {
-        ui->pointNameColor_ComboBox->setCurrentIndex(index);
-    }
-    connect(ui->pointNameColor_ComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]()
-    {
-        m_pointNameColorChanged = true;
-    });
+    // Axis Orgin Color
+    setIndex(ui->axisOrginColor_ComboBox, qApp->Seamly2DSettings()->getAxisOrginColor());
 
-    index = ui->pointNameHoverColor_ComboBox->findText(qApp->Seamly2DSettings()->getPointNameHoverColor());
-    if (index != -1)
-    {
-        ui->pointNameHoverColor_ComboBox->setCurrentIndex(index);
-    }
-    connect(ui->pointNameHoverColor_ComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]()
-    {
-        m_pointNameHoverColorChanged = true;
-    });
-
-    //----------------------- Axis Orgin Color
-    index = ui->axisOrginColor_ComboBox->findText(qApp->Seamly2DSettings()->getAxisOrginColor());
-    if (index != -1)
-    {
-        ui->axisOrginColor_ComboBox->setCurrentIndex(index);
-    }
-    connect(ui->axisOrginColor_ComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]()
-    {
-        m_orginAxisColorChanged = true;
-    });
-
-    //----------------------- Selection Support Colors
+    // Selection Support Colors
     ui->primarySupportColor_ComboBox->setItems(VAbstractTool::supportColorsList());
     ui->secondarySupportColor_ComboBox->setItems(VAbstractTool::supportColorsList());
     ui->tertiarySupportColor_ComboBox->setItems(VAbstractTool::supportColorsList());
-    index = ui->primarySupportColor_ComboBox->findText(qApp->Seamly2DSettings()->getPrimarySupportColor());
-    if (index != -1)
-    {
-        ui->primarySupportColor_ComboBox->setCurrentIndex(index);
-    }
-    connect(ui->primarySupportColor_ComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]()
-    {
-        m_primarySupportColorChanged = true;
-    });
-
-    index = ui->secondarySupportColor_ComboBox->findText(qApp->Seamly2DSettings()->getSecondarySupportColor());
-    if (index != -1)
-    {
-        ui->secondarySupportColor_ComboBox->setCurrentIndex(index);
-    }
-    connect(ui->secondarySupportColor_ComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]()
-    {
-        m_secondarySupportColorChanged = true;
-    });
-
-    index = ui->tertiarySupportColor_ComboBox->findText(qApp->Seamly2DSettings()->getTertiarySupportColor());
-    if (index != -1)
-    {
-        ui->tertiarySupportColor_ComboBox->setCurrentIndex(index);
-    }
-    connect(ui->tertiarySupportColor_ComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this]()
-    {
-        m_tertiarySupportColorChanged = true;
-    });
+    setIndex(ui->primarySupportColor_ComboBox, qApp->Seamly2DSettings()->getPrimarySupportColor());
+    setIndex(ui->secondarySupportColor_ComboBox, qApp->Seamly2DSettings()->getSecondarySupportColor());
+    setIndex(ui->tertiarySupportColor_ComboBox, qApp->Seamly2DSettings()->getTertiarySupportColor());
 
     // Navigation preferences
     // Show Scroll Bars
@@ -250,7 +167,7 @@ PreferencesGraphicsViewPage::PreferencesGraphicsViewPage (QWidget *parent)
     QFont nameFont = qApp->Seamly2DSettings()->getPointNameFont();
     ui->pointNameFont_ComboBox->setCurrentFont(nameFont);
 
-    index = ui->pointNameFontSize_ComboBox->findText(QString().setNum(qApp->Seamly2DSettings()->getPointNameSize()));
+    int index = ui->pointNameFontSize_ComboBox->findText(QString().setNum(qApp->Seamly2DSettings()->getPointNameSize()));
     if (index != -1)
     {
         ui->pointNameFontSize_ComboBox->setCurrentIndex(index);
@@ -369,61 +286,25 @@ void PreferencesGraphicsViewPage::Apply()
     qApp->getSceneView()->setRenderHint(QPainter::SmoothPixmapTransform, ui->graphicsOutput_CheckBox->isChecked());
 
     // Color preferences
-    if (m_bgColorChanged)
-    {
-      settings->setBackgroundColor(ui->bgColor_ComboBox->currentText());
-      m_bgColorChanged = false;
-    }
+    // Background color
+    settings->setBackgroundColor(ui->bgColor_ComboBox->currentData().toString());
+
 
     // Zoom Rubberband colors
-    if (m_zrbPositiveColorChanged)
-    {
-      settings->setZoomRBPositiveColor(ui->zrbPositiveColor_ComboBox->currentText());
-      m_zrbPositiveColorChanged = false;
-    }
-
-    if (m_zrbNegativeColorChanged)
-    {
-      settings->setZoomRBNegativeColor(ui->zrbNegativeColor_ComboBox->currentText());
-      m_zrbNegativeColorChanged = false;
-    }
+    settings->setZoomRBPositiveColor(ui->zrbPositiveColor_ComboBox->currentData().toString());
+    settings->setZoomRBNegativeColor(ui->zrbNegativeColor_ComboBox->currentData().toString());
 
     // Point Name colors
-    if (m_pointNameColorChanged)
-    {
-      settings->setPointNameColor(ui->pointNameColor_ComboBox->currentText());
-      m_pointNameColorChanged = false;
-    }
+    settings->setPointNameColor(ui->pointNameColor_ComboBox->currentData().toString());
+    settings->setPointNameHoverColor(ui->pointNameHoverColor_ComboBox->currentData().toString());
 
-    if (m_pointNameHoverColorChanged)
-    {
-      settings->setPointNameHoverColor(ui->pointNameHoverColor_ComboBox->currentText());
-      m_pointNameHoverColorChanged = false;
-    }
+    // Avxi Origin color
+    settings->setAxisOrginColor(ui->axisOrginColor_ComboBox->currentData().toString());
 
-    if (m_orginAxisColorChanged)
-    {
-      settings->setAxisOrginColor(ui->axisOrginColor_ComboBox->currentText());
-      m_orginAxisColorChanged = false;
-    }
-
-    if (m_primarySupportColorChanged)
-    {
-      settings->setPrimarySupportColor(ui->primarySupportColor_ComboBox->currentText());
-      m_primarySupportColorChanged = false;
-    }
-
-    if (m_secondarySupportColorChanged)
-    {
-      settings->setSecondarySupportColor(ui->secondarySupportColor_ComboBox->currentText());
-      m_secondarySupportColorChanged = false;
-    }
-
-    if (m_tertiarySupportColorChanged)
-    {
-      settings->setTertiarySupportColor(ui->tertiarySupportColor_ComboBox->currentText());
-      m_tertiarySupportColorChanged = false;
-    }
+    // Support colors
+    settings->setPrimarySupportColor(ui->primarySupportColor_ComboBox->currentData().toString());
+    settings->setSecondarySupportColor(ui->secondarySupportColor_ComboBox->currentData().toString());
+    settings->setTertiarySupportColor(ui->tertiarySupportColor_ComboBox->currentData().toString());
 
     // Navigation preferences
     // Scroll Bars
@@ -463,4 +344,18 @@ void PreferencesGraphicsViewPage::Apply()
 
     settings->setPointNameFont(ui->pointNameFont_ComboBox->currentFont());
     settings->setPointNameSize(ui->pointNameFontSize_ComboBox->currentText().toInt());
+}
+
+void PreferencesGraphicsViewPage::setIndex(QComboBox *box, const QString &text)
+{
+    int index;
+    index = box->findData(text);
+    if (index != -1)
+    {
+        box->setCurrentIndex(index);
+    }
+    else
+    {
+        box->setCurrentIndex(box->findText(text));
+    }
 }

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.cpp
@@ -50,6 +50,7 @@ Q_LOGGING_CATEGORY(vGraphicsViewConfig, "vgraphicsviewconfig")
 PreferencesGraphicsViewPage::PreferencesGraphicsViewPage (QWidget *parent)
     : QWidget(parent)
     , ui(new Ui::PreferencesGraphicsViewPage)
+    , m_bgColorChanged(false)
     , m_zrbPositiveColorChanged(false)
     , m_zrbNegativeColorChanged(false)
     , m_pointNameColorChanged(false)
@@ -96,13 +97,21 @@ PreferencesGraphicsViewPage::PreferencesGraphicsViewPage (QWidget *parent)
     // Antialiasing
     ui->graphicsOutput_CheckBox->setChecked(qApp->Seamly2DSettings()->GetGraphicalOutput());
 
-    ui->primarySupportColor_ComboBox->setItems(VAbstractTool::supportColorsList());
-    ui->secondarySupportColor_ComboBox->setItems(VAbstractTool::supportColorsList());
-    ui->tertiarySupportColor_ComboBox->setItems(VAbstractTool::supportColorsList());
-
     // Color preferences
+    //-----------------------  Background Color
+    ui->bgColor_ComboBox->setItems(VAbstractTool::backgroundColorsList());
+    int index = ui->bgColor_ComboBox->findText(qApp->Seamly2DSettings()->getBackgroundColor());
+    if (index != -1)
+    {
+        ui->bgColor_ComboBox->setCurrentIndex(index);
+    }
+    connect(ui->bgColor_ComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, [this]()
+    {
+        m_bgColorChanged = true;
+    });
+
     // Zoom Rubberband colors
-    int index = ui->zrbPositiveColor_ComboBox->findText(qApp->Seamly2DSettings()->getZoomRBPositiveColor());
+    index = ui->zrbPositiveColor_ComboBox->findText(qApp->Seamly2DSettings()->getZoomRBPositiveColor());
     if (index != -1)
     {
         ui->zrbPositiveColor_ComboBox->setCurrentIndex(index);
@@ -154,6 +163,9 @@ PreferencesGraphicsViewPage::PreferencesGraphicsViewPage (QWidget *parent)
     });
 
     //----------------------- Selection Support Colors
+    ui->primarySupportColor_ComboBox->setItems(VAbstractTool::supportColorsList());
+    ui->secondarySupportColor_ComboBox->setItems(VAbstractTool::supportColorsList());
+    ui->tertiarySupportColor_ComboBox->setItems(VAbstractTool::supportColorsList());
     index = ui->primarySupportColor_ComboBox->findText(qApp->Seamly2DSettings()->getPrimarySupportColor());
     if (index != -1)
     {
@@ -357,6 +369,12 @@ void PreferencesGraphicsViewPage::Apply()
     qApp->getSceneView()->setRenderHint(QPainter::SmoothPixmapTransform, ui->graphicsOutput_CheckBox->isChecked());
 
     // Color preferences
+    if (m_bgColorChanged)
+    {
+      settings->setBackgroundColor(ui->bgColor_ComboBox->currentText());
+      m_bgColorChanged = false;
+    }
+
     // Zoom Rubberband colors
     if (m_zrbPositiveColorChanged)
     {

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.h
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.h
@@ -51,6 +51,7 @@ protected:
 private:
     Q_DISABLE_COPY(PreferencesGraphicsViewPage )
     Ui::PreferencesGraphicsViewPage  *ui;
+    bool                              m_bgColorChanged;
     bool                              m_zrbPositiveColorChanged;
     bool                              m_zrbNegativeColorChanged;
     bool                              m_pointNameColorChanged;

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.h
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.h
@@ -28,6 +28,7 @@
 #define PREFERENCES_GRAPHICSVIEWPAGE_H
 
 #include <QWidget>
+#include <QComboBox>
 
 namespace Ui
 {
@@ -46,20 +47,13 @@ public:
 
 protected:
     void                              enableOffsets();
-    virtual void                      changeEvent(QEvent* event) Q_DECL_OVERRIDE;
+    virtual void                      changeEvent(QEvent *event) Q_DECL_OVERRIDE;
 
 private:
     Q_DISABLE_COPY(PreferencesGraphicsViewPage )
     Ui::PreferencesGraphicsViewPage  *ui;
-    bool                              m_bgColorChanged;
-    bool                              m_zrbPositiveColorChanged;
-    bool                              m_zrbNegativeColorChanged;
-    bool                              m_pointNameColorChanged;
-    bool                              m_pointNameHoverColorChanged;
-    bool                              m_orginAxisColorChanged;
-    bool                              m_primarySupportColorChanged;
-    bool                              m_secondarySupportColorChanged;
-    bool                              m_tertiarySupportColorChanged;
+
+    void                              setIndex(QComboBox *box, const QString &text);
 };
 
 #endif // PREFERENCES_GRAPHICSVIEWPAGE_H

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
@@ -75,7 +75,7 @@
       <enum>QTabWidget::West</enum>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="appearanceTab">
       <attribute name="title">

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.ui
@@ -75,7 +75,7 @@
       <enum>QTabWidget::West</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="appearanceTab">
       <attribute name="title">
@@ -1458,6 +1458,98 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_18">
        <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="title">
+          <string>Workspace</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_26">
+          <item>
+           <layout class="QFormLayout" name="formLayout_12">
+            <item row="0" column="0">
+             <widget class="QLabel" name="bgColor_Label">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>85</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Background:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="ColorComboBox" name="bgColor_ComboBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>0</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">background-color: rgb(255, 255, 255);</string>
+              </property>
+              <property name="maxVisibleItems">
+               <number>15</number>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>40</width>
+                <height>14</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="zoomRubberBandGroupBox">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -1524,9 +1616,15 @@
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
-              <property name="maximumSize">
+              <property name="minimumSize">
                <size>
                 <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>0</width>
                 <height>16777215</height>
                </size>
               </property>

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -529,6 +529,8 @@ void MainWindow::initializeScenes()
     connect(ui->view, &VMainGraphicsView::signalZoomScaleChanged, this, &MainWindow::zoomScaleChanged);
 
     qApp->setSceneView(ui->view);
+
+    setSceneBackgroundColor();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -3707,6 +3709,20 @@ void MainWindow::keyReleaseEvent(QKeyEvent *event)
     QMainWindow::keyReleaseEvent(event);
 }
 
+//-----------------------------------------------------------------------------
+/// @brief setSceneBackgroundColor Sets the scene background color.
+///
+/// This method Sets the background color of the draft and piece scenes.
+///
+/// @details Uses the background color preference saved in the settigs.
+//-----------------------------------------------------------------------------
+void MainWindow::setSceneBackgroundColor()
+{
+    QColor color = QColor(qApp->Seamly2DSettings()->getBackgroundColor());
+    draftScene->setBackgroundBrush(color);
+    pieceScene->setBackgroundBrush(color);
+}
+
 //---------------------------------------------------------------------------------------------------------------------
 /**
  * @brief SaveCurrentScene save scene options before set another.
@@ -6694,6 +6710,7 @@ void MainWindow::updatePreferences()
     refreshLabels();
     resetOrigins();
     upDateScenes();
+    setSceneBackgroundColor();
     updateViewToolbar();
     resetPanShortcuts();
     initPropertyEditor();

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -388,8 +388,10 @@ private:
     void               setToolsEnabled(bool enable);
     void               SetLayoutModeActions();
 
+    void               setSceneBackgroundColor();
     void               SaveCurrentScene();
     void               RestoreCurrentScene();
+
     void               MinimumScrollBar();
 
     template <typename Dialog, typename Func>

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -145,6 +145,7 @@ const QString settingGraphicsViewUseDefaultPen           = QStringLiteral("graph
 const QString settingGraphicsViewShowIsoOnly             = QStringLiteral("graphicsview/showOnlyIso");
 const QString settingGraphicsViewZoomSpeedFactor         = QStringLiteral("graphicsview/zoomSpeedFactor");
 const QString settingGraphicsViewExportQuality           = QStringLiteral("graphicsview/exportQuality");
+const QString settingGraphicsViewBackgroundColor         = QStringLiteral("graphicsview/backgroundColor");
 const QString settingGraphicsViewZoomRBPositiveColor     = QStringLiteral("graphicsview/zoomRBPositiveColor");
 const QString settingGraphicsViewZoomRBNegativeColor     = QStringLiteral("graphicsview/zoomRBNegativeColor");
 const QString settingGraphicsViewPointNameColor          = QStringLiteral("graphicsview/pointNameColor");
@@ -1116,6 +1117,30 @@ int  VCommonSettings::getExportQuality() const
 void VCommonSettings::setExportQuality(const int  &value)
 {
     setValue(settingGraphicsViewExportQuality, value);
+}
+
+//-----------------------------------------------------------------------------
+/// @brief getBackgroundColor Gets the background color.
+///
+/// This method gets the name of the background color from the settings.
+///
+/// @return String name of the background color.
+//-----------------------------------------------------------------------------
+QString VCommonSettings::getBackgroundColor() const
+{
+    return value(settingGraphicsViewBackgroundColor, "White").toString();
+}
+
+//-----------------------------------------------------------------------------
+/// @brief setBackgroundColor Sets the background color.
+///
+/// This method saves the background color name to the settings.
+///
+/// @param color String name of background color to save.
+//-----------------------------------------------------------------------------
+void VCommonSettings::setBackgroundColor(const QString &color)
+{
+    setValue(settingGraphicsViewBackgroundColor, color);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vmisc/vcommonsettings.h
+++ b/src/libs/vmisc/vcommonsettings.h
@@ -244,6 +244,9 @@ public:
     int                  getExportQuality() const;
     void                 setExportQuality(const int &value);
 
+    QString              getBackgroundColor() const;
+    void                 setBackgroundColor(const QString &color);
+
     QString              getZoomRBPositiveColor() const;
     void                 setZoomRBPositiveColor(const QString &value);
 

--- a/src/libs/vtools/tools/vabstracttool.cpp
+++ b/src/libs/vtools/tools/vabstracttool.cpp
@@ -439,7 +439,7 @@ QMap<QString, QString> VAbstractTool::backgroundColorsList()
     map.insert("lightgrey", tr("Light Grey"));
     map.insert("darkslategrey", tr("Dark Slate Grey"));
     map.insert("lightsteelblue", tr("Light Steel Blue"));
-    map.insert("biege", tr("Biege"));
+    map.insert("beige", tr("Beige"));
     map.insert("thistle", tr("Thistle"));
     map.insert("silver", tr("Silver"));
     map.insert("whitesmoke", tr("White Smoke"));

--- a/src/libs/vwidgets/color_combobox.cpp
+++ b/src/libs/vwidgets/color_combobox.cpp
@@ -1,6 +1,29 @@
-/******************************************************************************
- *   @file   color_combobox.cpp                                               *
- *****************************************************************************/
+//-----------------------------------------------------------------------------
+//  @file   color_comboox.cpp
+//  @author Douglas S Caskey
+//  @date   11 Apr, 2025
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017-2025 Seamly2D project
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//-----------------------------------------------------------------------------
+
 #include <QColor>
 #include <QPixmap>
 #include <QMap>
@@ -15,9 +38,14 @@
 
 Q_LOGGING_CATEGORY(colorComboBox, "color_combobox")
 
-/*
- * Default Constructor.
- */
+//-----------------------------------------------------------------------------
+/// @brief ColorComboBox Color comnbo box.
+///
+/// This is the constructor that provides just a name for the box.
+///
+/// @param parent parent widget.
+/// @param name name of combobox.
+//-----------------------------------------------------------------------------
 ColorComboBox::ColorComboBox(QWidget *parent, const char *name)
     : QComboBox(parent)
     , m_currentColor("black")
@@ -29,9 +57,16 @@ ColorComboBox::ColorComboBox(QWidget *parent, const char *name)
     init();
 }
 
-/*
- * Constructor that provides width and height for icon.
- */
+//-----------------------------------------------------------------------------
+/// @brief ColorComboBox Color comnbo box.
+///
+/// This is the constructor that provides width and height for icon, and a name.
+///
+/// @param width width of icon.
+/// @param height height of icon.
+/// @param parent parent widget.
+/// @param name name of combobox.
+//-----------------------------------------------------------------------------
 ColorComboBox::ColorComboBox(int width, int height, QWidget *parent, const char *name)
     : QComboBox(parent)
     , m_currentColor("black")
@@ -44,23 +79,29 @@ ColorComboBox::ColorComboBox(int width, int height, QWidget *parent, const char 
     init();
 }
 
-/**
- * Destructor
- */
+//-----------------------------------------------------------------------------*
+/// @brief ~ColorComboBox Color comnbo box.
+///
+/// This is the destructor.
+//-----------------------------------------------------------------------------
 ColorComboBox::~ColorComboBox(){}
 
-/*
- * Initialisation called from constructor or manually but only once.
- */
+//-----------------------------------------------------------------------------
+/// @brief init Initialisation called from constructor or manually but only once.
+//-----------------------------------------------------------------------------
 void ColorComboBox::init()
 {
     setItems(VAbstractTool::ColorsList());
     connect(this, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ColorComboBox::colorChanged);
 }
 
-/*
- * Sets the items shown in the combobox and sets index to the 1st color.
- */
+//-----------------------------------------------------------------------------
+/// @brief setItems Sets the items shown in the combobox and sets index to the 1st color.
+///
+/// This method sets the item list for the combobox.
+///
+/// @param map QMap of the text & data pair for combobox.
+//-----------------------------------------------------------------------------
 void ColorComboBox::setItems(QMap<QString, QString> map)
 {
     this->blockSignals(true);
@@ -76,7 +117,7 @@ void ColorComboBox::setItems(QMap<QString, QString> map)
 #endif
 
     this->view()->setTextElideMode(Qt::ElideNone);
-    map.remove(ColorByGroup);
+    //map.remove(ColorByGroup);
     QMap<QString, QString>::const_iterator i = map.constBegin();
     while (i != map.constEnd())
     {
@@ -92,9 +133,13 @@ void ColorComboBox::setItems(QMap<QString, QString> map)
 
     this->blockSignals(false);
 }
-/*
- * Sets the color shown in the combobox to the given color.
- */
+//-----------------------------------------------------------------------------
+///@brief setColor Set boc color
+///
+/// This method sets the color shown in the combobox to the given color.
+///
+/// @param color color to set item index to.
+//-----------------------------------------------------------------------------
 void ColorComboBox::setColor(const QString &color)
 {
     qCDebug(colorComboBox, "ColorComboBox::setColor");
@@ -108,10 +153,14 @@ void ColorComboBox::setColor(const QString &color)
     }
 }
 
-/*
- * Called when the color has changed. This method sets the current color to the
- * value chosen.
- */
+//-----------------------------------------------------------------------------
+///@brief colorChanged Handle color index chamge
+///
+/// This Called when the color has changed. This method sets the current color to the
+/// value chosen.
+///
+/// @param index Item index to set box to.  
+//-----------------------------------------------------------------------------
 void ColorComboBox::colorChanged(int index)
 {
     qCDebug(colorComboBox, "ColorComboBox::colorChanged");


### PR DESCRIPTION
This PR addresses issue #1279

It adds a workspace background color preference so a user can select a color other than white (or black if they enable Darkmode on thier system). Changing from white can reduce glare, while not displaying a Darkmode white->black backgroud which makes it impossble to see the tool points and lines. 

![Screenshot 2025-06-22 202918](https://github.com/user-attachments/assets/78fdc6c1-e96e-471b-98ed-893d8fcb04ce)

Closes issue #1279 