### PR TITLE
Fix file locking issue in non-GUI environments

### DIFF
--- a/src/libs/vmisc/vlockguard.h
+++ b/src/libs/vmisc/vlockguard.h
@@ -84,6 +84,8 @@ public:
     template <typename Alloc, typename Delete>
     VLockGuard(const QString& lockName, Alloc a, Delete d, int stale = 0, int timeout=0);
 
+    ~VLockGuard();
+
     const std::shared_ptr<Guarded> &GetProtected() const;
     int             GetLockError() const;
     bool            IsLocked() const;
@@ -133,6 +135,16 @@ VLockGuard<Guarded>::VLockGuard(const QString& lockName, Alloc a, Delete d, int 
     if (TryLock(lockName, stale, timeout))
     {
         holder.reset(a(), d);
+    }
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+template <typename Guarded>
+VLockGuard<Guarded>::~VLockGuard()
+{
+    if (lock && lock->isLocked())
+    {
+        lock->unlock();
     }
 }
 


### PR DESCRIPTION
Problem:
- VLockGuard class lacked a destructor to clean up lock files
- Lock files (.locked) persisted on filesystem after process termination
- Subsequent Seamly2D processes failed with 'Pattern file was locked' errors
- Affected headless operation in containers and servers

Solution:
- Add destructor to VLockGuard template class that calls QLockFile::unlock()
- Ensures lock files are properly removed when VLockGuard objects are destroyed
- Fixes the issue for all usage patterns (class members, local variables, etc.)
- Backward compatible - no changes required in existing code

Impact:
- Resolves critical blocking issue for non-GUI Seamly2D usage
- Enables proper operation in containerized/server environments
- Allows sequential processing of the same pattern files
- Existing test tst_vlockguard.cpp now passes