### PR TITLE
fix:  pattern and piece labels

### DIFF
--- a/src/libs/vlayout/vlayoutpiece.cpp
+++ b/src/libs/vlayout/vlayoutpiece.cpp
@@ -158,9 +158,11 @@ bool findLabelGeometry(const VPatternLabelData &labelData, const VContainer *pat
     {
         Calculator cal1;
         labelWidth = cal1.EvalFormula(pattern->DataVariables(), labelData.GetLabelWidth());
+        labelWidth = ToPixel(labelWidth, *pattern->GetPatternUnit());
 
         Calculator cal2;
         labelHeight = cal2.EvalFormula(pattern->DataVariables(), labelData.GetLabelHeight());
+        labelHeight = ToPixel(labelHeight, *pattern->GetPatternUnit());
     }
     catch(qmu::QmuParserError &error)
     {
@@ -174,11 +176,7 @@ bool findLabelGeometry(const VPatternLabelData &labelData, const VContainer *pat
         try
         {
             const auto centerAnchorPoint = pattern->GeometricObject<VPointF>(centerAnchor);
-
-            const qreal lWidth = ToPixel(labelWidth, *pattern->GetPatternUnit());
-            const qreal lHeight = ToPixel(labelHeight, *pattern->GetPatternUnit());
-
-            pos = static_cast<QPointF>(*centerAnchorPoint) - QRectF(0, 0, lWidth, lHeight).center();
+            pos = static_cast<QPointF>(*centerAnchorPoint) - QRectF(0, 0, labelWidth, labelHeight).center();
         }
         catch(const VExceptionBadId &)
         {
@@ -543,9 +541,6 @@ void VLayoutPiece::SetPieceText(const QString& qsName, const VPieceLabelData& da
         return;
     }
 
-    labelWidth = ToPixel(labelWidth, *pattern->GetPatternUnit());
-    labelHeight = ToPixel(labelHeight, *pattern->GetPatternUnit());
-
     QVector<QPointF> v;
     v << ptPos
       << QPointF(ptPos.x() + labelWidth, ptPos.y())
@@ -567,6 +562,7 @@ void VLayoutPiece::SetPieceText(const QString& qsName, const VPieceLabelData& da
     d->m_tmPiece.setFont(font);
     d->m_tmPiece.SetFontSize(data.getFontSize());
     d->m_tmPiece.Update(qsName, data);
+
     // this will generate the lines of text
     d->m_tmPiece.SetFontSize(data.getFontSize());
     d->m_tmPiece.FitFontSize(labelWidth, labelHeight);
@@ -604,9 +600,6 @@ void VLayoutPiece::SetPatternInfo(VAbstractPattern* pDoc, const VPatternLabelDat
         return;
     }
 
-    labelWidth = ToPixel(labelWidth, *pattern->GetPatternUnit());
-    labelHeight = ToPixel(labelHeight, *pattern->GetPatternUnit());
-
     QVector<QPointF> v;
     v << ptPos
       << QPointF(ptPos.x() + labelWidth, ptPos.y())
@@ -625,7 +618,6 @@ void VLayoutPiece::SetPatternInfo(VAbstractPattern* pDoc, const VPatternLabelDat
     // Generate text
     d->m_tmPattern.setFont(font);
     d->m_tmPattern.SetFontSize(data.getFontSize());
-
     d->m_tmPattern.Update(pDoc);
 
     // generate lines of text

--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -1808,12 +1808,12 @@ VPieceItem::MoveTypes PatternPieceTool::findLabelGeometry(const VPatternLabelDat
 
         Calculator cal1;
         labelWidth = cal1.EvalFormula(VAbstractTool::data.DataVariables(), labelData.GetLabelWidth());
-        //labelWidth = ToPixel(labelWidth, *VDataTool::data.GetPatternUnit());
+
         const bool heightIsSingle = qmu::QmuTokenParser::IsSingle(labelData.GetLabelHeight());
 
         Calculator cal2;
         labelHeight = cal2.EvalFormula(VAbstractTool::data.DataVariables(), labelData.GetLabelHeight());
-        //labelHeight = ToPixel(labelHeight, *VDataTool::data.GetPatternUnit());
+
 
         if (!widthIsSingle || not heightIsSingle)
         {
@@ -1835,10 +1835,8 @@ VPieceItem::MoveTypes PatternPieceTool::findLabelGeometry(const VPatternLabelDat
 
             const qreal lWidth = ToPixel(labelWidth, *VDataTool::data.GetPatternUnit());
             const qreal lHeight = ToPixel(labelHeight, *VDataTool::data.GetPatternUnit());
-
             pos = static_cast<QPointF>(*centerAnchorPoint) - QRectF(0, 0, lWidth, lHeight).center();
-            //labelWidth = ToPixel(labelWidth, *VDataTool::data.GetPatternUnit());
-            //labelHeight = ToPixel(labelHeight, *VDataTool::data.GetPatternUnit());
+
             restrictions &= ~ VPieceItem::IsMovable;
         }
         catch(const VExceptionBadId &)

--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -1808,14 +1808,13 @@ VPieceItem::MoveTypes PatternPieceTool::findLabelGeometry(const VPatternLabelDat
 
         Calculator cal1;
         labelWidth = cal1.EvalFormula(VAbstractTool::data.DataVariables(), labelData.GetLabelWidth());
-        qDebug() << " Label width: " << labelWidth;
-        qDebug() << " Label width is single: " << widthIsSingle;
+        //labelWidth = ToPixel(labelWidth, *VDataTool::data.GetPatternUnit());
         const bool heightIsSingle = qmu::QmuTokenParser::IsSingle(labelData.GetLabelHeight());
 
         Calculator cal2;
         labelHeight = cal2.EvalFormula(VAbstractTool::data.DataVariables(), labelData.GetLabelHeight());
-        qDebug() << " Label height: " << labelHeight;
-        qDebug() << " Label height is single: " << heightIsSingle;
+        //labelHeight = ToPixel(labelHeight, *VDataTool::data.GetPatternUnit());
+
         if (!widthIsSingle || not heightIsSingle)
         {
             restrictions &= ~ VPieceItem::IsResizable;
@@ -1833,13 +1832,13 @@ VPieceItem::MoveTypes PatternPieceTool::findLabelGeometry(const VPatternLabelDat
         try
         {
             const auto centerAnchorPoint = VAbstractTool::data.GeometricObject<VPointF>(centerAnchor);
-            qDebug() << " Anchor center point: " << centerAnchorPoint;
+
             const qreal lWidth = ToPixel(labelWidth, *VDataTool::data.GetPatternUnit());
             const qreal lHeight = ToPixel(labelHeight, *VDataTool::data.GetPatternUnit());
-            qDebug() << " Label pixel width: " << lWidth;
-            qDebug() << " Label pixel height: " << lHeight;
+
             pos = static_cast<QPointF>(*centerAnchorPoint) - QRectF(0, 0, lWidth, lHeight).center();
-            qDebug() << " Anchor point position: " << pos;
+            //labelWidth = ToPixel(labelWidth, *VDataTool::data.GetPatternUnit());
+            //labelHeight = ToPixel(labelHeight, *VDataTool::data.GetPatternUnit());
             restrictions &= ~ VPieceItem::IsMovable;
         }
         catch(const VExceptionBadId &)


### PR DESCRIPTION
This fixes issue #1378 

Removes calling ToPixel() for the width and height of labels that use the top and bottom anchor points which would cause the font size to be set much larger and outside the bounding rect of the label. 

close issue #1378 