### PR TITLE
Cancel button removed from the "Broken formula" dialog

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -3082,12 +3082,9 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Opravit vzorec</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Zrušit</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Chyba při výpočtu vzorce. Můžete zkusit vrátit zpět poslední operaci nebo opravit poškozený vzorec.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4902,9 +4899,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Seamly2D je aplikace pro počítačem podporovaný návrh oděvních střihů.
@@ -4913,9 +4910,9 @@ Seamly2D je bezplatný (open source) software.
 
 Všechny názvy značek nebo produktů jsou ochrannými známkami nebo registrovanými ochrannými známkami příslušných vlastníků.
 
-© 2017–2024 Seamly2D Project.
+© 2017–2025 Seamly2D Project.
 
-Části tohoto softwaru © 2008–2024 The Qt Company Ltd.
+Části tohoto softwaru © 2008–2025 The Qt Company Ltd.
 
 Program je poskytován TAK, JAK JE, BEZ JAKÉKOLI ZÁRUKY, VČETNĚ ZÁRUKY DESIGNU, OBCHODOVATELNOSTI A VHODNOSTI PRO URČITÝ ÚČEL.</translation>
     </message>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -3067,12 +3067,9 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Formel festlegen</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Abbrechen</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Fehler beim Berechnen der Formel. Du kannst versuchen, den letzten Schritt rückgängig zu machen, oder die defekte Formel festlegen.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4887,9 +4884,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Seamly2D ist eine Anwendung für den computergestützten Entwurf von Bekleidungsmustern.
@@ -4898,9 +4895,9 @@ Seamly2D ist eine kostenlose (Open Source) Software.
 
 Alle Marken- oder Produktnamen sind Marken oder eingetragene Marken der jeweiligen Inhaber.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Teile dieser Software © 2008-2024 The Qt Company Ltd.
+Teile dieser Software © 2008-2025 The Qt Company Ltd.
 
 Das Programm wird WIE ES IST, OHNE GEWÄHRLEISTUNG JEGLICHER ART, EINSCHLIESSLICH DER GARANTIE FÜR DESIGN, GEBRAUCHSFÄHIGKEIT UND EIGNUNG FÜR EINEN BESTIMMTEN ZWECK zur Verfügung gestellt.</translation>
     </message>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -3082,12 +3082,9 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Επιδιόρθωση φόρμουλας</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Ακύρωση</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Σφάλμα κατα τον υπολογισμό της φόρμουλας. Μπορείτε να δοκιμάσετε να αναιρέσετε την τελευταια λειτουργία ή να επιδιορθώσετε τη χαλασμένη φόρμουλα.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4906,9 +4903,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Το Seamly2D είναι μια εφαρμογή για σχεδιασμό πατρόν ενδυμάτων με τη βοήθεια υπολογιστή.
@@ -4917,9 +4914,9 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 
 Όλα τα ονόματα επωνυμιών ή προϊόντων είναι εμπορικά σήματα ή σήματα κατατεθέντα των αντίστοιχων κατόχων τους.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Τμήματα αυτού του λογισμικού © 2008-2024 The Qt Company Ltd.
+Τμήματα αυτού του λογισμικού © 2008-2025 The Qt Company Ltd.
 
 Το πρόγραμμα παρέχεται ΩΣ ΕΧΕΙ χωρίς ΚΑΜΙΑ ΕΓΓΥΗΣΗ ΚΑΝΕΝΟΣ ΕΙΔΟΥΣ, ΣΥΜΠΕΡΙΛΑΜΒΑΝΟΜΕΝΗΣ ΤΗΣ ΕΓΓΥΗΣΗΣ ΣΧΕΔΙΑΣΜΟΥ, ΕΜΠΟΡΕΥΣΙΜΟΤΗΤΑΣ ΚΑΙ ΚΑΤΑΛΛΗΛΟΤΗΤΑΣ ΓΙΑ ΣΥΓΚΕΚΡΙΜΕΝΟ ΣΚΟΠΟ.</translation>
     </message>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -3067,12 +3067,9 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Fix formula</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Cancel</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Error while calculation formula. You can try to undo last operation or fix broken formula.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4884,9 +4881,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation type="unfinished"></translation>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -3067,11 +3067,8 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4884,9 +4881,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation type="unfinished"></translation>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -3067,12 +3067,9 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Fix formula</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Cancel</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Error while calculation formula. You can try to undo last operation or fix broken formula.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4884,9 +4881,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation type="unfinished"></translation>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -3067,11 +3067,8 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4884,9 +4881,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation type="unfinished"></translation>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -3100,12 +3100,9 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Reparar fórmula</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Cancelar</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Error al calcular la fórmula. Puede intentar deshacer las últimas operaciones o corregir la fórmula.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4924,9 +4921,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Seamly2D es una aplicación para el diseño asistido por ordenador de patrones de prendas de vestir.
@@ -4935,9 +4932,9 @@ Seamly2D es un software gratuito (de código abierto).
 
 Todos los nombres de marcas o productos son marcas comerciales o marcas registradas de sus respectivos propietarios.
 
-2017-2024 Proyecto Seamly2D.
+2017-2025 Proyecto Seamly2D.
 
-Partes de este software © 2008-2024 The Qt Company Ltd.
+Partes de este software © 2008-2025 The Qt Company Ltd.
 
 El programa se proporciona TAL CUAL, SIN GARANTÍA DE NINGÚN TIPO, INCLUIDAS LAS GARANTÍAS DE DISEÑO, COMERCIABILIDAD E IDONEIDAD PARA UN PROPÓSITO PARTICULAR.</translation>
     </message>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -3082,12 +3082,9 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Korjaa matemaattinen kaava</translation>
     </message>
     <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Kaavaa laskettaessa tapahtui virhe. Voit yrittää kumota viimeisimmän operaation tai korjata rikkinäisen kaavan.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>Peruuttaa</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4904,9 +4901,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Seamly2D on sovellus tietokoneella avustettuun vaatekaavojen suunnitteluun.
@@ -4915,9 +4912,9 @@ Seamly2D on ilmainen (avoimen lähdekoodin) ohjelmisto.
 
 Kaikki tuotemerkit tai tuotenimet ovat omistajiensa tavaramerkkejä tai rekisteröityjä tavaramerkkejä.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Osat tästä ohjelmistosta © 2008-2024 The Qt Company Ltd.
+Osat tästä ohjelmistosta © 2008-2025 The Qt Company Ltd.
 
 Ohjelma toimitetaan SELLAISENAAN ILMAN MINKÄÄNLAISTA TAKUUTA, MUKAAN LUKIEN SUUNNITTELUN, MYYNTIKELPOISUUDEN JA TIETTYYN TARKOITUKSEEN SOPIVUUDEN TAKUU.</translation>
     </message>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -3098,12 +3098,9 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Corriger la formule</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Annuler</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Erreur pendant le calcul. Essayer d&apos;annuler la précedente opération ou modifier la formule.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4927,9 +4924,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Seamly2D est une application de conception assistée par ordinateur de patrons de vêtements.
@@ -4938,9 +4935,9 @@ Seamly2D est un logiciel gratuit (open source).
 
 Tous les noms de marques ou de produits sont des marques commerciales ou des marques déposées de leurs détenteurs respectifs.
 
-© 2017-2024 Projet Seamly2D.
+© 2017-2025 Projet Seamly2D.
 
-Certaines parties de ce logiciel © 2008-2024 The Qt Company Ltd.
+Certaines parties de ce logiciel © 2008-2025 The Qt Company Ltd.
 
 Le programme est fourni &quot;TEL QUEL&quot;sans aucune garantie, y compris la garantie de conception, de qualité marchande et d&apos;adéquation à un usage particulier.</translation>
     </message>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -3067,11 +3067,8 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4884,9 +4881,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation type="unfinished"></translation>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -3082,12 +3082,9 @@ p, li { spasi: pra-bungkus; }
         <translation>&amp;Perbaiki rumus</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Batalkan</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Kesalahan saat menghitung rumus. Anda dapat mencoba membatalkan operasi terakhir atau memperbaiki rumus yang rusak.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4904,9 +4901,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Seamly2D adalah aplikasi untuk desain pola pakaian dengan bantuan komputer.
@@ -4915,9 +4912,9 @@ Seamly2D adalah perangkat lunak gratis (sumber terbuka).
 
 Semua nama merek atau produk adalah merek dagang atau merek dagang terdaftar dari pemiliknya masing-masing.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Bagian dari perangkat lunak ini © 2008-2024 The Qt Company Ltd.
+Bagian dari perangkat lunak ini © 2008-2025 The Qt Company Ltd.
 
 Program ini disediakan SEBAGAIMANA ADANYA TANPA JAMINAN DALAM BENTUK APA PUN, TERMASUK JAMINAN DESAIN, KEMAMPUAN UNTUK DIPERDAGANGKAN, DAN KESESUAIAN UNTUK TUJUAN TERTENTU.</translation>
     </message>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -3067,12 +3067,9 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Correggi formula</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Cancel</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Errore durante la formula di calcolo. Prova ad annullare l&apos;ultima operazione o a correggere la formula errata.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4892,9 +4889,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Seamly2D è un&apos;applicazione per la progettazione assistita da computer di modelli di abbigliamento.
@@ -4903,9 +4900,9 @@ Seamly2D è un software libero (open source).
 
 Tutti i nomi di marchi o prodotti sono marchi o marchi registrati dei rispettivi proprietari.
 
-© 2017-2024 Progetto Seamly2D.
+© 2017-2025 Progetto Seamly2D.
 
-Parti di questo software © 2008-2024 The Qt Company Ltd.
+Parti di questo software © 2008-2025 The Qt Company Ltd.
 
 Il programma viene fornito così com&apos;è, senza alcuna garanzia di alcun tipo, comprese le garanzie di progettazione, commerciabilità e idoneità a uno scopo particolare.</translation>
     </message>
@@ -8823,7 +8820,7 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
     </message>
     <message>
         <source>User&apos;s System</source>
-        <translation>Sistema dell'utente</translation>
+        <translation>Sistema dell&apos;utente</translation>
     </message>
     <message>
         <source>Locale</source>
@@ -9866,7 +9863,7 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
     </message>
     <message>
         <source>User&apos;s System</source>
-        <translation>Sistema dell'utente</translation>
+        <translation>Sistema dell&apos;utente</translation>
     </message>
     <message>
         <source>Locale</source>
@@ -10012,7 +10009,7 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
     </message>
     <message>
         <source>User&apos;s System</source>
-        <translation>Sistema dell'utente</translation>
+        <translation>Sistema dell&apos;utente</translation>
     </message>
     <message>
         <source>Locale</source>
@@ -10111,7 +10108,7 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
     </message>
     <message>
         <source>User&apos;s System</source>
-        <translation>Sistema dell'utente</translation>
+        <translation>Sistema dell&apos;utente</translation>
     </message>
     <message>
         <source>Locale</source>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -3067,12 +3067,9 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Verbeter formule</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Stop</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Fout tijdens het berekenen van de formule. Je kunt proberen om de laatste actie ongedaan te maken of de formule te herstellen.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4887,9 +4884,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Seamly2D is een toepassing voor computerondersteund ontwerpen van kledingpatronen.
@@ -4898,9 +4895,9 @@ Seamly2D is gratis (open source) software.
 
 Alle merk- of productnamen zijn handelsmerken of geregistreerde handelsmerken van hun respectievelijke houders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Delen van deze software © 2008-2024 The Qt Company Ltd.
+Delen van deze software © 2008-2025 The Qt Company Ltd.
 
 Het programma wordt geleverd in de staat waarin het zich bevindt, zonder enige garantie, inclusief de garantie van het ontwerp, de verkoopbaarheid en geschiktheid voor een bepaald doel.</translation>
     </message>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -3067,12 +3067,9 @@ p, li { white-space: pre-wrap; }
         <translation>Fârmula &amp;Fix</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Cancelar</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Erro ao calcular fârmula. Vocâ pode tentar desfazer a âltima operação ou consertar a fârmula quebrada.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4890,9 +4887,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>O Seamly2D é uma aplicação para a conceção de moldes de vestuário assistida por computador.
@@ -4901,9 +4898,9 @@ Seamly2D é um software livre (open source).
 
 Todas as marcas ou nomes de produtos são marcas comerciais ou marcas registadas dos respectivos titulares.
 
-© 2017-2024 Projeto Seamly2D.
+© 2017-2025 Projeto Seamly2D.
 
-Partes deste software © 2008-2024 The Qt Company Ltd.
+Partes deste software © 2008-2025 The Qt Company Ltd.
 
 O programa é fornecido NO ESTADO EM QUE SE ENCONTRA, SEM GARANTIA DE QUALQUER TIPO, INCLUINDO A GARANTIA DE DESIGN, COMERCIALIZAÇÃO E ADEQUAÇÃO A UM DETERMINADO FIM.</translation>
     </message>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -3082,12 +3082,9 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Repară formula</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Anulare</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Eroare la calcularea formulei. Puteți încerca să anulați ultima operațiune sau să remediați formula defectă.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4906,9 +4903,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Seamly2D este o aplicație pentru proiectarea asistată de calculator a tiparelor de îmbrăcăminte.
@@ -4917,9 +4914,9 @@ Seamly2D este un software gratuit (open source).
 
 Toate numele de mărci sau produse sunt mărci comerciale sau mărci comerciale înregistrate ale deținătorilor respectivi.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Porțiuni ale acestui software © 2008-2024 The Qt Company Ltd.
+Porțiuni ale acestui software © 2008-2025 The Qt Company Ltd.
 
 Programul este furnizat CA ATARE, FĂRĂ NICIUN FEL DE GARANȚIE, INCLUSIV GARANȚIA DE DESIGN, VANDABILITATE ȘI POTRIVIRE PENTRU UN ANUMIT SCOP.</translation>
     </message>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -3082,12 +3082,9 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Исправить формулу</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Отмена</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Ошибка при расчете формулы. Вы можете попробовать отменить последнюю операцию или исправить неисправную формулу.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4908,9 +4905,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Seamly2D — это приложение для автоматизированного проектирования выкроек одежды.
@@ -4919,9 +4916,9 @@ Seamly2D — это бесплатное программное обеспече
 
 Все названия брендов или продуктов являются товарными знаками или зарегистрированными товарными знаками их соответствующих владельцев.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Части этого программного обеспечения © 2008-2024 The Qt Company Ltd.
+Части этого программного обеспечения © 2008-2025 The Qt Company Ltd.
 
 Программа предоставляется «КАК ЕСТЬ» БЕЗ КАКИХ-ЛИБО ГАРАНТИЙ, ВКЛЮЧАЯ ГАРАНТИЮ ДИЗАЙНА, ТОВАРНОЙ ПРИГОДНОСТИ И ПРИГОДНОСТИ ДЛЯ КОНКРЕТНОЙ ЦЕЛИ.</translation>
     </message>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -3082,12 +3082,9 @@ p, li { boşluk: ön sarma; }
         <translation>&amp;Formülü düzelt</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>İptal</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Hesaplama formülü sırasında hata oluştu. Son işlemi geri almayı veya bozuk formülü düzeltmeyi deneyebilirsiniz.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4904,9 +4901,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Seamly2D, giysi kalıplarının bilgisayar destekli tasarımı için bir uygulamadır.
@@ -4915,9 +4912,9 @@ Seamly2D ücretsiz (açık kaynaklı) bir yazılımdır.
 
 Tüm marka veya ürün adları, ilgili sahiplerinin ticari markaları veya tescilli ticari markalarıdır.
 
-© 2017-2024 Seamly2D Projesi.
+© 2017-2025 Seamly2D Projesi.
 
-Bu yazılımın bölümleri © 2008-2024 The Qt Company Ltd.
+Bu yazılımın bölümleri © 2008-2025 The Qt Company Ltd.
 
 Program, TASARIM, SATILABİLİRLİK VE BELİRLİ BİR AMACA UYGUNLUK GARANTİSİ DAHİL OLMAK ÜZERE HİÇBİR TÜRLÜ GARANTİ OLMADAN OLDUĞU GİBİ sunulmaktadır.</translation>
     </message>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -3082,12 +3082,9 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Виправити формулу</translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>Відмінити</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
-        <translation>Помилка при розрахунку формули. Ви можете попробувати відмінити останню операцію чи виправити поламану формулу.</translation>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4906,9 +4903,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation>Το Seamly2D είναι μια εφαρμογή για σχεδιασμό πατρόν ενδυμάτων με τη βοήθεια υπολογιστή.
@@ -4917,9 +4914,9 @@ The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRAN
 
 Όλα τα ονόματα επωνυμιών ή προϊόντων είναι εμπορικά σήματα ή σήματα κατατεθέντα των αντίστοιχων κατόχων τους.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Τμήματα αυτού του λογισμικού © 2008-2024 The Qt Company Ltd.
+Τμήματα αυτού του λογισμικού © 2008-2025 The Qt Company Ltd.
 
 Το πρόγραμμα παρέχεται ΩΣ ΕΧΕΙ χωρίς ΚΑΜΙΑ ΕΓΓΥΗΣΗ ΚΑΝΕΝΟΣ ΕΙΔΟΥΣ, ΣΥΜΠΕΡΙΛΑΜΒΑΝΟΜΕΝΗΣ ΤΗΣ ΕΓΓΥΗΣΗΣ ΣΧΕΔΙΑΣΜΟΥ, ΕΜΠΟΡΕΥΣΙΜΟΤΗΤΑΣ ΚΑΙ ΚΑΤΑΛΛΗΛΟΤΗΤΑΣ ΓΙΑ ΣΥΓΚΕΚΡΙΜΕΝΟ ΣΚΟΠΟ.</translation>
     </message>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -3067,11 +3067,8 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Error while calculation formula. You can try to undo last operation or fix broken formula.</source>
+        <source>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4884,9 +4881,9 @@ Seamly2D is a free (open source) software.
 
 All brand or product names are trademarks or registered trademarks of their respective holders.
 
-© 2017-2024 Seamly2D Project.
+© 2017-2025 Seamly2D Project.
 
-Portions of this software © 2008-2024 The Qt Company Ltd.
+Portions of this software © 2008-2025 The Qt Company Ltd.
 
 The program is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.</source>
         <translation type="unfinished"></translation>

--- a/src/libs/vtools/dialogs/support/dialogundo.cpp
+++ b/src/libs/vtools/dialogs/support/dialogundo.cpp
@@ -86,7 +86,6 @@ DialogUndo::DialogUndo(QWidget *parent)
         result = UndoButton::Fix;
         accept();
     });
-    connect(ui->pushButtonCancel, &QPushButton::clicked, this, &DialogUndo::Cancel);
 
     setCursor(Qt::ArrowCursor);
 }

--- a/src/libs/vtools/dialogs/support/dialogundo.ui
+++ b/src/libs/vtools/dialogs/support/dialogundo.ui
@@ -3,7 +3,7 @@
  <class>DialogUndo</class>
  <widget class="QDialog" name="DialogUndo">
   <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
+   <enum>Qt::WindowModality::WindowModal</enum>
   </property>
   <property name="geometry">
    <rect>
@@ -29,7 +29,8 @@
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Error while calculation formula. You can try to undo last operation or fix broken formula.</string>
+        <string>Seamly2D encountered an error while computing a formula. 
+Please try to undo the latest operation or fix the broken formula.</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -49,13 +50,6 @@
         <widget class="QPushButton" name="pushButtonFix">
          <property name="text">
           <string>&amp;Fix formula</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButtonCancel">
-         <property name="text">
-          <string>Cancel</string>
          </property>
         </widget>
        </item>

--- a/src/libs/vtools/tools/drawTools/vdrawtool.h
+++ b/src/libs/vtools/tools/drawTools/vdrawtool.h
@@ -213,10 +213,10 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
     QAction *actionCopyToolLength = nullptr;
     QAction *actionCopyLineAngle = nullptr;
 
-    QAction *actionOption = menu.addAction(QIcon::fromTheme("preferences-other"), tr("Properties"));
+    QAction *actionOption = menu.addAction(QIcon::fromTheme("preferences-other"), VDrawTool::tr("Properties"));
 
     // Show object name menu item
-    QAction *actionShowPointName = menu.addAction(QIcon("://icon/16x16/open_eye.png"), tr("Show Point Name"));
+    QAction *actionShowPointName = menu.addAction(QIcon("://icon/16x16/open_eye.png"), VDrawTool::tr("Show Point Name"));
     actionShowPointName->setCheckable(true);
 
     if (itemType == GOType::Point)
@@ -229,9 +229,9 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
     }
 
     // Add Copy menu
-    QMenu *copyMenu = menu.addMenu(QIcon("://icon/32x32/clipboard_icon.png"), tr("Copy"));
-    actionCopyToolLength  = copyMenu->addAction(tr("Length"));
-    actionCopyLineAngle = copyMenu->addAction(tr("Angle"));
+    QMenu *copyMenu = menu.addMenu(QIcon("://icon/32x32/clipboard_icon.png"), VDrawTool::tr("Copy"));
+    actionCopyToolLength  = copyMenu->addAction(QCoreApplication::translate("VDrawTool", "Length"));
+    actionCopyLineAngle = copyMenu->addAction(QCoreApplication::translate("VDrawTool", "Angle"));
 
     // Only add the Angle submneu for the point tools that add a line.
     if (tooltype != Tool::Line &&
@@ -246,7 +246,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
         actionCopyLineAngle->setVisible(false);
     }
 
-    QAction *actionDelete = menu.addAction(QIcon::fromTheme("edit-delete"), tr("Delete"));
+    QAction *actionDelete = menu.addAction(QIcon::fromTheme("edit-delete"), VDrawTool::tr("Delete"));
     if (showRemove == RemoveOption::Enable)
     {
         if (ref == Referens::Follow)
@@ -282,7 +282,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
 
     if (!groupsContainingItem.empty() && !groupsNotContainingItem.empty())
     {
-        QMenu *menuMoveGroupItem = menu.addMenu(QIcon("://icon/svg/list-move.svg"), tr("Move Group Object"));
+        QMenu *menuMoveGroupItem = menu.addMenu(QIcon("://icon/svg/list-move.svg"), VDrawTool::tr("Move Group Object"));
         QStringList sourceList = QStringList(groupsContainingItem.values());
         QStringList destList   = QStringList(groupsNotContainingItem.values());
         sourceList.sort(Qt::CaseInsensitive);
@@ -294,7 +294,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
 
             for(int j=0; j < destList.count(); ++j)
             {
-                QAction *actionMoveGroupItem = menuMoveGroupItem->addAction(tr("From ") + sourceList[i] + tr(" to ") + destList[j]);
+                QAction *actionMoveGroupItem = menuMoveGroupItem->addAction(VDrawTool::tr("From ") + sourceList[i] + VDrawTool::tr(" to ") + destList[j]);
                 actionMoveGroupMenu->addAction(actionMoveGroupItem);
                 const quint32 destId = groupsNotContainingItem.key(destList[j]);
 
@@ -309,7 +309,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
     QActionGroup *actionAddGroupMenu= new QActionGroup(this);
     if (!groupsNotContainingItem.empty())
     {
-        QMenu *menuAddGroupItem = menu.addMenu(QIcon("://icon/32x32/add.png"), tr("Add Group Object"));
+        QMenu *menuAddGroupItem = menu.addMenu(QIcon("://icon/32x32/add.png"), VDrawTool::tr("Add Group Object"));
         QStringList list = QStringList(groupsNotContainingItem.values());
         list.sort(Qt::CaseInsensitive);
 
@@ -330,7 +330,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
 
     if (!groupsContainingItem.empty())
     {
-        QMenu *menuRemoveGroupItem = menu.addMenu(QIcon("://icon/32x32/remove.png"), tr("Remove Group Object"));
+        QMenu *menuRemoveGroupItem = menu.addMenu(QIcon("://icon/32x32/remove.png"), VDrawTool::tr("Remove Group Object"));
 
         QStringList list = QStringList(groupsContainingItem.values());
         list.sort(Qt::CaseInsensitive);
@@ -386,7 +386,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
                 const QDomElement domElement = doc->elementById(toolId);
                 if (domElement.isElement())
                 {
-                    text = tr("Line_") +
+                    text = VDrawTool::tr("Line_") +
                             data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, AttrFirstPoint, "0"))->name() +
                             "_"+
                             data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, AttrSecondPoint, "0"))->name();
@@ -398,7 +398,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
             {
                 const QSharedPointer<VArc> arc = data.GeometricObject<VArc>(toolId);
                 SCASSERT(!arc.isNull())
-                text = arc->NameForHistory(tr("Arc_"));
+                text = arc->NameForHistory(VDrawTool::tr("Arc_"));
                 break;
             }
             case Tool::ShoulderPoint:
@@ -432,7 +432,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
             {
                 const QSharedPointer<VEllipticalArc> elArc = data.GeometricObject<VEllipticalArc>(toolId);
                 SCASSERT(!elArc.isNull())
-                text = elArc->NameForHistory(tr("ElArc_"));
+                text = elArc->NameForHistory(VDrawTool::tr("ElArc_"));
                 break;
             }
 
@@ -440,7 +440,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
             {
                 const QSharedPointer<VSpline> spl = data.GeometricObject<VSpline>(toolId);
                 SCASSERT(!spl.isNull())
-                text = spl->NameForHistory(tr("Spl_"));
+                text = spl->NameForHistory(VDrawTool::tr("Spl_"));
                 break;
             }
 
@@ -448,7 +448,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
             {
                 const QSharedPointer<VSplinePath> splPath = data.GeometricObject<VSplinePath>(toolId);
                 SCASSERT(!splPath.isNull())
-                text = splPath->NameForHistory(tr("SplPath_"));
+                text = splPath->NameForHistory(VDrawTool::tr("SplPath_"));
                 break;
             }
 
@@ -456,7 +456,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
             {
                 const QSharedPointer<VCubicBezier> spl = data.GeometricObject<VCubicBezier>(toolId);
                 SCASSERT(!spl.isNull())
-                text = spl->NameForHistory(tr("Spl_"));
+                text = spl->NameForHistory(VDrawTool::tr("Spl_"));
                 break;
             }
 
@@ -464,7 +464,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
             {
                 const QSharedPointer<VCubicBezierPath> splPath = data.GeometricObject<VCubicBezierPath>(toolId);
                 SCASSERT(!splPath.isNull())
-                text = splPath->NameForHistory(tr("SplPath_"));
+                text = splPath->NameForHistory(VDrawTool::tr("SplPath_"));
                 break;
             }
 
@@ -540,7 +540,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
                 const QDomElement domElement = doc->elementById(toolId);
                 if (domElement.isElement())
                 {
-                    angleName = tr("AngleLine_") +
+                    angleName = VDrawTool::tr("AngleLine_") +
                             data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, AttrFirstPoint, "0"))->name() +
                             "_"+
                             data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, AttrSecondPoint, "0"))->name();
@@ -553,7 +553,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
                 const QDomElement domElement = doc->elementById(toolId);
                 if (domElement.isElement())
                 {
-                    angleName = tr("AngleLine_") +
+                    angleName = VDrawTool::tr("AngleLine_") +
                     data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, AttrFirstPoint, "0"))->name() +
                     "_" +  data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, "id", "0"))->name();
                     break;
@@ -564,7 +564,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
                 const QDomElement domElement = doc->elementById(toolId);
                 if (domElement.isElement())
                 {
-                    angleName = tr("AngleLine_") +
+                    angleName = VDrawTool::tr("AngleLine_") +
                     data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, AttrSecondPoint, "0"))->name() +
                     "_" +  data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, "id", "0"))->name();
                     break;
@@ -578,7 +578,7 @@ void VDrawTool::ContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 itemI
                 const QDomElement domElement = doc->elementById(toolId);
                 if (domElement.isElement())
                 {
-                    angleName = tr("AngleLine_") +
+                    angleName = VDrawTool::tr("AngleLine_") +
                     data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, AttrBasePoint, "0"))->name() +
                     "_" +  data.GeometricObject<VPointF>(doc->GetParametrUInt(domElement, "id", "0"))->name();
                     break;


### PR DESCRIPTION
Clicking on the cancel button always triggers an error.
Users may think that the cancel button cancels the operation that broke the formula.

<img width="399" height="186" alt="image" src="https://github.com/user-attachments/assets/2db4e683-6d2f-4953-aaec-5a86e02ca8e5" />
