### PR TITLE
fix: default lineweight

### DIFF
--- a/src/app/seamly2d/xml/vpattern.cpp
+++ b/src/app/seamly2d/xml/vpattern.cpp
@@ -1114,7 +1114,7 @@ void VPattern::PointsCommonAttributes(const QDomElement &domElement, quint32 &id
 {
     PointsCommonAttributes(domElement, id, name, mx, my, isVisible);
     lineType   = GetParametrString(domElement, AttrLineType,   LineTypeSolidLine);
-    lineWeight = GetParametrString(domElement, AttrLineWeight, "1.00");
+    lineWeight = GetParametrString(domElement, AttrLineWeight, DefaultLineWeight);
     lineColor  = GetParametrString(domElement, AttrLineColor,  qApp->Settings()->getPointNameColor());
 }
 
@@ -1282,7 +1282,7 @@ void VPattern::ParseLineElement(VMainGraphicsScene *scene, const QDomElement &do
         const quint32 firstPoint  = GetParametrUInt(domElement,   AttrFirstPoint,  NULL_ID_STR);
         const quint32 secondPoint = GetParametrUInt(domElement,   AttrSecondPoint, NULL_ID_STR);
         const QString lineType    = GetParametrString(domElement, AttrLineType,    LineTypeSolidLine);
-        const QString lineWeight  = GetParametrString(domElement, AttrLineWeight,  "1.00");
+        const QString lineWeight  = GetParametrString(domElement, AttrLineWeight,  DefaultLineWeight);
         const QString lineColor   = GetParametrString(domElement, AttrLineColor,   ColorBlack);
 
         VToolLine::Create(id, firstPoint, secondPoint, lineType, lineWeight, lineColor, scene, this, data, parse, Source::FromFile);
@@ -2281,8 +2281,8 @@ void VPattern::ParseToolPointFromCircleAndTangent(VMainGraphicsScene *scene, QDo
         const QString cRadius = GetParametrString(domElement, AttrCRadius);
         QString cR = cRadius;
         const CrossCirclesPoint crossPoint = static_cast<CrossCirclesPoint>(GetParametrUInt(domElement,
-                                                                                  AttrCrossPoint,
-                                                                                  "1"));
+                                                                                            AttrCrossPoint,
+                                                                                            "1"));
 
         IntersectCircleTangentTool::Create(id, name, cCenterId, cR, tangentId, crossPoint, mx, my,
                                                showPointName, scene, this, data, parse, Source::FromFile);
@@ -2321,8 +2321,8 @@ void VPattern::ParseToolPointFromArcAndTangent(VMainGraphicsScene *scene, const 
         const quint32 arcId = GetParametrUInt(domElement, AttrArc, NULL_ID_STR);
         const quint32 tangentId = GetParametrUInt(domElement, AttrTangent, NULL_ID_STR);
         const CrossCirclesPoint crossPoint = static_cast<CrossCirclesPoint>(GetParametrUInt(domElement,
-                                                                                  AttrCrossPoint,
-                                                                                  "1"));
+                                                                                            AttrCrossPoint,
+                                                                                            "1"));
 
         VToolPointFromArcAndTangent::Create(id, name, arcId, tangentId, crossPoint, mx, my,
                                             showPointName, scene, this, data, parse, Source::FromFile);
@@ -2450,7 +2450,7 @@ void VPattern::ParseToolSpline(VMainGraphicsScene *scene, QDomElement &domElemen
 
         const QString color      = GetParametrString(domElement, AttrColor,      ColorBlack);
         const QString penStyle   = GetParametrString(domElement, AttrPenStyle,   LineTypeSolidLine);
-        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, "1.00");
+        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, DefaultLineWeight);
         const quint32 duplicate  = GetParametrUInt(domElement,   AttrDuplicate,  "0");
 
         VToolSpline *spl = VToolSpline::Create(id, point1, point4, a1, a2, l1, l2, duplicate, color, penStyle,
@@ -2506,7 +2506,7 @@ void VPattern::ParseToolCubicBezier(VMainGraphicsScene *scene, const QDomElement
 
         const QString color      = GetParametrString(domElement, AttrColor,      ColorBlack);
         const QString penStyle   = GetParametrString(domElement, AttrPenStyle,   LineTypeSolidLine);
-        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, "1.00");
+        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, DefaultLineWeight);
         const quint32 duplicate  = GetParametrUInt(domElement, AttrDuplicate,    "0");
 
         auto p1 = data->GeometricObject<VPointF>(point1);
@@ -2608,7 +2608,7 @@ void VPattern::ParseToolSplinePath(VMainGraphicsScene *scene, const QDomElement 
         ToolsCommonAttributes(domElement, id);
         const QString color      = GetParametrString(domElement, AttrColor,      ColorBlack);
         const QString penStyle   = GetParametrString(domElement, AttrPenStyle,   LineTypeSolidLine);
-        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, "1.00");
+        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, DefaultLineWeight);
         const quint32 duplicate  = GetParametrUInt(domElement,   AttrDuplicate,  "0");
 
         QVector<quint32> points;
@@ -2702,7 +2702,7 @@ void VPattern::ParseToolCubicBezierPath(VMainGraphicsScene *scene, const QDomEle
         ToolsCommonAttributes(domElement, id);
         const QString color      = GetParametrString(domElement, AttrColor,      ColorBlack);
         const QString penStyle   = GetParametrString(domElement, AttrPenStyle,   LineTypeSolidLine);
-        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, "1.00");
+        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, DefaultLineWeight);
         const quint32 duplicate  = GetParametrUInt(domElement,   AttrDuplicate,  "0");
 
         QVector<VPointF> points;
@@ -2857,7 +2857,7 @@ void VPattern::ParseToolArc(VMainGraphicsScene *scene, QDomElement &domElement, 
               QString f2Fix      = f2;//need for saving fixed formula;
         const QString color      = GetParametrString(domElement, AttrColor,      ColorBlack);
         const QString penStyle   = GetParametrString(domElement, AttrPenStyle,   LineTypeSolidLine);
-        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, "1.00");
+        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, DefaultLineWeight);
 
         VToolArc::Create(id, center, r, f1Fix, f2Fix, color, penStyle, lineWeight, scene, this, data,
                          parse, Source::FromFile);
@@ -2909,7 +2909,7 @@ void VPattern::ParseToolEllipticalArc(VMainGraphicsScene *scene, QDomElement &do
         QString frotationFix     = frotation;//need for saving fixed formula;
         const QString color      = GetParametrString(domElement, AttrColor, ColorBlack);
         const QString penStyle   = GetParametrString(domElement, AttrPenStyle, LineTypeSolidLine);
-        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, "1.00");
+        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, DefaultLineWeight);
 
         VToolEllipticalArc::Create(id, center, r1, r2, f1Fix, f2Fix, frotationFix, color, penStyle, lineWeight,
                                    scene, this, data,
@@ -3030,7 +3030,7 @@ void VPattern::ParseToolArcWithLength(VMainGraphicsScene *scene, QDomElement &do
         QString lengthFix        = length;//need for saving fixed length;
         const QString color      = GetParametrString(domElement, AttrColor, ColorBlack);
         const QString penStyle   = GetParametrString(domElement, AttrPenStyle, LineTypeSolidLine);
-        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, "1.00");
+        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, DefaultLineWeight);
 
         VToolArcWithLength::Create(id, center, r, f1Fix, lengthFix, color, penStyle, lineWeight, scene, this,
                                    data, parse,
@@ -3540,7 +3540,7 @@ void VPattern::ParsePathElement(VMainGraphicsScene *scene, QDomElement &domEleme
         const quint32 idTool     = GetParametrUInt(domElement,   VAbstractNode::AttrIdTool, NULL_ID_STR);
         const QString color      = GetParametrString(domElement, AttrLineColor, ColorBlack);
         const QString lineType   = GetParametrString(domElement, AttrLineType, LineTypeSolidLine);
-        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, "1.00");
+        const QString lineWeight = GetParametrString(domElement, AttrLineWeight, DefaultLineWeight);
         const bool cut           = getParameterBool(domElement,  AttrCut, falseStr);
         const bool extendStartPt = getParameterBool(domElement,  AttrExtendStartPoint, falseStr);
         const bool extendEndPt   = getParameterBool(domElement,  AttrExtendEndPoint, falseStr);

--- a/src/libs/ifc/ifcdef.cpp
+++ b/src/libs/ifc/ifcdef.cpp
@@ -167,6 +167,8 @@ const QString LineTypeDotLine        = QStringLiteral("dotLine");
 const QString LineTypeDashDotLine    = QStringLiteral("dashDotLine");
 const QString LineTypeDashDotDotLine = QStringLiteral("dashDotDotLine");
 
+const QString DefaultLineWeight      = QStringLiteral("0.35");
+
 //---------------------------------------------------------------------------------------------------------------------
 /**
  * @brief LineTypeList return list of all line types.

--- a/src/libs/ifc/ifcdef.h
+++ b/src/libs/ifc/ifcdef.h
@@ -186,6 +186,8 @@ extern const QString LineTypeDotLine;
 extern const QString LineTypeDashDotLine;
 extern const QString LineTypeDashDotDotLine;
 
+extern const QString DefaultLineWeight;
+
 QStringList            LineTypes();
 Qt::PenStyle           lineTypeToPenStyle(const QString &lineType);
 QString                PenStyleToLineType(Qt::PenStyle penStyle);

--- a/src/libs/ifc/xml/vabstractpattern.cpp
+++ b/src/libs/ifc/xml/vabstractpattern.cpp
@@ -2411,7 +2411,7 @@ QMap<quint32, GroupAttributes> VAbstractPattern::getGroups()
                             const bool locked = getParameterBool(group, AttrGroupLocked, trueStr);
                             const QString color = GetParametrString(group, AttrGroupColor, ColorBlack);
                             const QString linetype = GetParametrString(group, AttrLineType, LineTypeSolidLine);
-                            const QString lineweight = GetParametrString(group, AttrLineWeight, "0.35");
+                            const QString lineweight = GetParametrString(group, AttrLineWeight, DefaultLineWeight);
 
                             groupData.name = name;
                             groupData.visible = visible;
@@ -3051,7 +3051,7 @@ QString VAbstractPattern::getGroupLineWeight(quint32 id)
     if (group.isElement())
     {
 
-        weight = GetParametrString(group, AttrLineWeight, "0.35");
+        weight = GetParametrString(group, AttrLineWeight, DefaultLineWeight);
         return weight;
     }
     else

--- a/src/libs/ifc/xml/vdomdocument.cpp
+++ b/src/libs/ifc/xml/vdomdocument.cpp
@@ -1,54 +1,54 @@
-/***************************************************************************
- **  @file   vdomdocument.cpp
- **  @author Douglas S Caskey
- **  @date   17 Sep, 2023
- **
- **  @copyright
- **  Copyright (C) 2017 - 2023 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+///--------------------------------------------------------------------------------------------------------------------
+/// @file   vdomdocument.cpp
+/// @author Douglas S Caskey
+/// @date   17 Sep, 2023
+///
+/// @brief
+/// @copyright
+/// This source code is part of the Seamly2D project, a pattern making
+/// program to create and model patterns of clothing.
+/// Copyright (C) 2017-2025 Seamly2D project
+/// <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+///
+/// Seamly2D is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, either version 3 of the License, or
+/// (at your option) any later version.
+///
+/// Seamly2D is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+///--------------------------------------------------------------------------------------------------------------------
 
- /************************************************************************
-  **
-  **  @file   vtoolline.cpp
-  **  @author Roman Telezhynskyi <dismine(at)gmail.com>
-  **  @date   November 15, 2013
-  **
-  **  @brief
-  **  @copyright
-  **  This source code is part of the Valentina project, a pattern making
-  **  program, whose allow create and modeling patterns of clothing.
-  **  Copyright (C) 2013-2015 Valentina project
-  **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
-  **
-  **  Valentina is free software: you can redistribute it and/or modify
-  **  it under the terms of the GNU General Public License as published by
-  **  the Free Software Foundation, either version 3 of the License, or
-  **  (at your option) any later version.
-  **
-  **  Valentina is distributed in the hope that it will be useful,
-  **  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  **  GNU General Public License for more details.
-  **
-  **  You should have received a copy of the GNU General Public License
-  **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
-  **
-  *************************************************************************/
+///--------------------------------------------------------------------------------------------------------------------
+/// @file   vdomdocument.cpp
+/// @author Roman Telezhynskyi <dismine(at)gmail.com>
+/// @date   November 15, 2013
+///
+/// @brief
+/// @copyright
+/// This source code is part of the Valentina project, a pattern making
+/// program, whose allow create and modeling patterns of clothing.
+/// Copyright (C) 2013-2015 Valentina project
+/// <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+///
+/// Valentina is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, either version 3 of the License, or
+/// (at your option) any later version.
+///
+/// Valentina is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+///--------------------------------------------------------------------------------------------------------------------
 
 #include "vdomdocument.h"
 
@@ -87,7 +87,7 @@
 
 namespace
 {
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 void SaveNodeCanonically(QXmlStreamWriter &stream, const QDomNode &domNode)
 {
     if (stream.hasError())
@@ -157,13 +157,13 @@ const QString VDomDocument::TagVersion = QStringLiteral("version");
 const QString VDomDocument::TagUnit    = QStringLiteral("unit");
 const QString VDomDocument::TagLine    = QStringLiteral("line");
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 VDomDocument::VDomDocument()
     : QDomDocument(),
       map()
 {}
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 QDomElement VDomDocument::elementById(quint32 id, const QString &tagName)
 {
     if (id == 0)
@@ -217,13 +217,12 @@ QDomElement VDomDocument::elementById(quint32 id, const QString &tagName)
     return QDomElement();
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Find element by id.
- * @param node node
- * @param id id value
- * @return true if found
- */
+///--------------------------------------------------------------------------------------------------------------------
+/// @brief Find element by id.
+/// @param node node
+/// @param id id value
+/// @return true if found
+///--------------------------------------------------------------------------------------------------------------------
 bool VDomDocument::find(const QDomElement &node, quint32 id)
 {
     if (node.hasAttribute(AttrId))
@@ -258,7 +257,7 @@ bool VDomDocument::find(const QDomElement &node, quint32 id)
     return false;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 bool VDomDocument::SaveCanonicalXML(QIODevice *file, int indent, QString &error) const
 {
     SCASSERT(file != nullptr)
@@ -289,13 +288,12 @@ bool VDomDocument::SaveCanonicalXML(QIODevice *file, int indent, QString &error)
     return true;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Returns the long long value of the given attribute. RENAME: GetParameterLongLong?
- * @param domElement tag in xml tree
- * @param name attribute name
- * @return long long value
- */
+///--------------------------------------------------------------------------------------------------------------------
+/// @brief Returns the long long value of the given attribute. RENAME: GetParameterLongLong?
+/// @param domElement tag in xml tree
+/// @param name attribute name
+/// @return long long value
+///--------------------------------------------------------------------------------------------------------------------
 quint32 VDomDocument::GetParametrUInt(const QDomElement &domElement, const QString &name, const QString &defValue)
 {
     Q_ASSERT_X(not name.isEmpty(), Q_FUNC_INFO, "name of parametr is empty");
@@ -324,7 +322,7 @@ quint32 VDomDocument::GetParametrUInt(const QDomElement &domElement, const QStri
     return id;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 bool VDomDocument::getParameterBool(const QDomElement &domElement, const QString &name, const QString &defValue)
 {
     Q_ASSERT_X(not name.isEmpty(), Q_FUNC_INFO, "name of parametr is empty");
@@ -366,7 +364,7 @@ bool VDomDocument::getParameterBool(const QDomElement &domElement, const QString
     return val;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 NodeUsage VDomDocument::GetParametrUsage(const QDomElement &domElement, const QString &name)
 {
     const bool value = getParameterBool(domElement, name, trueStr);
@@ -380,7 +378,7 @@ NodeUsage VDomDocument::GetParametrUsage(const QDomElement &domElement, const QS
     }
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 void VDomDocument::SetParametrUsage(QDomElement &domElement, const QString &name, const NodeUsage &value)
 {
     if (value == NodeUsage::InUse)
@@ -393,14 +391,13 @@ void VDomDocument::SetParametrUsage(QDomElement &domElement, const QString &name
     }
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Returns the string value of the given attribute. RENAME: see above
- *
- * if attribute empty return default value. If default value empty too throw exception.
- * @return attribute value
- * @throw VExceptionEmptyParameter when attribute is empty
- */
+///--------------------------------------------------------------------------------------------------------------------
+/// @brief Returns the string value of the given attribute. RENAME: see above
+///
+/// if attribute empty return default value. If default value empty too throw exception.
+/// @return attribute value
+/// @throw VExceptionEmptyParameter when attribute is empty
+///--------------------------------------------------------------------------------------------------------------------
 QString VDomDocument::GetParametrString(const QDomElement &domElement, const QString &name,
                                         const QString &defValue)
 {
@@ -421,7 +418,7 @@ QString VDomDocument::GetParametrString(const QDomElement &domElement, const QSt
     return parameter;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 QString VDomDocument::GetParametrEmptyString(const QDomElement &domElement, const QString &name)
 {
     QString result;
@@ -436,13 +433,12 @@ QString VDomDocument::GetParametrEmptyString(const QDomElement &domElement, cons
     return result;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief Returns the double value of the given attribute.
- * @param domElement tag in xml tree
- * @param name attribute name
- * @return double value
- */
+///--------------------------------------------------------------------------------------------------------------------
+/// @brief Returns the double value of the given attribute.
+/// @param domElement tag in xml tree
+/// @param name attribute name
+/// @return double value
+///--------------------------------------------------------------------------------------------------------------------
 qreal VDomDocument::GetParametrDouble(const QDomElement &domElement, const QString &name, const QString &defValue)
 {
     Q_ASSERT_X(not name.isEmpty(), Q_FUNC_INFO, "name of parametr is empty");
@@ -470,12 +466,11 @@ qreal VDomDocument::GetParametrDouble(const QDomElement &domElement, const QStri
     return param;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief getParameterId return value id attribute.
- * @param domElement tag in xml tree.
- * @return id value.
- */
+///--------------------------------------------------------------------------------------------------------------------
+/// @brief getParameterId return value id attribute.
+/// @param domElement tag in xml tree.
+/// @return id value.
+///--------------------------------------------------------------------------------------------------------------------
 quint32 VDomDocument::getParameterId(const QDomElement &domElement)
 {
     Q_ASSERT_X(not domElement.isNull(), Q_FUNC_INFO, "domElement is null");
@@ -500,7 +495,7 @@ quint32 VDomDocument::getParameterId(const QDomElement &domElement)
     return id;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 Unit VDomDocument::measurementUnits() const
 {
     Unit unit = StrToUnits(UniqueTagText(TagUnit, unitCM));
@@ -513,7 +508,7 @@ Unit VDomDocument::measurementUnits() const
     return unit;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 QString VDomDocument::UniqueTagText(const QString &tagName, const QString &defVal) const
 {
     const QDomNodeList nodeList = this->elementsByTagName(tagName);
@@ -544,17 +539,16 @@ QString VDomDocument::UniqueTagText(const QString &tagName, const QString &defVa
     return defVal;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief TestUniqueId test exist unique id in pattern file. Each id must be unique.
- */
+///--------------------------------------------------------------------------------------------------------------------
+/// @brief TestUniqueId test exist unique id in pattern file. Each id must be unique.
+///--------------------------------------------------------------------------------------------------------------------
 void VDomDocument::TestUniqueId() const
 {
     QVector<quint32> vector;
     CollectId(documentElement(), vector);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 void VDomDocument::CollectId(const QDomElement &node, QVector<quint32> &vector) const
 {
     if (node.hasAttribute(VDomDocument::AttrId))
@@ -577,7 +571,7 @@ void VDomDocument::CollectId(const QDomElement &node, QVector<quint32> &vector) 
     }
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 class CErrorHandler : public xercesc::ErrorHandler
 {
 public:
@@ -610,12 +604,11 @@ void CErrorHandler::resetErrors()
 {
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief ValidateXML validate xml file by xsd schema.
- * @param schema path to schema file.
- * @param fileName name of xml file.
- */
+///--------------------------------------------------------------------------------------------------------------------
+/// @brief ValidateXML validate xml file by xsd schema.
+/// @param schema path to schema file.
+/// @param fileName name of xml file.
+///--------------------------------------------------------------------------------------------------------------------
 void VDomDocument::ValidateXML(const QString &schema, const QString &fileName)
 {
     qCDebug(vXML, "Validation xml file %s.", qUtf8Printable(fileName));
@@ -665,22 +658,49 @@ void VDomDocument::ValidateXML(const QString &schema, const QString &fileName)
     QFile patternFile(fileName);
     if (patternFile.open(QIODevice::ReadOnly) == false)
     {
-        const QString errorMsg(tr("Can't open schema file %1:\n%2.").arg(schema).arg(fileSchema.errorString()));
+        const QString errorMsg(tr("Can't open pattern file %1:\n%2.").arg(fileName).arg(patternFile.errorString()));
         throw VException(errorMsg);
     }
 
     QTextStream patternIn(&patternFile);
     std::string xmlString = patternIn.readAll().toStdString();
+
+    // Fix files with invalid lineweight. 
+    size_t startPos = 0;
+    std::string fromString = "lineWeight=\"1.00\"";
+    std::string toString = "lineWeight=\"1\"";
+    while((startPos = xmlString.find(fromString, startPos)) != std::string::npos)
+    {
+        xmlString.replace(startPos, fromString.length(), toString);
+        // Advance startPos past the newly inserted 'toString' to avoid infinite loops
+        // if 'fromString' is a substring of 'toString' (e.g., replacing "a" with "aa").
+        startPos += toString.length();
+    }
+    // If any replacements were made write the changes back to the pattern file.
+    if (startPos > 0)
+    {
+        patternFile.close();
+        if (patternFile.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate) == false)
+        {
+            const QString errorMsg(tr("Can't open pattern file %1:\n%2.").arg(fileName).arg(patternFile.errorString()));
+            throw VException(errorMsg);
+        }
+
+        QTextStream patternOut(&patternFile);
+        patternOut << QString::fromStdString(xmlString);
+    }
+
     xercesc::MemBufInputSource inputBuffer((XMLByte*)xmlString.c_str(), xmlString.size(), "/input.xml");
 
     domParser->parse(inputBuffer);
-    if (domParser->getErrorCount() != 0) {
+    if (domParser->getErrorCount() != 0)
+    {
         const QString errorMsg(tr("Validation error file %1").arg(fileName));
         throw VException(errorMsg);
     }
 }
 
-// //---------------------------------------------------------------------------------------------------------------------
+// ///--------------------------------------------------------------------------------------------------------------------
 void VDomDocument::setXMLContent(const QString &fileName)
 {
     QFile file(fileName);
@@ -704,7 +724,7 @@ void VDomDocument::setXMLContent(const QString &fileName)
     }
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 QString VDomDocument::UnitsHelpString()
 {
     QString r;
@@ -719,7 +739,7 @@ QString VDomDocument::UnitsHelpString()
     return r;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 bool VDomDocument::SaveDocument(const QString &fileName, QString &error)
 {
     if (fileName.isEmpty())
@@ -754,7 +774,7 @@ bool VDomDocument::SaveDocument(const QString &fileName, QString &error)
     return success;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 // cppcheck-suppress unusedFunction
 QString VDomDocument::Major() const
 {
@@ -763,7 +783,7 @@ QString VDomDocument::Major() const
     return v.at(0);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 // cppcheck-suppress unusedFunction
 QString VDomDocument::Minor() const
 {
@@ -772,7 +792,7 @@ QString VDomDocument::Minor() const
     return v.at(1);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 // cppcheck-suppress unusedFunction
 QString VDomDocument::Patch() const
 {
@@ -781,7 +801,7 @@ QString VDomDocument::Patch() const
     return v.at(2);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 bool VDomDocument::setTagText(const QString &tag, const QString &text)
 {
     const QDomNodeList nodeList = this->elementsByTagName(tag);
@@ -801,7 +821,7 @@ bool VDomDocument::setTagText(const QString &tag, const QString &text)
     return false;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 bool VDomDocument::setTagText(const QDomElement &domElement, const QString &text)
 {
     if (domElement.isNull() == false)
@@ -818,11 +838,10 @@ bool VDomDocument::setTagText(const QDomElement &domElement, const QString &text
     return false;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-/**
- * @brief RemoveAllChildren remove all children from file.
- * @param domElement tag in xml tree.
- */
+///--------------------------------------------------------------------------------------------------------------------
+/// @brief RemoveAllChildren remove all children from file.
+/// @param domElement tag in xml tree.
+///--------------------------------------------------------------------------------------------------------------------
 void VDomDocument::RemoveAllChildren(QDomElement &domElement)
 {
     if ( domElement.hasChildNodes() )
@@ -834,21 +853,21 @@ void VDomDocument::RemoveAllChildren(QDomElement &domElement)
     }
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 QDomNode VDomDocument::ParentNodeById(const quint32 &nodeId)
 {
     QDomElement domElement = NodeById(nodeId);
     return domElement.parentNode();
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 QDomElement VDomDocument::CloneNodeById(const quint32 &nodeId)
 {
     QDomElement domElement = NodeById(nodeId);
     return domElement.cloneNode().toElement();
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 QDomElement VDomDocument::NodeById(const quint32 &nodeId)
 {
     QDomElement domElement = elementById(nodeId);
@@ -859,7 +878,7 @@ QDomElement VDomDocument::NodeById(const quint32 &nodeId)
     return domElement;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 bool VDomDocument::SafeCopy(const QString &source, const QString &destination, QString &error)
 {
     bool result = false;
@@ -927,7 +946,7 @@ bool VDomDocument::SafeCopy(const QString &source, const QString &destination, Q
     return result;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 QVector<VLabelTemplateLine> VDomDocument::GetLabelTemplate(const QDomElement &element) const
 {
     // We use implicit conversion. That's why check if values are still the same as excpected.
@@ -959,7 +978,7 @@ QVector<VLabelTemplateLine> VDomDocument::GetLabelTemplate(const QDomElement &el
     return lines;
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 void VDomDocument::SetLabelTemplate(QDomElement &element, const QVector<VLabelTemplateLine> &lines)
 {
     if (not element.isNull())

--- a/src/libs/ifc/xml/vdomdocument.h
+++ b/src/libs/ifc/xml/vdomdocument.h
@@ -1,53 +1,54 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                             *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+///--------------------------------------------------------------------------------------------------------------------
+/// @file   vdomdocument.h
+/// @author Douglas S Caskey
+/// @date   17 Sep, 2023
+///
+/// @brief
+/// @copyright
+/// This source code is part of the Seamly2D project, a pattern making
+/// program to create and model patterns of clothing.
+/// Copyright (C) 2017-2025 Seamly2D project
+/// <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+///
+/// Seamly2D is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, either version 3 of the License, or
+/// (at your option) any later version.
+///
+/// Seamly2D is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+///--------------------------------------------------------------------------------------------------------------------
 
- ************************************************************************
- **
- **  @file   vdomdocument.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   November 15, 2013
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Seamly2D project, a pattern making
- **  program that allows creating and modelling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+///--------------------------------------------------------------------------------------------------------------------
+/// @file   vdomdocument.h
+/// @author Roman Telezhynskyi <dismine(at)gmail.com>
+/// @date   November 15, 2013
+///
+/// @brief
+/// @copyright
+/// This source code is part of the Valentina project, a pattern making
+/// program, whose allow create and modeling patterns of clothing.
+/// Copyright (C) 2013-2015 Valentina project
+/// <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+///
+/// Valentina is free software: you can redistribute it and/or modify
+/// it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation, either version 3 of the License, or
+/// (at your option) any later version.
+///
+/// Valentina is distributed in the hope that it will be useful,
+/// but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/// GNU General Public License for more details.
+///
+/// You should have received a copy of the GNU General Public License
+/// along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+///--------------------------------------------------------------------------------------------------------------------
 
 #ifndef VDOMDOCUMENT_H
 #define VDOMDOCUMENT_H
@@ -78,27 +79,27 @@ QT_WARNING_PUSH
 QT_WARNING_DISABLE_GCC("-Weffc++")
 QT_WARNING_DISABLE_GCC("-Wnon-virtual-dtor")
 
-/**
- * @brief The VDomDocument class represents a Seamly2D document (.val file).
- *
- * A Seamly2D document describes the construction of a sewing pattern. The
- * information is stored in XML format. By parsing a VDomDocument, the contained
- * pattern is rendered to a Seamly2D graphics scene (VMainGraphicsScene).
- *
- * A sewing pattern consists of zero or more custom variables and one
- * or more pattern pieces.
- *
- * A custom variable is an auxiliary variable that is calculated from regular measurement
- * variables (that belong to the multisize measurements table). Variables are used to
- * create a graduation schema for the sewing pattern.
- *
- * A pattern piece contains
- * 1) auxiliary pattern construction elements (calculation),
- * 2) pattern construction elements (modeling), and
- * 3) special markers, e.g. seam allowances (details).
- * Of these, 2) and 3) are visible in the final pattern (draw mode 'Modeling'),
- * 1) is only displayed when editing (draw mode 'Calculation') the pattern.
- */
+///--------------------------------------------------------------------------------------------------------------------
+/// @brief The VDomDocument class represents a Seamly2D document (.val file).
+///
+/// A Seamly2D document describes the construction of a sewing pattern. The
+/// information is stored in XML format. By parsing a VDomDocument, the contained
+/// pattern is rendered to a Seamly2D graphics scene (VMainGraphicsScene).
+///
+/// A sewing pattern consists of zero or more custom variables and one
+/// or more pattern pieces.
+///
+/// A custom variable is an auxiliary variable that is calculated from regular measurement
+/// variables (that belong to the multisize measurements table). Variables are used to
+/// create a graduation schema for the sewing pattern.
+///
+/// A pattern piece contains
+/// 1) auxiliary pattern construction elements (calculation),
+/// 2) pattern construction elements (modeling), and
+/// 3) special markers, e.g. seam allowances (details).
+/// Of these, 2) and 3) are visible in the final pattern (draw mode 'Modeling'),
+/// 1) is only displayed when editing (draw mode 'Calculation') the pattern.
+///--------------------------------------------------------------------------------------------------------------------
 class VDomDocument : public QDomDocument
 {
     Q_DECLARE_TR_FUNCTIONS(VDomDocument)
@@ -114,72 +115,70 @@ public:
     static const QString TagUnit;
     static const QString TagLine;
 
-    VDomDocument();
-    virtual ~VDomDocument() Q_DECL_EQ_DEFAULT;
-    QDomElement elementById(quint32 id, const QString &tagName = QString());
+                     VDomDocument();
+    virtual         ~VDomDocument() Q_DECL_EQ_DEFAULT;
+    QDomElement      elementById(quint32 id, const QString &tagName = QString());
 
     template <typename T>
-    void SetAttribute(QDomElement &domElement, const QString &name, const T &value) const;
+    void             SetAttribute(QDomElement &domElement, const QString &name, const T &value) const;
 
-    static quint32 GetParametrUInt(const QDomElement& domElement, const QString &name, const QString &defValue);
-    static bool    getParameterBool(const QDomElement& domElement, const QString &name, const QString &defValue);
+    static quint32   GetParametrUInt(const QDomElement& domElement, const QString &name, const QString &defValue);
+    static bool      getParameterBool(const QDomElement& domElement, const QString &name, const QString &defValue);
 
     static NodeUsage GetParametrUsage(const QDomElement& domElement, const QString &name);
     static void      SetParametrUsage(QDomElement& domElement, const QString &name, const NodeUsage &value);
 
-    static QString GetParametrString(const QDomElement& domElement, const QString &name,
-                                     const QString &defValue = QString());
-    static QString GetParametrEmptyString(const QDomElement& domElement, const QString &name);
-    static qreal   GetParametrDouble(const QDomElement& domElement, const QString &name, const QString &defValue);
-    static quint32 getParameterId(const QDomElement& domElement);
+    static QString   GetParametrString(const QDomElement& domElement, const QString &name,
+                                      const QString &defValue = QString());
+    static QString   GetParametrEmptyString(const QDomElement& domElement, const QString &name);
+    static qreal     GetParametrDouble(const QDomElement& domElement, const QString &name, const QString &defValue);
+    static quint32   getParameterId(const QDomElement& domElement);
 
-    Unit           measurementUnits() const;
+    Unit             measurementUnits() const;
 
-    static void    ValidateXML(const QString &schema, const QString &fileName);
-    virtual void   setXMLContent(const QString &fileName);
-    static QString UnitsHelpString();
+    static void      ValidateXML(const QString &schema, const QString &fileName);
+    virtual void     setXMLContent(const QString &fileName);
+    static QString   UnitsHelpString();
 
-    virtual bool   SaveDocument(const QString &fileName, QString &error);
-    QString        Major() const;
-    QString        Minor() const;
-    QString        Patch() const;
-    static void    RemoveAllChildren(QDomElement &domElement);
+    virtual bool     SaveDocument(const QString &fileName, QString &error);
+    QString          Major() const;
+    QString          Minor() const;
+    QString          Patch() const;
+    static void      RemoveAllChildren(QDomElement &domElement);
 
-    QDomNode       ParentNodeById(const quint32 &nodeId);
-    QDomElement    CloneNodeById(const quint32 &nodeId);
-    QDomElement    NodeById(const quint32 &nodeId);
+    QDomNode         ParentNodeById(const quint32 &nodeId);
+    QDomElement      CloneNodeById(const quint32 &nodeId);
+    QDomElement      NodeById(const quint32 &nodeId);
 
-    static bool    SafeCopy(const QString &source, const QString &destination, QString &error);
+    static bool      SafeCopy(const QString &source, const QString &destination, QString &error);
 
     QVector<VLabelTemplateLine> GetLabelTemplate(const QDomElement &element) const;
     void                        SetLabelTemplate(QDomElement &element, const QVector<VLabelTemplateLine> &lines);
 
 protected:
-    bool           setTagText(const QString &tag, const QString &text);
-    bool           setTagText(const QDomElement &domElement, const QString &text);
-    QString        UniqueTagText(const QString &tagName, const QString &defVal = QString()) const;
+    bool             setTagText(const QString &tag, const QString &text);
+    bool             setTagText(const QDomElement &domElement, const QString &text);
+    QString          UniqueTagText(const QString &tagName, const QString &defVal = QString()) const;
 
-    void           TestUniqueId() const;
-    void           CollectId(const QDomElement &node, QVector<quint32> &vector)const;
+    void             TestUniqueId() const;
+    void             CollectId(const QDomElement &node, QVector<quint32> &vector)const;
 
 private:
     Q_DISABLE_COPY(VDomDocument)
-    /** @brief Map used for finding element by id. */
-    QHash<quint32, QDomElement> map;
 
-    bool           find(const QDomElement &node, quint32 id);
+    QHash<quint32, QDomElement> map; /// @brief Map used for finding element by id.
 
-    bool SaveCanonicalXML(QIODevice *file, int indent, QString &error) const;
+    bool             find(const QDomElement &node, quint32 id);
+    bool             SaveCanonicalXML(QIODevice *file, int indent, QString &error) const;
 };
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
+/// @brief SetAttribute set attribute in pattern file. Replace "," by ".".
+/// @param domElement element in xml tree.
+/// @param name name of attribute.
+/// @param value value of attribute.
+///--------------------------------------------------------------------------------------------------------------------
 template <typename T>
-/**
- * @brief SetAttribute set attribute in pattern file. Replace "," by ".".
- * @param domElement element in xml tree.
- * @param name name of attribute.
- * @param value value of attribute.
- */
 inline void VDomDocument::SetAttribute(QDomElement &domElement, const QString &name, const T &value) const
 {
     // See specification for xs:decimal
@@ -187,7 +186,7 @@ inline void VDomDocument::SetAttribute(QDomElement &domElement, const QString &n
     domElement.setAttribute(name, locale.toString(value).remove(localeGroupSeparator(locale)));
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 template <>
 inline void VDomDocument::SetAttribute<QString>(QDomElement &domElement, const QString &name,
                                                 const QString &value) const
@@ -195,20 +194,20 @@ inline void VDomDocument::SetAttribute<QString>(QDomElement &domElement, const Q
     domElement.setAttribute(name, value);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 template <>
 inline void VDomDocument::SetAttribute<bool>(QDomElement &domElement, const QString &name, const bool &value) const
 {
     domElement.setAttribute(name, value ? trueStr : falseStr);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
+///--------------------------------------------------------------------------------------------------------------------
 template <>
 inline void VDomDocument::SetAttribute<MeasurementsType>(QDomElement &domElement, const QString &name,
                                                               const MeasurementsType &value) const
 {
     domElement.setAttribute(name, value == MeasurementsType::Multisize ? QStringLiteral("multisize") :
-                                                                        QStringLiteral("individual"));
+                                                                         QStringLiteral("individual"));
 }
 
 QT_WARNING_POP

--- a/src/libs/ifc/xml/vpatternconverter.cpp
+++ b/src/libs/ifc/xml/vpatternconverter.cpp
@@ -53,6 +53,7 @@
 #include "abstract_converter.h"
 #include "../exception/vexception.h"
 #include "../exception/vexceptionemptyparameter.h"
+#include "../ifc/ifcdef.h"
 #include "../qmuparser/qmutokenparser.h"
 #include "../vmisc/def.h"
 #include "../vmisc/logging.h"
@@ -1138,9 +1139,9 @@ void VPatternConverter::toVersion0_6_4()
             {
                 element.removeAttribute(QStringLiteral("pointOfIntersection"));
                 element.setAttribute(strType, QStringLiteral("intersectXY"));
-                element.setAttribute(strLineType, QStringLiteral("dashLine"));
-                element.setAttribute(strLineWeight, QStringLiteral("0.35"));
-                element.setAttribute(strLineColor, QStringLiteral("black"));
+                element.setAttribute(strLineType, LineTypeDashLine);
+                element.setAttribute(strLineWeight, DefaultLineWeight);
+                element.setAttribute(strLineColor, ColorBlack);
             }
         }
     }

--- a/src/libs/vgeometry/vabstractcurve_p.h
+++ b/src/libs/vgeometry/vabstractcurve_p.h
@@ -69,7 +69,7 @@ public:
         : duplicate(0)
         , color(ColorBlack)
         , penStyle(LineTypeSolidLine)
-        , lineWeight("0.35")
+        , lineWeight(DefaultLineWeight)
     {}
 
     VAbstractCurveData(const VAbstractCurveData &curve)

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -1221,7 +1221,7 @@ void VCommonSettings::setDefaultLineColor(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultLineWeight() const
 {
-    return value(settingGraphicsViewDefaultLineWeight, 1.00).toReal();
+    return value(settingGraphicsViewDefaultLineWeight, DefaultLineWeight).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1281,7 +1281,7 @@ void VCommonSettings::setTertiarySupportColor(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getConstrainValue() const
 {
-    return value(settingGraphicsViewConstrainValue, 10.00).toReal();
+    return value(settingGraphicsViewConstrainValue, 10).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1894,7 +1894,7 @@ void VCommonSettings::setDefaultSeamLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultSeamLineweight() const
 {
-   return value(settingDefaultSeamLineweight, 1.00).toReal();
+   return value(settingDefaultSeamLineweight, DefaultLineWeight).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1930,7 +1930,7 @@ void VCommonSettings::setDefaultCutLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultCutLineweight() const
 {
-   return value(settingDefaultCutLineweight, 1.00).toReal();
+   return value(settingDefaultCutLineweight, DefaultLineWeight).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1966,7 +1966,7 @@ void VCommonSettings::setDefaultInternalLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultInternalLineweight() const
 {
-   return value(settingDefaultInternalLineweight, 1.00).toReal();
+   return value(settingDefaultInternalLineweight, DefaultLineWeight).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -2002,7 +2002,7 @@ void VCommonSettings::setDefaultCutoutLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultCutoutLineweight() const
 {
-   return value(settingDefaultCutoutLineweight, 1.00).toReal();
+   return value(settingDefaultCutoutLineweight, DefaultLineWeight).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -2086,7 +2086,7 @@ void VCommonSettings::setDefaultGrainlineColor(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultGrainlineLineweight() const
 {
-   return value(settingDefaultGrainlineLineweight, 0.25).toReal();
+   return value(settingDefaultGrainlineLineweight, DefaultLineWeight).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -2098,7 +2098,7 @@ void VCommonSettings::setDefaultGrainlineLineweight(const qreal &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultArrowLength() const
 {
-   return value(settingDefaultArrowLength, 0.70).toReal();
+   return value(settingDefaultArrowLength, 40).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vmisc/vcommonsettings.cpp
+++ b/src/libs/vmisc/vcommonsettings.cpp
@@ -1221,7 +1221,7 @@ void VCommonSettings::setDefaultLineColor(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultLineWeight() const
 {
-    return value(settingGraphicsViewDefaultLineWeight, DefaultLineWeight).toReal();
+    return value(settingGraphicsViewDefaultLineWeight, 0.35).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1894,7 +1894,7 @@ void VCommonSettings::setDefaultSeamLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultSeamLineweight() const
 {
-   return value(settingDefaultSeamLineweight, DefaultLineWeight).toReal();
+   return value(settingDefaultSeamLineweight, 0.35).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1930,7 +1930,7 @@ void VCommonSettings::setDefaultCutLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultCutLineweight() const
 {
-   return value(settingDefaultCutLineweight, DefaultLineWeight).toReal();
+   return value(settingDefaultCutLineweight, 0.35).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -1966,7 +1966,7 @@ void VCommonSettings::setDefaultInternalLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultInternalLineweight() const
 {
-   return value(settingDefaultInternalLineweight, DefaultLineWeight).toReal();
+   return value(settingDefaultInternalLineweight, 0.35).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -2002,7 +2002,7 @@ void VCommonSettings::setDefaultCutoutLinetype(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultCutoutLineweight() const
 {
-   return value(settingDefaultCutoutLineweight, DefaultLineWeight).toReal();
+   return value(settingDefaultCutoutLineweight, 0.35).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -2086,7 +2086,7 @@ void VCommonSettings::setDefaultGrainlineColor(const QString &value)
 //---------------------------------------------------------------------------------------------------------------------
 qreal VCommonSettings::getDefaultGrainlineLineweight() const
 {
-   return value(settingDefaultGrainlineLineweight, DefaultLineWeight).toReal();
+   return value(settingDefaultGrainlineLineweight, 0.35).toReal();
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogalongline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogalongline.cpp
@@ -145,7 +145,7 @@ DialogAlongLine::DialogAlongLine(const VContainer *data, const quint32 &toolId, 
     if(!qApp->Settings()->useCurrentPen())
     {
         setLineType(LineTypeNone);  //By default don't show line
-        setLineWeight("0.35");
+        setLineWeight(DefaultLineWeight);
     }
 }
 
@@ -399,7 +399,7 @@ void DialogAlongLine::setLineColor(const QString &value)
  */
 QString DialogAlongLine::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogarc.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogarc.cpp
@@ -263,7 +263,7 @@ void DialogArc::setPenStyle(const QString &value)
  */
 QString DialogArc::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogarcwithlength.cpp
@@ -288,7 +288,7 @@ void DialogArcWithLength::setPenStyle(const QString &value)
  */
 QString DialogArcWithLength::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogbisector.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogbisector.cpp
@@ -139,7 +139,7 @@ DialogBisector::DialogBisector(const VContainer *data, const quint32 &toolId, QW
     if(!qApp->Settings()->useCurrentPen())
     {
         setLineType(LineTypeDashLine);
-        setLineWeight("0.35");
+        setLineWeight(DefaultLineWeight);
     }
 }
 
@@ -307,7 +307,7 @@ void DialogBisector::setLineType(const QString &value)
  */
 QString DialogBisector::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.cpp
@@ -171,7 +171,7 @@ void DialogCubicBezier::setPenStyle(const QString &value)
  */
 QString DialogCubicBezier::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezierpath.cpp
@@ -183,7 +183,7 @@ void DialogCubicBezierPath::setPenStyle(const QString &value)
  */
 QString DialogCubicBezierPath::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.cpp
@@ -165,7 +165,7 @@ void DialogCurveIntersectAxis::setLineType(const QString &value)
  */
 QString DialogCurveIntersectAxis::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogellipticalarc.cpp
@@ -418,7 +418,7 @@ void DialogEllipticalArc::setPenStyle(const QString &value)
  */
 QString DialogEllipticalArc::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogendline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogendline.cpp
@@ -268,7 +268,7 @@ void DialogEndLine::setLineType(const QString &value)
  */
 QString DialogEndLine::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogheight.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogheight.cpp
@@ -128,7 +128,7 @@ DialogHeight::DialogHeight(const VContainer *data, const quint32 &toolId, QWidge
     if(!qApp->Settings()->useCurrentPen())
     {
         setLineType(LineTypeDashLine);
-        setLineWeight("0.35");
+        setLineWeight(DefaultLineWeight);
     }
 }
 
@@ -177,7 +177,7 @@ void DialogHeight::setLineType(const QString &value)
  */
 QString DialogHeight::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogline.cpp
@@ -174,7 +174,7 @@ void DialogLine::setLineType(const QString &value)
  */
 QString DialogLine::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp
+++ b/src/libs/vtools/dialogs/tools/dialoglineintersectaxis.cpp
@@ -177,7 +177,7 @@ void DialogLineIntersectAxis::setLineType(const QString &value)
  */
 QString DialogLineIntersectAxis::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialognormal.cpp
+++ b/src/libs/vtools/dialogs/tools/dialognormal.cpp
@@ -139,7 +139,7 @@ DialogNormal::DialogNormal(const VContainer *data, const quint32 &toolId, QWidge
     if(!qApp->Settings()->useCurrentPen())
     {
         setLineType(LineTypeDashLine);
-        setLineWeight("0.35");
+        setLineWeight(DefaultLineWeight);
     }
 }
 
@@ -364,7 +364,7 @@ void DialogNormal::setLineType(const QString &value)
  */
 QString DialogNormal::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogshoulderpoint.cpp
@@ -139,7 +139,7 @@ DialogShoulderPoint::DialogShoulderPoint(const VContainer *data, const quint32 &
     if(!qApp->Settings()->useCurrentPen())
     {
         setLineType(LineTypeDashLine);
-        setLineWeight("0.35");
+        setLineWeight(DefaultLineWeight);
     }
 }
 
@@ -397,7 +397,7 @@ void DialogShoulderPoint::setLineType(const QString &value)
  */
 QString DialogShoulderPoint::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogspline.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogspline.cpp
@@ -689,7 +689,7 @@ void DialogSpline::setLineColor(const QString &value)
  */
 QString DialogSpline::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/dialogsplinepath.cpp
+++ b/src/libs/vtools/dialogs/tools/dialogsplinepath.cpp
@@ -235,7 +235,7 @@ void DialogSplinePath::setPenStyle(const QString &value)
  */
 QString DialogSplinePath::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/editgroup_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/editgroup_dialog.cpp
@@ -183,7 +183,7 @@ void  EditGroupDialog::setLineType(const QString &type)
 //---------------------------------------------------------------------------------------------------------------------
 QString  EditGroupDialog::getLineWeight() const
 {
-    return getComboBoxCurrentData(ui->groupLineWeight_ComboBox, "0.35");
+    return getComboBoxCurrentData(ui->groupLineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.cpp
@@ -1091,7 +1091,7 @@ void InternalPathDialog::setLineType(const Qt::PenStyle &type)
 /// @return lineweight
 QString InternalPathDialog::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "1.00");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, ".35");
 }
 
 /// @brief setLineWeight set weight of the lines

--- a/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.cpp
@@ -50,6 +50,7 @@
 
 #include "internal_path_dialog.h"
 #include "ui_internal_path_dialog.h"
+#include "../ifc/ifcdef.h"
 #include "../vpatterndb/vpiecenode.h"
 #include "visualization/path/internal_path_visual.h"
 #include "../../../tools/vabstracttool.h"
@@ -1091,7 +1092,7 @@ void InternalPathDialog::setLineType(const Qt::PenStyle &type)
 /// @return lineweight
 QString InternalPathDialog::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, ".35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 /// @brief setLineWeight set weight of the lines

--- a/src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/point_intersectxy_dialog.cpp
@@ -122,7 +122,7 @@ PointIntersectXYDialog::PointIntersectXYDialog(const VContainer *data, const qui
     if(!qApp->Settings()->useCurrentPen())
     {
         setLineType(LineTypeDashLine);
-        setLineWeight("0.35");
+        setLineWeight(DefaultLineWeight);
     }
 }
 
@@ -219,7 +219,7 @@ void PointIntersectXYDialog::setLineType(const QString &value)
  */
 QString PointIntersectXYDialog::getLineWeight() const
 {
-        return getComboBoxCurrentData(ui->lineWeight_ComboBox, "0.35");
+        return getComboBoxCurrentData(ui->lineWeight_ComboBox, DefaultLineWeight);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/tools/drawTools/operation/vabstractoperation.h
+++ b/src/libs/vtools/tools/drawTools/operation/vabstractoperation.h
@@ -62,6 +62,7 @@
 #include <QGraphicsLineItem>
 
 #include "../vdrawtool.h"
+#include "../ifc/ifcdef.h"
 #include "../vwidgets/vsimplecurve.h"
 #include "../vwidgets/vsimplepoint.h"
 
@@ -69,9 +70,9 @@ struct SourceItem
 {
     quint32 id{NULL_ID};
     QString alias{QString()};
-    QString lineType{"solidLine"};
-    QString lineWidth{"1"};
-    QString color{"black"};
+    QString lineType{LineTypeSolidLine};
+    QString lineWidth{DefaultLineWeight};
+    QString color{ColorBlack};
 };
 
 Q_DECLARE_METATYPE(SourceItem)

--- a/src/libs/vtools/tools/drawTools/operation/vabstractoperation.h
+++ b/src/libs/vtools/tools/drawTools/operation/vabstractoperation.h
@@ -70,7 +70,7 @@ struct SourceItem
     quint32 id{NULL_ID};
     QString alias{QString()};
     QString lineType{"solidLine"};
-    QString lineWidth{"1.00"};
+    QString lineWidth{"1"};
     QString color{"black"};
 };
 

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/point_intersectxy_tool.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/point_intersectxy_tool.cpp
@@ -290,7 +290,7 @@ void PointIntersectXYTool::SaveOptions(QDomElement &tag, QSharedPointer<VGObject
 void PointIntersectXYTool::ReadToolAttributes(const QDomElement &domElement)
 {
     m_lineType    = doc->GetParametrString(domElement, AttrLineType,    LineTypeDashLine);
-    m_lineWeight  = doc->GetParametrString(domElement, AttrLineWeight,  "0.35");
+    m_lineWeight  = doc->GetParametrString(domElement, AttrLineWeight,  DefaultLineWeight); 
     lineColor     = doc->GetParametrString(domElement, AttrLineColor,   ColorBlack);
     firstPointId  = doc->GetParametrUInt(domElement,   AttrFirstPoint,  NULL_ID_STR);
     secondPointId = doc->GetParametrUInt(domElement,   AttrSecondPoint, NULL_ID_STR);

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.cpp
@@ -165,7 +165,7 @@ void VToolAlongLine::SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj
 void VToolAlongLine::ReadToolAttributes(const QDomElement &domElement)
 {
     m_lineType    = doc->GetParametrString(domElement, AttrLineType,    LineTypeSolidLine);
-    m_lineWeight  = doc->GetParametrString(domElement, AttrLineWeight,  "0.35");
+    m_lineWeight  = doc->GetParametrString(domElement, AttrLineWeight,  DefaultLineWeight); 
     lineColor     = doc->GetParametrString(domElement, AttrLineColor,   ColorBlack);
     formulaLength = doc->GetParametrString(domElement, AttrLength,      "");
     basePointId   = doc->GetParametrUInt(domElement,   AttrFirstPoint,  NULL_ID_STR);

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolbisector.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolbisector.cpp
@@ -341,7 +341,7 @@ void VToolBisector::SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj)
 void VToolBisector::ReadToolAttributes(const QDomElement &domElement)
 {
     m_lineType    = doc->GetParametrString(domElement, AttrLineType, LineTypeSolidLine);
-    m_lineWeight  = doc->GetParametrString(domElement, AttrLineWeight,  "0.35");
+    m_lineWeight  = doc->GetParametrString(domElement, AttrLineWeight,  DefaultLineWeight); 
     lineColor     = doc->GetParametrString(domElement, AttrLineColor, ColorBlack);
     formulaLength = doc->GetParametrString(domElement, AttrLength, "");
     firstPointId  = doc->GetParametrUInt(domElement, AttrFirstPoint, NULL_ID_STR);

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.cpp
@@ -364,7 +364,7 @@ void VToolCurveIntersectAxis::SaveOptions(QDomElement &tag, QSharedPointer<VGObj
 void VToolCurveIntersectAxis::ReadToolAttributes(const QDomElement &domElement)
 {
     m_lineType   = doc->GetParametrString(domElement, AttrLineType, LineTypeSolidLine);
-    m_lineWeight = doc->GetParametrString(domElement, AttrLineWeight,  "0.35");
+    m_lineWeight = doc->GetParametrString(domElement, AttrLineWeight,  DefaultLineWeight); 
     lineColor    = doc->GetParametrString(domElement, AttrLineColor, ColorBlack);
     basePointId  = doc->GetParametrUInt(domElement,   AttrBasePoint, NULL_ID_STR);
     curveId      = doc->GetParametrUInt(domElement,   AttrCurve, NULL_ID_STR);

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolendline.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolendline.cpp
@@ -272,7 +272,7 @@ void VToolEndLine::SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj)
 void VToolEndLine::ReadToolAttributes(const QDomElement &domElement)
 {
     m_lineType    = doc->GetParametrString(domElement, AttrLineType, LineTypeSolidLine);
-    m_lineWeight  = doc->GetParametrString(domElement, AttrLineWeight,  "0.35");
+    m_lineWeight  = doc->GetParametrString(domElement, AttrLineWeight,  DefaultLineWeight); 
     lineColor     = doc->GetParametrString(domElement, AttrLineColor, ColorBlack);
     formulaLength = doc->GetParametrString(domElement, AttrLength, "");
     basePointId   = doc->GetParametrUInt(domElement, AttrBasePoint, NULL_ID_STR);

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.cpp
@@ -299,7 +299,7 @@ void VToolHeight::SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj)
 void VToolHeight::ReadToolAttributes(const QDomElement &domElement)
 {
     m_lineType   = doc->GetParametrString(domElement, AttrLineType,   LineTypeSolidLine);
-    m_lineWeight = doc->GetParametrString(domElement, AttrLineWeight, "0.35");
+    m_lineWeight = doc->GetParametrString(domElement, AttrLineWeight, DefaultLineWeight);
     lineColor    = doc->GetParametrString(domElement, AttrLineColor,  ColorBlack);
     basePointId  = doc->GetParametrUInt(domElement,   AttrBasePoint,  NULL_ID_STR);
     p1LineId     = doc->GetParametrUInt(domElement,   AttrP1Line,     NULL_ID_STR);

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.cpp
@@ -359,7 +359,7 @@ void VToolLineIntersectAxis::SaveOptions(QDomElement &tag, QSharedPointer<VGObje
 void VToolLineIntersectAxis::ReadToolAttributes(const QDomElement &domElement)
 {
     m_lineType    = doc->GetParametrString(domElement, AttrLineType,   LineTypeSolidLine);
-    m_lineWeight  = doc->GetParametrString(domElement, AttrLineWeight, "0.35");
+    m_lineWeight  = doc->GetParametrString(domElement, AttrLineWeight, DefaultLineWeight);
     lineColor     = doc->GetParametrString(domElement, AttrLineColor,  ColorBlack);
     basePointId   = doc->GetParametrUInt(domElement,   AttrBasePoint,  NULL_ID_STR);
     firstPointId  = doc->GetParametrUInt(domElement,   AttrP1Line,     NULL_ID_STR);

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolnormal.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolnormal.cpp
@@ -315,7 +315,7 @@ void VToolNormal::SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj)
 void VToolNormal::ReadToolAttributes(const QDomElement &domElement)
 {
     m_lineType    = doc->GetParametrString(domElement, AttrLineType, LineTypeSolidLine);
-    m_lineWeight  = doc->GetParametrString(domElement, AttrLineWeight,  "0.35");
+    m_lineWeight  = doc->GetParametrString(domElement, AttrLineWeight,  DefaultLineWeight); 
     lineColor     = doc->GetParametrString(domElement, AttrLineColor, ColorBlack);
     formulaLength = doc->GetParametrString(domElement, AttrLength, "");
     basePointId   = doc->GetParametrUInt(domElement, AttrFirstPoint, NULL_ID_STR);

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.cpp
@@ -357,7 +357,7 @@ void VToolShoulderPoint::SaveOptions(QDomElement &tag, QSharedPointer<VGObject> 
 void VToolShoulderPoint::ReadToolAttributes(const QDomElement &domElement)
 {
     m_lineType    = doc->GetParametrString(domElement, AttrLineType, LineTypeSolidLine);
-    m_lineWeight  = doc->GetParametrString(domElement, AttrLineWeight,  "0.35");
+    m_lineWeight  = doc->GetParametrString(domElement, AttrLineWeight,  DefaultLineWeight); 
     lineColor     = doc->GetParametrString(domElement, AttrLineColor, ColorBlack);
     formulaLength = doc->GetParametrString(domElement, AttrLength, "");
     basePointId   = doc->GetParametrUInt(domElement, AttrP1Line, NULL_ID_STR);

--- a/src/libs/vtools/tools/drawTools/vdrawtool.cpp
+++ b/src/libs/vtools/tools/drawTools/vdrawtool.cpp
@@ -48,7 +48,7 @@
  **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
  **
  *************************************************************************/
- 
+
 #include "vdrawtool.h"
 
 #include "../vabstracttool.h"
@@ -83,7 +83,7 @@ VDrawTool::VDrawTool(VAbstractPattern *doc, VContainer *data, quint32 id, QObjec
     : VInteractiveTool(doc, data, id, parent)
     , activeBlockName(doc->getActiveDraftBlockName())
     , m_lineType(LineTypeSolidLine)
-    , m_lineWeight("0.35")
+    , m_lineWeight(DefaultLineWeight)
 {
     connect(this->doc, &VAbstractPattern::activeDraftBlockChanged, this, &VDrawTool::activeBlockChanged);
     connect(this->doc, &VAbstractPattern::draftBlockNameChanged, this, &VDrawTool::blockNameChanged);

--- a/src/libs/vtools/tools/drawTools/vtoolline.cpp
+++ b/src/libs/vtools/tools/drawTools/vtoolline.cpp
@@ -445,7 +445,7 @@ void VToolLine::ReadToolAttributes(const QDomElement &domElement)
     firstPoint   = doc->GetParametrUInt(domElement,   AttrFirstPoint,  NULL_ID_STR);
     secondPoint  = doc->GetParametrUInt(domElement,   AttrSecondPoint, NULL_ID_STR);
     m_lineType   = doc->GetParametrString(domElement, AttrLineType,    LineTypeSolidLine);
-    m_lineWeight = doc->GetParametrString(domElement, AttrLineWeight,  "0.35");
+    m_lineWeight = doc->GetParametrString(domElement, AttrLineWeight,  DefaultLineWeight); 
     lineColor    = doc->GetParametrString(domElement, AttrLineColor,   ColorBlack);
 }
 


### PR DESCRIPTION
Preface: When writing real numbers to xml all trailing zeros and deicmal places are truncated. When numbers are read from xml as a real number - for ex: "1.00" is invalid and should be "1". The values could be written / read as a string, but that then requires the additional overhead of converting back and forth between doubles and strings. 

This PR addresses issue #1385. It includes the following:

- Defines a uniform global default line weight of "0.35" -  DefaultLineWeight - which will allow changing the default line weight defaults by simply changing the define value. 
 
- Sets the default lineweight preference values for new installs of Seamly to "0.35". 
 
- Fixes existing pattern files containing a lineweight value of "1.00" to "1" by performing a search and replace before the file is validated.  

- Changes default grainline arrow length to "40".

- Some more style changes.

closes issue #1385 