### PR TITLE
fix: download fvupdater

### DIFF
--- a/src/app/seamly2d/dialogs/about2d_dialog.cpp
+++ b/src/app/seamly2d/dialogs/about2d_dialog.cpp
@@ -123,13 +123,13 @@ About2DAppDialog::About2DAppDialog(QWidget *parent)
 	connect(ui->pushButtonCheckUpdate, &QPushButton::clicked, []()
 	{
 		// Set feed URL before doing anything else
-		FvUpdater::sharedUpdater()->SetFeedURL(defaultFeedURL);
-		FvUpdater::sharedUpdater()->CheckForUpdatesNotSilent();
+		FvUpdater::sharedUpdater()->setFeedURL(defaultFeedURL);
+		FvUpdater::sharedUpdater()->checkForUpdatesNotSilent();
 	});
 
 	ui->downloadProgress->hide();
 	ui->downloadProgress->setValue(0);
-	connect(FvUpdater::sharedUpdater(), SIGNAL(setProgress(int)), this, SLOT(setProgressValue(int)));
+	connect(FvUpdater::sharedUpdater(), &FvUpdater::setProgress, this, &About2DAppDialog::setProgressValue);
 
     //System Tab
     ui->sysVersion_value->setText(QString("Seamly2D %1").arg(APP_VERSION_STR));
@@ -203,13 +203,16 @@ void About2DAppDialog::showEvent(QShowEvent *event)
 	m_isInitialized = true;//first show windows are held
 }
 
-void About2DAppDialog::setProgressValue(int val) {
-	if (!ui->downloadProgress->isVisible()){
+void About2DAppDialog::setProgressValue(int val)
+{
+	if (!ui->downloadProgress->isVisible())
+    {
 		ui->downloadProgress->show();
 		ui->pushButtonCheckUpdate->setDisabled(true);
 	}
 	ui->downloadProgress->setValue(val);
-	if (val == 100){
+	if (val == 100)
+    {
 		ui->downloadProgress->hide();
 		ui->downloadProgress->setValue(0);
 		ui->pushButtonCheckUpdate->setDisabled(false);

--- a/src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp
+++ b/src/app/seamlyme/dialogs/dialogaboutseamlyme.cpp
@@ -94,8 +94,8 @@ DialogAboutSeamlyMe::DialogAboutSeamlyMe(QWidget *parent)
     connect(ui->pushButtonCheckUpdate, &QPushButton::clicked, []()
     {
         // Set feed URL before doing anything else
-        FvUpdater::sharedUpdater()->SetFeedURL(defaultFeedURL);
-        FvUpdater::sharedUpdater()->CheckForUpdatesNotSilent();
+        FvUpdater::sharedUpdater()->setFeedURL(defaultFeedURL);
+        FvUpdater::sharedUpdater()->checkForUpdatesNotSilent();
     });
 
     // By default on Windows font point size 8 points we need 11 like on Linux.
@@ -105,7 +105,7 @@ DialogAboutSeamlyMe::DialogAboutSeamlyMe(QWidget *parent)
 
 	ui->downloadProgress->hide();
 	ui->downloadProgress->setValue(0);
-	connect(FvUpdater::sharedUpdater(), SIGNAL(setProgress(int)), this, SLOT(setProgressValue(int)));
+	connect(FvUpdater::sharedUpdater(), &FvUpdater::setProgress, this, &DialogAboutSeamlyMe::setProgressValue);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -182,13 +182,16 @@ void DialogAboutSeamlyMe::RetranslateUi()
     ui->pushButton_Web_Site->setText(tr("Web site : %1").arg(VER_COMPANYDOMAIN_STR));
 }
 
-void DialogAboutSeamlyMe::setProgressValue(int val) {
-	if (!ui->downloadProgress->isVisible()){
+void DialogAboutSeamlyMe::setProgressValue(int val)
+{
+	if (!ui->downloadProgress->isVisible())
+    {
 		ui->downloadProgress->show();
 		ui->pushButtonCheckUpdate->setDisabled(true);
 	}
 	ui->downloadProgress->setValue(val);
-	if (val == 100){
+	if (val == 100)
+    {
 		ui->downloadProgress->hide();
 		ui->downloadProgress->setValue(0);
 		ui->pushButtonCheckUpdate->setDisabled(false);

--- a/src/libs/fervor/fvupdater.cpp
+++ b/src/libs/fervor/fvupdater.cpp
@@ -1,50 +1,48 @@
-/***************************************************************************
- **  @file   fvupdater.cpp
- **  @author Douglas S Caskey
- **  @date   17 Sep, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//   @file   fvupdater.cpp
+//   @author Douglas S Caskey
+//   @date   17 Sep, 2023
+//
+//   @copyright
+//   Copyright (C) 2017 - 2025 Seamly, LLC
+//   https://github.com/fashionfreedom/seamly2d
+//
+//   @brief
+//   Seamly2D is free software: you can redistribute it and/or modify
+//   it under the terms of the GNU General Public License as published by
+//   the Free Software Foundation, either version 3 of the License, or
+//   (at your option) any later version.
+//
+//   Seamly2D is distributed in the hope that it will be useful,
+//   but WITHOUT ANY WARRANTY; without even the implied warranty of
+//   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//   GNU General Public License for more details.
+//
+//   You should have received a copy of the GNU General Public License
+//   along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+// ---------------------------------------------------------------------------------------------------------------------
 
-/***************************************************************************************************
- **  @file   fvupdater.cpp
- **
- **  @brief
- **  @copyright
- **  Copyright (c) 2012 Linas Valiukas and others.
- **
- **  Permission is hereby granted, free of charge, to any person obtaining a copy of this
- **  software and associated documentation files (the "Software"), to deal in the Software
- **  without restriction, including without limitation the rights to use, copy, modify,
- **  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
- **  permit persons to whom the Software is furnished to do so, subject to the following conditions:
- **
- **  The above copyright notice and this permission notice shall be included in all copies or
- **  substantial portions of the Software.
- **
- **  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
- **  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- **  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
- **  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- **  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- **
- ******************************************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//   @file   fvupdater.cpp
+//   @copyright
+//   Copyright (c) 2012 Linas Valiukas and others.
+//
+//   @brief
+//   Permission is hereby granted, free of charge, to any person obtaining a copy of this
+//   software and associated documentation files (the "Software"), to deal in the Software
+//   without restriction, including without limitation the rights to use, copy, modify,
+//   merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+//   permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//   The above copyright notice and this permission notice shall be included in all copies or
+//   substantial portions of the Software.
+//
+//   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+//   NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//---------------------------------------------------------------------------------------------------------------------
 
 #include "fvupdater.h"
 
@@ -83,9 +81,11 @@ const QString defaultFeedURL = QStringLiteral("https://api.github.com/repos/Fash
 QPointer<FvUpdater> FvUpdater::m_Instance;
 
 //---------------------------------------------------------------------------------------------------------------------
-FvUpdater *FvUpdater::sharedUpdater() {
+FvUpdater *FvUpdater::sharedUpdater()
+{
 	static QMutex mutex;
-	if (m_Instance.isNull()) {
+	if (!m_Instance)
+    {
         mutex.lock();
 		m_Instance = new FvUpdater;
 		mutex.unlock();
@@ -95,76 +95,98 @@ FvUpdater *FvUpdater::sharedUpdater() {
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void FvUpdater::drop() {
+void FvUpdater::drop()
+{
 	static QMutex mutex;
     mutex.lock();
 	delete m_Instance;
+    m_Instance = nullptr;
 	mutex.unlock();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 FvUpdater::FvUpdater()
-	: QObject(nullptr),
-	  m_silentAsMuchAsItCouldGet(true), m_feedURL(), m_qnam(), m_reply(nullptr),
-	  m_httpRequestAborted(false), m_dropOnFinish(true) {
-	// noop
+	: QObject(nullptr)
+    , m_silentMode(true)
+    , m_feedURL()
+    , m_networkAccessManager()
+    , m_reply(nullptr)
+    , m_httpRequestAborted(false)
+    , m_dropOnFinish(true)
+{
+	// no op
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-FvUpdater::~FvUpdater() {
+FvUpdater::~FvUpdater()
+{
 	delete m_reply;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void FvUpdater::SetFeedURL(const QUrl &feedURL) { m_feedURL = feedURL; }
-
-//---------------------------------------------------------------------------------------------------------------------
-void FvUpdater::SetFeedURL(const QString &feedURL) {
-	SetFeedURL(QUrl(feedURL));
+void FvUpdater::setFeedURL(const QUrl &feedURL)
+{
+    m_feedURL = feedURL;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QString FvUpdater::GetFeedURL() const { return m_feedURL.toString(); }
+void FvUpdater::setFeedURL(const QString &feedURL)
+{
+	setFeedURL(QUrl(feedURL));
+}
 
 //---------------------------------------------------------------------------------------------------------------------
-bool FvUpdater::IsDropOnFinish() const { return m_dropOnFinish; }
+QString FvUpdater::getFeedURL() const
+{
+    return m_feedURL.toString();
+}
 
 //---------------------------------------------------------------------------------------------------------------------
-void FvUpdater::SetDropOnFinish(bool value) { m_dropOnFinish = value; }
+bool FvUpdater::isDropOnFinish() const
+{
+    return m_dropOnFinish;
+}
 
 //---------------------------------------------------------------------------------------------------------------------
-bool FvUpdater::CheckForUpdates(bool silentAsMuchAsItCouldGet) {
-	if (m_feedURL.isEmpty()) {
-		qCritical()
-			<< "Please set feed URL via setFeedURL() before calling CheckForUpdates().";
+void FvUpdater::setDropOnFinish(bool value)
+{
+    m_dropOnFinish = value;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+bool FvUpdater::checkForUpdates(bool silentMode)
+{
+	if (m_feedURL.isEmpty())
+    {
+		qCritical() << "Please set feed URL via setFeedURL() before calling checkForUpdates().";
 		return false;
 	}
 
-	m_silentAsMuchAsItCouldGet = silentAsMuchAsItCouldGet;
+	m_silentMode = silentMode;
 
 	// Check if application's organization name and domain are set, fail
 	// otherwise (nowhere to store QSettings to)
-	if (QCoreApplication::organizationName().isEmpty()) {
-		qCritical()
-			<< "QApplication::organizationName is not set. Please do that.";
+	if (QCoreApplication::organizationName().isEmpty())
+    {
+		qCritical() << "QApplication::organizationName is not set. Please do that.";
 		return false;
 	}
-	if (QCoreApplication::organizationDomain().isEmpty()) {
-		qCritical()
-			<< "QApplication::organizationDomain is not set. Please do that.";
+	if (QCoreApplication::organizationDomain().isEmpty())
+    {
+		qCritical() << "QApplication::organizationDomain is not set. Please do that.";
 		return false;
 	}
 
 	// Set application name / version is not set yet
-	if (QCoreApplication::applicationName().isEmpty()) {
-		qCritical()
-			<< "QApplication::applicationName is not set. Please do that.";
+	if (QCoreApplication::applicationName().isEmpty())
+    {
+		qCritical() << "QApplication::applicationName is not set. Please do that.";
 		return false;
 	}
 
-	if (QCoreApplication::applicationVersion().isEmpty()) {
-		qCritical()
-			<< "QApplication::applicationVersion is not set. Please do that.";
+	if (QCoreApplication::applicationVersion().isEmpty())
+    {
+		qCritical() << "QApplication::applicationVersion is not set. Please do that.";
 		return false;
 	}
 
@@ -176,16 +198,21 @@ bool FvUpdater::CheckForUpdates(bool silentAsMuchAsItCouldGet) {
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-bool FvUpdater::CheckForUpdatesSilent() {
-	if (qApp->Settings()->GetDateOfLastRemind().daysTo(QDate::currentDate())
-		>= 1) {
-		const bool success = CheckForUpdates(true);
-		if (m_dropOnFinish && not success) {
+bool FvUpdater::checkForUpdatesSilent()
+{
+	if (qApp->Settings()->GetDateOfLastRemind().daysTo(QDate::currentDate()) >= 1)
+    {
+		const bool success = checkForUpdates(true);
+		if (m_dropOnFinish && !success)
+        {
 			drop();
 		}
 		return success;
-	} else {
-		if (m_dropOnFinish) {
+	}
+    else
+    {
+		if (m_dropOnFinish)
+        {
 			drop();
 		}
 		return true;
@@ -193,92 +220,198 @@ bool FvUpdater::CheckForUpdatesSilent() {
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-bool FvUpdater::CheckForUpdatesNotSilent() {
-	const bool success = CheckForUpdates(false);
-	if (m_dropOnFinish && not success) {
+bool FvUpdater::checkForUpdatesNotSilent()
+{
+	const bool success = checkForUpdates(false);
+	if (m_dropOnFinish && !success)
+    {
 		drop();
 	}
 	return success;
 }
 
-void FvUpdater::getFileSize() {
+//---------------------------------------------------------------------------------------------------------------------
+void FvUpdater::httpFeedDownloadFinished()
+{
+	if (m_httpRequestAborted)
+    {
+		m_reply->deleteLater();
+		return;
+	}
+
+	const QVariant redirectionTarget = m_reply->attribute(QNetworkRequest::RedirectionTargetAttribute);
+
+    if (m_reply->error() != QNetworkReply::NoError)
+    {
+		// Error.
+        showMessageBox(QMessageBox::Critical, tr("Error"),
+                       tr("Feed download failed: %1.").arg(m_reply->errorString()), false);
+	}
+    else if (!redirectionTarget.isNull())
+    {
+		const QUrl newUrl = m_feedURL.resolved(redirectionTarget.toUrl());
+
+		m_feedURL = newUrl;
+		m_reply->deleteLater();
+
+		startDownloadFeed(m_feedURL);
+		return;
+	}
+    else
+    {
+		auto jsonDoc = QJsonDocument::fromJson(m_reply->readAll());
+        qDebug() << "Response is a JSON object:" << jsonDoc.isObject();
+        if (jsonDoc.isObject())
+        {
+            auto tag = jsonDoc.object()["tag_name"].toString();
+            qDebug() << "Found the following tag" << tag;
+
+            if (!releaseIsNewer(tag))
+            {
+                showMessageBox(QMessageBox::Information, tr("Information"), tr("No new releases available."), false);
+                return;
+            }
+            if (showConfirmationDialog(tr("A new release %1 is available.\nDo you want to download it?").arg(tag), true))
+                getPLatformSpecificInstaller(jsonDoc.object()["assets"].toArray());
+            return;
+		}
+	}
+
+	m_reply->deleteLater();
+
+	if (m_dropOnFinish)
+    {
+		drop();
+	}
+}
+
+void FvUpdater::networkError(QNetworkReply::NetworkError)
+{
+	emit setProgress(100);
+	m_fileSize = 0;
+    showMessageBox(QMessageBox::Critical, tr("Error"), m_reply->errorString(), false);
+}
+
+void FvUpdater::getFileSize()
+{
 	auto fileSizeHeader = m_reply->header(QNetworkRequest::ContentLengthHeader).toInt();
-	if (m_fileSize == 0 && fileSizeHeader > 1000000) {
+	if (m_fileSize == 0 && fileSizeHeader > 1000000)
+    {
 		m_fileSize = fileSizeHeader;
 	}
 }
 
-void FvUpdater::startDownloadFile(QUrl url, QString name) {
+//---------------------------------------------------------------------------------------------------------------------
+void FvUpdater::startDownloadFeed(const QUrl &url)
+{
 	QNetworkRequest request;
-	request.setHeader(QNetworkRequest::ContentTypeHeader,
-					  QStringLiteral("application/text"));
-	request.setHeader(QNetworkRequest::UserAgentHeader,
-					  QCoreApplication::applicationName());
+	request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/text"));
+	request.setHeader(QNetworkRequest::UserAgentHeader, QCoreApplication::applicationName());
 	request.setUrl(url);
 	request.setSslConfiguration(QSslConfiguration::defaultConfiguration());
 
-	m_reply = m_qnam.get(request);
-	connect(m_reply, SIGNAL(metaDataChanged()), this, SLOT(getFileSize()));
+	m_reply = m_networkAccessManager.get(request);
+
+	connect(m_reply, &QNetworkReply::downloadProgress, this, [this](qint64 bytesRead, qint64 totalBytes)
+    {
+		Q_UNUSED(bytesRead)
+		Q_UNUSED(totalBytes)
+
+		if (m_httpRequestAborted)
+        {
+			return;
+		}
+	});
+
+	connect(m_reply, &QNetworkReply::finished, this, &FvUpdater::httpFeedDownloadFinished);
+}
+
+void FvUpdater::startDownloadFile(QUrl url, QString name)
+{
+	QNetworkRequest request;
+	request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/text"));
+	request.setHeader(QNetworkRequest::UserAgentHeader, QCoreApplication::applicationName());
+	request.setUrl(url);
+	request.setSslConfiguration(QSslConfiguration::defaultConfiguration());
+
+	m_reply = m_networkAccessManager.get(request);
+
+	connect(m_reply, &QNetworkReply::metaDataChanged, this, &FvUpdater::getFileSize);
+
 	QDir downloadDir = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
 	downloadDir.mkdir(m_releaseName);
 	downloadDir.cd(m_releaseName);
+
 	auto downloadedFile = new QFile(downloadDir.filePath(name), this);
-	if(downloadedFile->exists() && !downloadedFile->remove()){
-		showErrorDialog(tr("Unable to get exclusive access to file\n%1\nPossibly the file is already being downloaded.").arg(downloadDir.filePath(name)), false);
+	if(downloadedFile->exists() && !downloadedFile->remove())
+    {
+        showMessageBox(QMessageBox::Critical, tr("Error"),
+		               tr("Unable to get exclusive access to file\n%1\nPossibly the file is already being downloaded.").arg(downloadDir.filePath(name)), false);
 		return;
 	}
+
 	bool isOpen = downloadedFile->open(QIODevice::WriteOnly | QIODevice::Truncate);
-	if (!isOpen) {
-		showErrorDialog(tr("Unable to open file\n%1\nfor writing").arg(downloadDir.filePath(name)), false);
+	if (!isOpen)
+    {
+        showMessageBox(QMessageBox::Critical, tr("Error"),
+		               tr("Unable to open file\n%1\nfor writing").arg(downloadDir.filePath(name)), false);
 		return;
 	}
-	connect(m_reply.data(), &QNetworkReply::readyRead, this, [this, downloadedFile]() {
+
+	connect(m_reply, &QNetworkReply::readyRead, this, [this, downloadedFile]()
+    {
 		// this slot gets called every time the QNetworkReply has new data.
 		// We read all of its new data and write it into the file.
 		// That way we use less RAM than when reading it at the finished()
 		// signal of the QNetworkReply
 		downloadedFile->write(m_reply->readAll());
 		int progress = int(downloadedFile->size() * 100 / m_fileSize);
-		setProgress(progress);
+		emit setProgress(progress);
 	});
 
-	connect(m_reply.data(), SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(networkError(QNetworkReply::NetworkError)));
+    connect(m_reply, &QNetworkReply::errorOccurred, this, &FvUpdater::networkError);
 
+	connect(m_reply, &QNetworkReply::downloadProgress, this, [this]()
+    {
+		if (m_httpRequestAborted)
+        {
+			return;
+		}
+	});
 
-	connect(m_reply.data(), &QNetworkReply::downloadProgress, this,
-			[this](qint64 bytesRead, qint64 totalBytes) {
-				Q_UNUSED(bytesRead)
-				Q_UNUSED(totalBytes)
-
-				if (m_httpRequestAborted) {
-					return;
-				}
-			});
-	connect(m_reply.data(), &QNetworkReply::finished, this, [=]() {
+	connect(m_reply, &QNetworkReply::finished, this, [=]()
+    {
 		fileDownloadFinished(downloadedFile, name);
 	});
 }
-void FvUpdater::fileDownloadFinished(QFile *downloadedFile, QString name) {
-	if (m_httpRequestAborted) {
+
+void FvUpdater::fileDownloadFinished(QFile *downloadedFile, QString name)
+{
+	if (m_httpRequestAborted)
+    {
 		m_reply->deleteLater();
 		return;
 	}
 
-	const QVariant redirectionTarget =
-		m_reply->attribute(QNetworkRequest::RedirectionTargetAttribute);
-	if (m_reply->error() != QNetworkReply::NoError) {
-		// Error.
-		showErrorDialog(
-			tr("File download failed: %1.").arg(m_reply->errorString()), false);
-	} else if (not redirectionTarget.isNull()) {
+	const QVariant redirectionTarget = m_reply->attribute(QNetworkRequest::RedirectionTargetAttribute);
+
+	if (m_reply->error() != QNetworkReply::NoError)
+    {
+		// Show error.
+        showMessageBox(QMessageBox::Critical, tr("Error"),
+                       tr("File download failed: %1.").arg(m_reply->errorString()), false);
+	}
+    else if (!redirectionTarget.isNull())
+    {
 		downloadedFile->close();
 		const QUrl newUrl = m_feedURL.resolved(redirectionTarget.toUrl());
 		m_reply->deleteLater();
-		showInformationDialog(tr("Download has started, the installer will open once it's finished downloading"), false);
 		startDownloadFile(newUrl, name);
 		return;
-	} else {
-		setProgress(100); //just in case
+	}
+    else
+    {
+		emit setProgress(100); //just in case
 		m_fileSize = 0;
 		downloadedFile->write(m_reply->readAll());
 		downloadedFile->close();
@@ -291,188 +424,117 @@ void FvUpdater::fileDownloadFinished(QFile *downloadedFile, QString name) {
 		auto	 err = proc.error();
 		qDebug() << res << " " << err;
 #else
-
 		QDesktopServices::openUrl(QUrl::fromLocalFile(fileInfo.absoluteFilePath()));
 #endif
-
 		downloadedFile->deleteLater();
 	}
 }
-//---------------------------------------------------------------------------------------------------------------------
-void FvUpdater::startDownloadFeed(const QUrl &url) {
-	// m_xml.clear();
-
-	QNetworkRequest request;
-	request.setHeader(QNetworkRequest::ContentTypeHeader,
-					  QStringLiteral("application/text"));
-	request.setHeader(QNetworkRequest::UserAgentHeader,
-					  QCoreApplication::applicationName());
-	request.setUrl(url);
-	request.setSslConfiguration(QSslConfiguration::defaultConfiguration());
-
-	m_reply = m_qnam.get(request);
-
-	connect(m_reply.data(), &QNetworkReply::downloadProgress, this,
-			[this](qint64 bytesRead, qint64 totalBytes) {
-				Q_UNUSED(bytesRead)
-				Q_UNUSED(totalBytes)
-
-				if (m_httpRequestAborted) {
-					return;
-				}
-			});
-	connect(m_reply.data(), &QNetworkReply::finished, this,
-			&FvUpdater::httpFeedDownloadFinished);
-}
 
 //---------------------------------------------------------------------------------------------------------------------
-void FvUpdater::cancelDownloadFeed() {
-	if (m_reply) {
+void FvUpdater::cancelDownloadFeed()
+{
+	if (m_reply)
+    {
 		m_httpRequestAborted = true;
 		m_reply->abort();
 	}
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void FvUpdater::httpFeedDownloadFinished() {
-	if (m_httpRequestAborted) {
-		m_reply->deleteLater();
-		return;
+/// @brief showConfirmationDialog show a confirmatiom dialog.
+///
+/// This method displays a dialog a confirmatiom message box and returns a yes or no answer.
+///
+/// @param message This property holds the informative text that provides a fuller description for the message
+/// @param showEvenInSilentMode Sets the given option to show dialog or not.
+///     - true always show dialog.
+///     - false donlt show dialog in silent mode.
+///
+/// @return bool yes or no.
+//---------------------------------------------------------------------------------------------------------------------
+bool FvUpdater::showConfirmationDialog(const QString &message, bool showEvenInSilentMode)
+{
+    if (m_silentMode && !showEvenInSilentMode)
+    {
+		// Don't show confirmation dialog in the silent mode
+        return false;
 	}
 
-	const QVariant redirectionTarget =
-		m_reply->attribute(QNetworkRequest::RedirectionTargetAttribute);
-	if (m_reply->error() != QNetworkReply::NoError) {
-		// Error.
-		showErrorDialog(
-			tr("Feed download failed: %1.").arg(m_reply->errorString()), false);
-	} else if (not redirectionTarget.isNull()) {
-		const QUrl newUrl = m_feedURL.resolved(redirectionTarget.toUrl());
+	QMessageBox confirmationMsgBox;
+	confirmationMsgBox.setIcon(QMessageBox::Information);
+	confirmationMsgBox.setText(tr("Information"));
+	confirmationMsgBox.setInformativeText(message);
+	confirmationMsgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
 
-		m_feedURL = newUrl;
-		m_reply->deleteLater();
-
-		startDownloadFeed(m_feedURL);
-		return;
-	} else {
-		auto jsonDoc = QJsonDocument::fromJson(m_reply->readAll());
-        qDebug() << "Response is a JSON object:" << jsonDoc.isObject();
-        if (jsonDoc.isObject()) {
-            auto tag = jsonDoc.object()["tag_name"].toString();
-            qDebug() << "Found the following tag" << tag;
-
-            if (!releaseIsNewer(tag)) {
-                showInformationDialog(tr("No new releases available."));
-                return;
-            }
-            if (showConfirmationDialog(tr("A new release %1 is available.\nDo you want to download it?").arg(tag), true))
-                getPLatformSpecificInstaller(jsonDoc.object()["assets"].toArray());
-            return;
-		}
-	}
-
-	m_reply->deleteLater();
-
-	if (m_dropOnFinish) {
-		drop();
-	}
-}
-
-void FvUpdater::getPLatformSpecificInstaller(QJsonArray assets) {
-	qDebug() << "current application version" << QCoreApplication::applicationVersion();
-
-#ifdef Q_OS_LINUX // Defined on Linux.
-	auto searchPattern = "AppImage";
-#else
-	#ifdef Q_OS_MACOS // Defined on macOS
-		auto searchPattern = "macos";
-	#else
-		#ifdef Q_OS_WIN64 // Defined on Windows 64-bit only.
-			auto searchPattern = "windows";
-		#else // Only windows 32-bit left
-			auto searchPattern = "win32";
-		#endif
-	#endif
-#endif
-
-	for (const QJsonValueRef asset : assets) {
-		auto name = asset.toObject()["name"].toString();
-		qDebug() << "Checking" << searchPattern << "against" << name;
-		if (name.contains(searchPattern,
-						  Qt::CaseInsensitive)) {
-			QUrl downloadableUrl =
-				asset.toObject()["browser_download_url"].toString();
-			startDownloadFile(downloadableUrl, name);
-		}
-	}
+	return QMessageBox::Yes == confirmationMsgBox.exec();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-void FvUpdater::showErrorDialog(const QString &message,
-								bool		   showEvenInSilentMode) {
-	if (m_silentAsMuchAsItCouldGet) {
-		if (not showEvenInSilentMode) {
-			// Don't show errors in the silent mode
-			return;
-		}
-	}
-
-	QMessageBox dlFailedMsgBox;
-	dlFailedMsgBox.setIcon(QMessageBox::Critical);
-	dlFailedMsgBox.setText(tr("Error"));
-	dlFailedMsgBox.setInformativeText(message);
-	dlFailedMsgBox.exec();
-}
-
+/// @brief showMessageBox Show a message box.
+///
+/// This method displays a message box with an icon, text and informative text based on a boolean option.
+///
+/// @param icon QMessageBox This property holds the message box's icon.
+/// @param text This property holds the message box text to be displayed.
+/// @param message This property holds the informative text that provides a fuller description for the message
+/// @param showEvenInSilentMode Sets the given option to show message box or not.
+///     - true always show message box.
+///     - false don't show message box in silent mode.
 //---------------------------------------------------------------------------------------------------------------------
-void FvUpdater::showInformationDialog(const QString &message,
-									  bool			 showEvenInSilentMode) {
-	if (m_silentAsMuchAsItCouldGet) {
-		if (not showEvenInSilentMode) {
-			// Don't show information dialogs in the silent mode
-			return;
-		}
-	}
+void FvUpdater::showMessageBox(QMessageBox::Icon icon, const QString &text,
+                               const QString &message, bool showEvenInSilentMode)
+{
+    if (m_silentMode && !showEvenInSilentMode)
+    {
+        // Don't show MessageBox in the silent mode
+        return;
+    }
 
-	QMessageBox dlInformationMsgBox;
-	dlInformationMsgBox.setIcon(QMessageBox::Information);
-	dlInformationMsgBox.setText(tr("Information"));
-	dlInformationMsgBox.setInformativeText(message);
-	dlInformationMsgBox.exec();
+    QMessageBox messageBox;
+	messageBox.setIcon(icon);
+	messageBox.setText(text);
+	messageBox.setInformativeText(message);
+	messageBox.exec();
 }
 
-bool FvUpdater::showConfirmationDialog(const QString &message,
-									   bool			  showEvenInSilentMode) {
-	if (m_silentAsMuchAsItCouldGet) {
-		if (not showEvenInSilentMode) {
-			// Don't show information dialogs in the silent mode
-			return false;
-		}
-	}
-
-	QMessageBox dlInformationMsgBox;
-	dlInformationMsgBox.setIcon(QMessageBox::Information);
-	dlInformationMsgBox.setText(tr("Information"));
-	dlInformationMsgBox.setInformativeText(message);
-	dlInformationMsgBox.setStandardButtons(QMessageBox::Yes
-										   | QMessageBox::No);
-
-	return QMessageBox::Yes == dlInformationMsgBox.exec();
-}
-
-
-bool FvUpdater::releaseIsNewer(const QString &releaseTag) {
+bool FvUpdater::releaseIsNewer(const QString &releaseTag)
+{
 	const auto releaseVersion = releaseTag.mid(1).split('.');
 	const auto currentVersion = QCoreApplication::applicationVersion().split('.');
-	for (int i = 0; i < releaseVersion.length(); i++) {
+
+	for (int i = 0; i < releaseVersion.length(); i++)
+    {
 		if (releaseVersion[i].toInt() > currentVersion[i].toInt())
+        {
 			return (m_releaseName = releaseTag), true;
+        }
 	}
 	return false;
 }
 
-void FvUpdater::networkError(QNetworkReply::NetworkError) {
-	setProgress(100);
-	m_fileSize = 0;
-	showErrorDialog(m_reply->errorString(), false);
+void FvUpdater::getPLatformSpecificInstaller(QJsonArray assets)
+{
+	qDebug() << "current application version" << QCoreApplication::applicationVersion();
+
+    QString searchPattern = "Unknown";
+#if defined(Q_OS_LINUX)   // Defined on Linux
+	searchPattern = "AppImage";
+#elif defined(Q_OS_MAC)   // Defined on macOS
+    searchPattern = "macos";
+#elif defined(Q_OS_WIN)   // Defined on Windows 64-bit only.
+	searchPattern = "windows";
+#endif
+
+	for (const QJsonValueRef asset : assets)
+    {
+		auto name = asset.toObject()["name"].toString();
+		qDebug() << "Checking" << searchPattern << "against" << name;
+		if (name.contains(searchPattern, Qt::CaseInsensitive))
+        {
+			QUrl downloadableUrl = asset.toObject()["browser_download_url"].toString();
+			startDownloadFile(downloadableUrl, name);
+            showMessageBox(QMessageBox::Information, tr("Information"),
+                           tr("Download has started, the installer will open once it's finished downloading"), false);
+		}
+	}
 }

--- a/src/libs/fervor/fvupdater.h
+++ b/src/libs/fervor/fvupdater.h
@@ -1,39 +1,54 @@
-/***************************************************************************************************
- **
- **  Copyright (c) 2012 Linas Valiukas and others.
- **
- **  Permission is hereby granted, free of charge, to any person obtaining a
- *copy of this
- **  software and associated documentation files (the "Software"), to deal in
- *the Software
- **  without restriction, including without limitation the rights to use, copy,
- *modify,
- **  merge, publish, distribute, sublicense, and/or sell copies of the Software,
- *and to
- **  permit persons to whom the Software is furnished to do so, subject to the
- *following conditions:
- **
- **  The above copyright notice and this permission notice shall be included in
- *all copies or
- **  substantial portions of the Software.
- **
- **  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *IMPLIED, INCLUDING BUT
- **  NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
- *PURPOSE AND
- **  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
- *LIABLE FOR ANY CLAIM,
- **  DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
- *OTHERWISE, ARISING FROM,
- **  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- *THE SOFTWARE.
- **
- ******************************************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   fvupdater.h
+//  @author Douglas S Caskey
+//  @date   17 Sep, 2023
+//
+//  @copyright
+//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
+
+//---------------------------------------------------------------------------------------------------------------------
+//   @file   fvupdater.h
+//   @copyright
+//   Copyright (c) 2012 Linas Valiukas and others.
+//
+//   @brief
+//   Permission is hereby granted, free of charge, to any person obtaining a copy of this
+//   software and associated documentation files (the "Software"), to deal in the Software
+//   without restriction, including without limitation the rights to use, copy, modify,
+//   merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+//   permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+//   The above copyright notice and this permission notice shall be included in all copies or
+//   substantial portions of the Software.
+//
+//   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+//   NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+//   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+//   DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//---------------------------------------------------------------------------------------------------------------------
 
 #ifndef FVUPDATER_H
 #define FVUPDATER_H
 
 #include <QMetaObject>
+#include <QMessageBox>
 #include <QMutex>
 #include <QNetworkAccessManager>
 #include <QObject>
@@ -45,89 +60,76 @@
 
 extern const QString defaultFeedURL;
 class QFile;
-class FvUpdater : public QObject {
+class FvUpdater : public QObject
+{
 	Q_OBJECT
 
 public:
 	// Singleton
-	static FvUpdater *sharedUpdater();
-	static void		  drop();
+	static FvUpdater       *sharedUpdater();
+	static void		        drop();
 
 	// Set / get feed URL
-	void	SetFeedURL(const QUrl &feedURL);
-	void	SetFeedURL(const QString &feedURL);
-	QString GetFeedURL() const;
+	void	                setFeedURL(const QUrl &feedURL);
+	void	                setFeedURL(const QString &feedURL);
+	QString                 getFeedURL() const;
+	bool                    isDropOnFinish() const;
+	void                    setDropOnFinish(bool value);
 
-	bool IsDropOnFinish() const;
-	void SetDropOnFinish(bool value);
-signals:
-	void setProgress(int);
-public slots:
 	// Check for updates
-	bool CheckForUpdates(bool silentAsMuchAsItCouldGet = true);
-
-	// Aliases
-	bool CheckForUpdatesSilent();
-	bool CheckForUpdatesNotSilent();
-
-protected:
-	friend class FvUpdateWindow; // Uses GetProposedUpdate() and others
-
-
-protected slots:
-
+	bool                    checkForUpdates(bool silentMode = true);
+	bool                    checkForUpdatesSilent();
+	bool                    checkForUpdatesNotSilent();
 
 private slots:
-	void httpFeedDownloadFinished();
-	void networkError(QNetworkReply::NetworkError);
-	void getFileSize();
+    void                    httpFeedDownloadFinished();
+    void                    networkError(QNetworkReply::NetworkError);
+    void                    getFileSize();
+
+signals:
+    void                    setProgress(int);
+
+protected:
+	friend class            FvUpdateWindow; /// Uses GetProposedUpdate() and others
 
 private:
 	//
 	// Singleton business
 	//
 	Q_DISABLE_COPY(FvUpdater)
-	FvUpdater();		  // Hide main constructor
-	virtual ~FvUpdater(); // Hide main destructor
+	                        FvUpdater();		  // Hide main constructor
+	virtual                ~FvUpdater();          // Hide main destructor
 
-	static QPointer<FvUpdater> m_Instance; // Singleton instance
+	static QPointer<FvUpdater> m_Instance;        // Singleton instance
 
 	// If true, don't show the error dialogs and the "no updates." dialog
-	// (silentAsMuchAsItCouldGet from CheckForUpdates() goes here)
+	// (silentMode from checkForUpdates() goes here)
 	// Useful for automatic update checking upon application startup.
-	bool m_silentAsMuchAsItCouldGet;
+	bool                    m_silentMode;
 
 	//
 	// HTTP feed fetcher infrastructure
 	//
-	QUrl					m_feedURL; // Feed URL that will be fetched
-	QNetworkAccessManager	m_qnam;
+	QUrl					m_feedURL;            // Feed URL that will be fetched
+	QNetworkAccessManager	m_networkAccessManager;
 	QPointer<QNetworkReply> m_reply;
 	bool					m_httpRequestAborted;
 	bool					m_dropOnFinish;
 	int						m_fileSize{};
 	QString					m_releaseName{};
 
-	void startDownloadFeed(const QUrl &url);		// Start downloading feed
-	void startDownloadFile(QUrl url, QString name); // Start downloading file
-	void fileDownloadFinished(QFile *downloadedFile, QString name);
-	void cancelDownloadFeed(); // Stop downloading the current feed
+	void                    startDownloadFeed(const QUrl &url);		   // Start downloading feed
+	void                    startDownloadFile(QUrl url, QString name); // Start downloading file
+	void                    fileDownloadFinished(QFile *downloadedFile, QString name);
+	void                    cancelDownloadFeed();                      // Stop downloading the current feed
 
 	// Dialogs (notifications)
-	// Show an error message
-	void showErrorDialog(const QString &message,
-						 bool			showEvenInSilentMode = false);
-	// Show an informational message
-	void showInformationDialog(const QString &message,
-							   bool			  showEvenInSilentMode = false);
+    bool                    showConfirmationDialog(const QString &message, bool showEvenInSilentMode = false);
+    void                    showMessageBox(QMessageBox::Icon icon, const QString &text,
+                                           const QString &message, bool showEvenInSilentMode);
 
-	bool showConfirmationDialog(const QString &message,
-								bool		   showEvenInSilentMode = false);
-
-
-	// bool jsonParsing(); //
-	bool releaseIsNewer(const QString &releaseTag);
-	void getPLatformSpecificInstaller(QJsonArray assets);
+    bool                    releaseIsNewer(const QString &releaseTag);
+	void                    getPLatformSpecificInstaller(QJsonArray assets);
 };
 
 #endif // FVUPDATER_H


### PR DESCRIPTION
This PR 

- Fixes the connect statement to use the correct errorOccurred signal to prevent throwing an erroneous warning.
- Restores the bracket styling in keeping with the rest of the code base.
- Consolidates the error and information dialogs into a single showMessageBox routine to reduce redundant code. 
- Moves displaying the installer information message box so it shows with all downloads, and not just when the feed uses a redirect target. 

This closes issue #1372