### PR TITLE
bug: fix non-modal dialogs

### DIFF
--- a/src/app/seamly2d/dialogs/dialogvariables.cpp
+++ b/src/app/seamly2d/dialogs/dialogvariables.cpp
@@ -94,7 +94,7 @@ DialogVariables::DialogVariables(VContainer *data, VPattern *doc, QWidget *paren
     ui->setupUi(this);
 
     setWindowFlags(Qt::Window);
-    setWindowFlags((windowFlags() | Qt::WindowStaysOnTopHint) & ~Qt::WindowContextHelpButtonHint);
+    setWindowFlags(windowFlags() & ~Qt::WindowStaysOnTopHint & ~Qt::WindowContextHelpButtonHint);
 
     //Limit dialog height to 80% of screen size
     setMaximumHeight(qRound(QGuiApplication::primaryScreen()->availableGeometry().height() * .8));

--- a/src/app/seamly2d/dialogs/history_dialog.cpp
+++ b/src/app/seamly2d/dialogs/history_dialog.cpp
@@ -90,7 +90,7 @@ HistoryDialog::HistoryDialog(VContainer *data, VPattern *doc, QWidget *parent)
 {
     ui->setupUi(this);
     setWindowFlags(Qt::Window);
-    setWindowFlags((windowFlags() | Qt::WindowStaysOnTopHint | Qt::WindowMaximizeButtonHint) & ~Qt::WindowContextHelpButtonHint);
+    setWindowFlags(windowFlags() & ~Qt::WindowStaysOnTopHint & ~Qt::WindowContextHelpButtonHint);
 
     // Limit dialog height to 80% of screen size
     setMaximumHeight(qRound(QGuiApplication::primaryScreen()->availableGeometry().height() * .8));


### PR DESCRIPTION
This fixes the issue with the History and Variables Table dialogs always being on top of every window. 

Closes issue #1321 