### PR TITLE
feature: change default values for notches

### DIFF
--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -56,6 +56,7 @@
 #include <QDate>
 #include <QDir>
 #include <QFont>
+#include <QtGlobal>
 #include <QLocale>
 #include <QMessageLogger>
 #include <QString>
@@ -1657,14 +1658,14 @@ qreal VCommonSettings::getDefaultNotchLength() const
     switch (units)
     {
         case Unit::Mm:
-            maxValue = 40;
+            maxValue = 12.5;
             break;
         case Unit::Inch:
-            maxValue = 1.5;
+            maxValue = .5;
             break;
         default:
         case Unit::Cm:
-            maxValue = 4;
+            maxValue = 1.25;
             break;
    }
    return value(settingDefaultNotchLength, maxValue).toReal();
@@ -1686,14 +1687,14 @@ qreal VCommonSettings::getDefaultNotchWidth() const
    switch (units)
    {
        case Unit::Mm:
-           maxValue = 12.50;
+           maxValue = 5.0;
            break;
        case Unit::Inch:
-           maxValue = 0.50;
+           maxValue = 0.25;
            break;
        default:
        case Unit::Cm:
-           maxValue = 1.25;
+           maxValue = .5;
            break;
    }
    return value(settingDefaultNotchWidth, maxValue).toReal();


### PR DESCRIPTION
This PR addresses issue #1380 

Changes the default notch length and width attributes according to the pattern units to:

<img width="574" height="470" alt="image" src="https://github.com/user-attachments/assets/8de81d64-9f0e-432f-a6d3-ca33d9a9b95b" />

The maxium values for the spinboxes remains as follows"

<img width="546" height="465" alt="image" src="https://github.com/user-attachments/assets/1f8e8475-acd6-4eb2-b1c0-00a225051ef9" />

Closes issue #1380 