### PR TITLE
docs: update developer readme doc

### DIFF
--- a/.github/README-DEVELOPER.md
+++ b/.github/README-DEVELOPER.md
@@ -1,9 +1,10 @@
 # Build Seamly2D
 
 ## Basic Software Prerequisites:  
-* [Qt 5.15.2](https://www.qt.io/download-open-source) (includes Qt, QtCreator, QtChooser, and Qt Maintenance Tool)
+* [Qt 6.5.3](https://www.qt.io/download-open-source) (includes Qt, QtCreator, QtChooser, and Qt Maintenance Tool)
+* [Visual Studio](https://visualstudio.microsoft.com/downloads/) Qt Visual Studio Tools extension - needed to build with MSVC.
 * [Git](https://git-scm.com/downloads) or [Github Desktop for Windows and MacOS](https://desktop.github.com)
-* Compiler - MSVC 2022, gcc, and g++ are included with QtCreator, and you can add or update them using the Qt Maintenance Tool (Maintenance.exe).
+* Compiler - MSVC 2019, gcc, and g++ are included with QtCreator, and you can add or update them using the Qt Maintenance Tool (Maintenance.exe).
 * Pdftops (from XpdfReader or poppler) - Required to create PS or EPS layout files.
 * Check the sections below for your operating system to find additional installation requirements.
 
@@ -29,7 +30,7 @@ ___________________________________________________
 
   _These instructions apply in general_
 
-* Install Qt 5.15.2, eg via [Qt unified installer](https://www.qt.io/download-qt-installer) or https://github.com/miurahr/aqtinstall
+* Install Qt 6.5.3, eg via [Qt unified installer](https://www.qt.io/download-qt-installer) or https://github.com/miurahr/aqtinstall
 * Install QtCreator https://wiki.qt.io/VendorPackages
 * Install Additional libraries
   - gnu compiler
@@ -65,7 +66,7 @@ ___________________________________________________
       - Select:
         * Custom Installation
         * Qt  - _Minimize your options, otherwise your download size could be in Gs_
-          * Qt 5.15.2
+          * Qt 6.5.3
             * MSVC 2019
             * Qt Debug Information Files
           * Developer and Designer Tools


### PR DESCRIPTION
This updates the README-DEVELOPER.md to reflect the change to Qt 6.5.3.

-  Bumps ver from 5.15.2 to 6.5.3
-  Changes the MSVC 2022 to MSVC 2019 as there is no MSVC 2022 kit included with Qt 6.5.3

<img width="358" height="172" alt="image" src="https://github.com/user-attachments/assets/84e09ef5-5046-4afc-92c6-87c029437c4e" />

-  Add Visual Studio as required to build with MSVC kits. 