### PR TITLE
feature: Add move group object to context menu

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -12373,6 +12373,18 @@ SeamlyME jako obvykle.
         <source>AngleLine_</source>
         <translation>Úhelníky_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation>Přesunout objekt skupiny</translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation>Z </translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation> na </translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -12360,6 +12360,18 @@ wie gewohnt in SeamlyME laden können.
         <source>AngleLine_</source>
         <translation>WinkelLinie_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation>Gruppenobjekt bewegen</translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation>Aus </translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation> zu </translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -12377,6 +12377,18 @@ load in SeamlyME as usual.
         <source>AngleLine_</source>
         <translation>ΓωνίαΓραμμής_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation>Μετακίνηση αντικειμένου ομάδας</translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation>Από </translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation> να </translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -12338,6 +12338,18 @@ load in SeamlyME as usual.
         <source>AngleLine_</source>
         <translation type="unfinished">AngleLine_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -12338,6 +12338,18 @@ load in SeamlyME as usual.
         <source>AngleLine_</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -12338,6 +12338,18 @@ load in SeamlyME as usual.
         <source>AngleLine_</source>
         <translation type="unfinished">AngleLine_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -12338,6 +12338,18 @@ load in SeamlyME as usual.
         <source>AngleLine_</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -12415,6 +12415,18 @@ load in SeamlyME as usual.
         <source>AngleLine_</source>
         <translation>AngleLine_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation>Mover Objeto de Grupo</translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation>De </translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation> a </translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -12375,6 +12375,18 @@ Haluatko tallentaa muutokset?</translation>
         <source>AngleLine_</source>
         <translation>Kulmaviiva_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation>Siirrä ryhmäobjektia</translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation>Luota </translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation> että </translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -12390,6 +12390,18 @@ charger dans SeamlyME comme d&apos;habitude.
         <source>AngleLine_</source>
         <translation>AngleLine_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation>Changer l&apos;objet de groupe</translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation>du </translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation> à </translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -12331,6 +12331,18 @@ load in SeamlyME as usual.
         <source>AngleLine_</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -12375,6 +12375,18 @@ unggah ke SeamlyME seperti biasa.
         <source>AngleLine_</source>
         <translation>GarisSudut_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation>Pindahkan Objek Grup</translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation>Dari </translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation> ke </translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -12363,6 +12363,18 @@ caricare in SeamlyME come di consueto.
         <source>AngleLine_</source>
         <translation>AngoloLinea_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation>Sposta oggetto gruppo</translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation>Da </translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation> A </translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -12359,6 +12359,18 @@ load in SeamlyME as usual.
         <source>AngleLine_</source>
         <translation>HoekLijn_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation>Groepsobject verplaatsen</translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation>Van </translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation> naar </translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -12361,6 +12361,18 @@ carregar no SeamlyME como de costume.
         <source>AngleLine_</source>
         <translation>LinhaÂngulo_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation>Mover objeto de grupo</translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation>De </translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation> para </translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -12376,6 +12376,18 @@ load in SeamlyME as usual.
         <source>AngleLine_</source>
         <translation>UnghiLinie_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation>Mutare obiect grup</translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation>Din </translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation> la </translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -12382,6 +12382,18 @@ load in SeamlyME as usual.
         <source>AngleLine_</source>
         <translation>УголЛинии_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation>Переместить Группу Объектов</translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation>От </translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation> к </translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -12374,6 +12374,18 @@ load in SeamlyME as usual.
         <source>AngleLine_</source>
         <translation>AçıÇizgisi_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation>Grup Nesnesini Taşı</translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation>İtibaren </translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation> ile </translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -12375,6 +12375,18 @@ load in SeamlyME as usual.
         <source>AngleLine_</source>
         <translation>КутЛінії_</translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation>Μετακίνηση αντικειμένου ομάδας</translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation>Від </translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation> до </translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -12331,6 +12331,18 @@ load in SeamlyME as usual.
         <source>AngleLine_</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move Group Object</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>From </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> to </source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>VException</name>

--- a/src/app/seamly2d/dialogs/groups_widget.cpp
+++ b/src/app/seamly2d/dialogs/groups_widget.cpp
@@ -1115,7 +1115,7 @@ QString GroupsWidget::getObjName(quint32 toolId)
 
     if(!groupsNotContainingItem.empty())
     {
-        QMenu *menuMoveGroupItem = menu.addMenu(QIcon("://icon/32x32/list-move_32.png"), tr("Move Group Object"));
+        QMenu *menuMoveGroupItem = menu.addMenu(QIcon("://icon/svg/list-move.svg"), tr("Move Group Object"));
         QStringList list = QStringList(groupsNotContainingItem.values());
         list.sort(Qt::CaseInsensitive);
 

--- a/src/libs/vmisc/share/resources/icon.qrc
+++ b/src/libs/vmisc/share/resources/icon.qrc
@@ -169,5 +169,6 @@
         <file>icon/svg/word.svg</file>
         <file>icon/svg/case.svg</file>
         <file>icon/svg/regex.svg</file>
+        <file>icon/svg/list-move.svg</file>
     </qresource>
 </RCC>

--- a/src/libs/vmisc/share/resources/icon/svg/list-move.svg
+++ b/src/libs/vmisc/share/resources/icon/svg/list-move.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 512 512"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="list-move.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#111111"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="745"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="0.16536316"
+     inkscape:cx="876.88055"
+     inkscape:cy="-96.847337"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path819"
+     style="fill:#417de1;fill-opacity:1;stroke:#000000;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 264.32417,78.364217 264.72103,433.75126 471.88339,256.05774 Z"
+     sodipodi:nodetypes="cccc" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path819-7"
+     style="fill:#417de1;fill-opacity:1;stroke:#000000;stroke-width:16;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 257.67586,256.05774 50.116605,78.364217 m 0,0 0.396862,355.387043 207.162393,-177.69352" />
+</svg>

--- a/src/libs/vpatterndb/msvc_make.bat
+++ b/src/libs/vpatterndb/msvc_make.bat
@@ -1,0 +1,2 @@
+chcp 65001
+"C:\Qt\Tools\QtCreator\bin\jom\jom.exe" %*

--- a/src/libs/vtools/tools/drawTools/vdrawtool.h
+++ b/src/libs/vtools/tools/drawTools/vdrawtool.h
@@ -72,6 +72,7 @@
 #include "../vtools/undocommands/addgroup.h"
 #include "../vtools/undocommands/add_groupitem.h"
 #include "../vtools/undocommands/remove_groupitem.h"
+#include "../vtools/undocommands/move_groupitem.h"
 
 #include <qcompilerdetection.h>
 #include <QAction>
@@ -84,8 +85,10 @@
 #include <QMenu>
 #include <QMetaObject>
 #include <QObject>
+#include <QPair>
 #include <QString>
 #include <QtGlobal>
+#include <QVariant>
 
 template <class T> class QSharedPointer;
 
@@ -270,10 +273,39 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
         actionDelete->setEnabled(false);
     }
 
-    // Add Group Item menu item
-    QMap<quint32,QString> groupsNotContainingItem =  doc->getGroupsContainingItem(this->getId(), itemId, false);
-    QActionGroup* actionAddGroupMenu= new QActionGroup(this);
+    QMap<quint32,QString> groupsContainingItem    =  doc->getGroupsContainingItem(toolId, itemId, true);
+    QMap<quint32,QString> groupsNotContainingItem =  doc->getGroupsContainingItem(toolId, itemId, false);
 
+    // Add Move Group Item menu
+    QActionGroup *actionMoveGroupMenu= new QActionGroup(this);
+
+    if (!groupsNotContainingItem.empty())
+    {
+        QMenu *menuMoveGroupItem = menu.addMenu(QIcon("://icon/32x32/list-move_32.png"), tr("Move Group Object"));
+        QStringList sourceList = QStringList(groupsContainingItem.values());
+        QStringList destList   = QStringList(groupsNotContainingItem.values());
+        sourceList.sort(Qt::CaseInsensitive);
+        destList.sort(Qt::CaseInsensitive);
+
+        for(int i=0; i < sourceList.count(); ++i)
+        {
+            const quint32 sourecId = groupsContainingItem.key(sourceList[i]);
+
+            for(int j=0; j < destList.count(); ++j)
+            {
+                QAction *actionMoveGroupItem = menuMoveGroupItem->addAction(tr("From ") + sourceList[i] + tr(" to ") + destList[j]);
+                actionMoveGroupMenu->addAction(actionMoveGroupItem);
+                const quint32 destId = groupsNotContainingItem.key(destList[j]);
+
+                QPair<quint32, quint32> data(sourecId, destId);
+                QVariant variantData = QVariant::fromValue(data);
+                actionMoveGroupItem->setData(variantData);
+            }
+        }
+    }
+
+    // Add Group Item menu item
+    QActionGroup *actionAddGroupMenu= new QActionGroup(this);
     if (!groupsNotContainingItem.empty())
     {
         QMenu *menuAddGroupItem = menu.addMenu(QIcon("://icon/32x32/add.png"), tr("Add Group Object"));
@@ -290,9 +322,10 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
         }
     }
 
+
+
     // Remove Group Item menu item
-    QMap<quint32,QString> groupsContainingItem =  doc->getGroupsContainingItem(this->getId(), itemId, true);
-    QActionGroup* actionDeleteGroupMenu = new QActionGroup(this);
+    QActionGroup *actionDeleteGroupMenu = new QActionGroup(this);
 
     if (!groupsContainingItem.empty())
     {
@@ -466,6 +499,35 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
             qApp->getUndoStack()->push(command);
         }
     }
+    else if (selectedAction->actionGroup() == actionMoveGroupMenu)
+    {
+        QVariant retrievedVariant = selectedAction->data();
+        QPair<quint32, quint32> retrievedPair = retrievedVariant.value<QPair<quint32, quint32>>();
+        const quint32 sourceGroupId       = retrievedPair.first;
+        const quint32 destinationGroupId  = retrievedPair.second;
+        const bool sourceLock      = doc->getGroupLock(sourceGroupId);
+        const bool destinationLock = doc->getGroupLock(destinationGroupId);
+
+        //only move if both groups are unlocked
+        if ((sourceLock == false) && (destinationLock == false))
+        {
+            QDomElement sourceItem = doc->removeGroupItem(this->getId(), itemId, sourceGroupId);
+            QDomElement destItem   = doc->addGroupItem(this->getId(), itemId, destinationGroupId);
+
+            VMainGraphicsScene *scene = qobject_cast<VMainGraphicsScene *>(qApp->getCurrentScene());
+            SCASSERT(scene != nullptr)
+            scene->clearSelection();
+
+            VAbstractMainWindow *window = qobject_cast<VAbstractMainWindow *>(qApp->getMainWindow());
+            SCASSERT(window != nullptr)
+            {
+                MoveGroupItem *command = new MoveGroupItem(sourceItem, destItem, doc, sourceGroupId, destinationGroupId);
+                connect(command, &MoveGroupItem::updateGroups, window, &VAbstractMainWindow::updateGroups);
+                qApp->getUndoStack()->push(command);
+            }
+        }
+    }
+
     else if (selectedAction == actionCopyLineAngle)
     {
         QString angleName = QString("");

--- a/src/libs/vtools/tools/drawTools/vdrawtool.h
+++ b/src/libs/vtools/tools/drawTools/vdrawtool.h
@@ -279,9 +279,9 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
     // Add Move Group Item menu
     QActionGroup *actionMoveGroupMenu= new QActionGroup(this);
 
-    if (!groupsNotContainingItem.empty())
+    if (!groupsContainingItem.empty() && !groupsNotContainingItem.empty())
     {
-        QMenu *menuMoveGroupItem = menu.addMenu(QIcon("://icon/32x32/list-move_32.png"), tr("Move Group Object"));
+        QMenu *menuMoveGroupItem = menu.addMenu(QIcon("://icon/svg/list-move.svg"), tr("Move Group Object"));
         QStringList sourceList = QStringList(groupsContainingItem.values());
         QStringList destList   = QStringList(groupsNotContainingItem.values());
         sourceList.sort(Qt::CaseInsensitive);


### PR DESCRIPTION
This PR adds a Move Group Object item to a selected object's context menu. It's is only added to the menu if the object is in at least one group, and there is at least one group it's not in. 

![image](https://github.com/user-attachments/assets/c1d196dc-8454-499e-8c7f-902d3f887d5c)

Closes issue #1323 