### PR TITLE
bug: fix ElArc_ transation

### DIFF
--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -4070,7 +4070,7 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>ElArc_</source>
-        <translation>Дуга_</translation>
+        <translation>ЕлДуга_</translation>
     </message>
     <message>
         <source>%1 - Rotation</source>
@@ -4289,7 +4289,7 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>ElArc_</source>
-        <translation>Дуга_</translation>
+        <translation>ЕлДуга_</translation>
     </message>
     <message>
         <source>Arc Elliptical with length %1</source>
@@ -12356,7 +12356,7 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>ElArc_</source>
-        <translation>Дуга_</translation>
+        <translation>ЕлДуга_</translation>
     </message>
     <message>
         <source>Spl_</source>
@@ -14634,7 +14634,7 @@ load in SeamlyME as usual.
     <message>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
-        <translation>Дуга_</translation>
+        <translation>ЕлДуга_</translation>
     </message>
     <message>
         <source>Spl_</source>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -4068,7 +4068,7 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>ElArc_</source>
-        <translation>ElArc_</translation>
+        <translation>ЕлДуга_</translation>
     </message>
     <message>
         <source>%1 - Rotation</source>
@@ -4287,7 +4287,7 @@ Do you want to download it?</source>
     </message>
     <message>
         <source>ElArc_</source>
-        <translation>ElArc_</translation>
+        <translation>ЕлДуга_</translation>
     </message>
     <message>
         <source>Arc Elliptical with length %1</source>
@@ -12349,7 +12349,7 @@ load in SeamlyME as usual.
     </message>
     <message>
         <source>ElArc_</source>
-        <translation>ElArc_</translation>
+        <translation>ЕлДуга_</translation>
     </message>
     <message>
         <source>Spl_</source>
@@ -14622,7 +14622,7 @@ load in SeamlyME as usual.
     <message>
         <source>ElArc_</source>
         <comment>Leave the _ symbol in translation</comment>
-        <translation>ElArc_</translation>
+        <translation>ЕлДуга_</translation>
     </message>
     <message>
         <source>Spl_</source>


### PR DESCRIPTION
This fixes the Russian translation for ElArc_ which was the same as Arc_. The translation also works for Ukrainian. 

Closes issue #1325 