### PR TITLE
feature: add formulas for grainline arrowheads

### DIFF
--- a/share/translations/seamly2d_cs_CZ.ts
+++ b/share/translations/seamly2d_cs_CZ.ts
@@ -3082,7 +3082,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Opravit vzorec</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8161,6 +8161,10 @@ Stisknutím klávesy Enter jej dočasně přidáte do seznamu.</translation>
     <message>
         <source>Count</source>
         <translation>Počet</translation>
+    </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation>Délka nesmí být menší než délka 2 šípů</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_de_DE.ts
+++ b/share/translations/seamly2d_de_DE.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Formel festlegen</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8146,6 +8146,10 @@ Drücken Sie die Eingabetaste, um ihn vorübergehend in die Liste aufzunehmen.</
     <message>
         <source>Count</source>
         <translation>Zählen</translation>
+    </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation>Die Länge darf nicht kürzer sein als die Länge von 2 Pfeilen</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_el_GR.ts
+++ b/share/translations/seamly2d_el_GR.ts
@@ -3082,7 +3082,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Επιδιόρθωση φόρμουλας</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8165,6 +8165,10 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Count</source>
         <translation>Αριθμός</translation>
+    </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation>Το μήκος δεν μπορεί να είναι μικρότερο από το μήκος 2 βελών</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_en_CA.ts
+++ b/share/translations/seamly2d_en_CA.ts
@@ -8133,6 +8133,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Count</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>

--- a/share/translations/seamly2d_en_GB.ts
+++ b/share/translations/seamly2d_en_GB.ts
@@ -8133,6 +8133,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Count</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>

--- a/share/translations/seamly2d_en_IN.ts
+++ b/share/translations/seamly2d_en_IN.ts
@@ -8133,6 +8133,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Count</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>

--- a/share/translations/seamly2d_en_US.ts
+++ b/share/translations/seamly2d_en_US.ts
@@ -8133,6 +8133,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Count</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>

--- a/share/translations/seamly2d_es_ES.ts
+++ b/share/translations/seamly2d_es_ES.ts
@@ -3100,7 +3100,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Reparar fórmula</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8199,6 +8199,10 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Count</source>
         <translation>Cuenta</translation>
+    </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation>La longitud no puede ser menor que la longitud de 2 flechas</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fi_FI.ts
+++ b/share/translations/seamly2d_fi_FI.ts
@@ -3082,7 +3082,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Korjaa matemaattinen kaava</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8163,6 +8163,10 @@ Lisää se väliaikaisesti luetteloon painamalla Enter-näppäintä.</translatio
     <message>
         <source>Count</source>
         <translation>Kreivi</translation>
+    </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation>Pituus ei voi olla pienempi kuin kahden nuolen pituus</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_fr_FR.ts
+++ b/share/translations/seamly2d_fr_FR.ts
@@ -3098,7 +3098,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Corriger la formule</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8187,6 +8187,10 @@ Appuyez sur Entrée pour l&apos;ajouter temporairement à la liste.</translation
     <message>
         <source>Count</source>
         <translation>Nombre</translation>
+    </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation>La longueur ne peut pas être inférieure à la longueur de 2 flèches</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_he_IL.ts
+++ b/share/translations/seamly2d_he_IL.ts
@@ -8129,6 +8129,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Count</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>

--- a/share/translations/seamly2d_id_ID.ts
+++ b/share/translations/seamly2d_id_ID.ts
@@ -3082,7 +3082,7 @@ p, li { spasi: pra-bungkus; }
         <translation>&amp;Perbaiki rumus</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8163,6 +8163,10 @@ Tekan enter untuk menambahkannya sementara ke daftar.</translation>
     <message>
         <source>Count</source>
         <translation>Hitung</translation>
+    </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation>Panjangnya tidak boleh kurang dari panjang 2 anak panah</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_it_IT.ts
+++ b/share/translations/seamly2d_it_IT.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Correggi formula</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8151,6 +8151,10 @@ Premere Invio per aggiungerlo temporaneamente all&apos;elenco.</translation>
     <message>
         <source>Count</source>
         <translation>Contare</translation>
+    </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation>La lunghezza non può essere inferiore alla lunghezza di 2 frecce</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_nl_NL.ts
+++ b/share/translations/seamly2d_nl_NL.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Verbeter formule</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8146,6 +8146,10 @@ Druk op enter om deze tijdelijk toe te voegen aan de lijst.</translation>
     <message>
         <source>Count</source>
         <translation>Graaf</translation>
+    </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation>Lengte mag niet kleiner zijn dan de lengte van 2 pijlen</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_pt_BR.ts
+++ b/share/translations/seamly2d_pt_BR.ts
@@ -3067,7 +3067,7 @@ p, li { white-space: pre-wrap; }
         <translation>Fârmula &amp;Fix</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8149,6 +8149,10 @@ Prima enter para o adicionar temporariamente à lista.</translation>
     <message>
         <source>Count</source>
         <translation>Contar</translation>
+    </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation>Lungimea nu poate fi mai mică decât lungimea a 2 săgeți</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ro_RO.ts
+++ b/share/translations/seamly2d_ro_RO.ts
@@ -3082,7 +3082,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Repară formula</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8165,6 +8165,10 @@ Apăsați Enter pentru a-l adăuga temporar la listă.</translation>
     <message>
         <source>Count</source>
         <translation>Numără</translation>
+    </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation>Lungimea nu poate fi mai mică decât lungimea a 2 săgeți</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_ru_RU.ts
+++ b/share/translations/seamly2d_ru_RU.ts
@@ -3082,7 +3082,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Исправить формулу</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8169,6 +8169,10 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Count</source>
         <translation>Граф</translation>
+    </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation>Длина не может быть меньше длины двух стрелок</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_tr_TR.ts
+++ b/share/translations/seamly2d_tr_TR.ts
@@ -3082,7 +3082,7 @@ p, li { boşluk: ön sarma; }
         <translation>&amp;Formülü düzelt</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8163,6 +8163,10 @@ Geçici olarak listeye eklemek için enter&apos;a basın.</translation>
     <message>
         <source>Count</source>
         <translation>Sayım</translation>
+    </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation>Uzunluk 2 okun uzunluğundan az olamaz</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_uk_UA.ts
+++ b/share/translations/seamly2d_uk_UA.ts
@@ -3082,7 +3082,7 @@ p, li { white-space: pre-wrap; }
         <translation>&amp;Виправити формулу</translation>
     </message>
     <message>
-        <source>Seamly2D encountered an error while computing a formula. 
+        <source>Seamly2D encountered an error while computing a formula.
 Please try to undo the latest operation or fix the broken formula.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8164,6 +8164,10 @@ Press enter to temporarily add it to the list.</source>
     <message>
         <source>Count</source>
         <translation>Αριθμός</translation>
+    </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation>Довжина не може бути меншою за довжину двох стріл</translation>
     </message>
 </context>
 <context>

--- a/share/translations/seamly2d_zh_CN.ts
+++ b/share/translations/seamly2d_zh_CN.ts
@@ -8129,6 +8129,10 @@ Press enter to temporarily add it to the list.</source>
         <source>Count</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Length can&apos;t be less than length of 2 arrows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PatternPieceTool</name>

--- a/src/app/seamly2d/xml/vpattern.cpp
+++ b/src/app/seamly2d/xml/vpattern.cpp
@@ -1076,6 +1076,7 @@ void VPattern::ParsePieceGrainline(const QDomElement &domElement, VPiece &piece)
     gGeometry.setLength(GetParametrString(domElement, AttrLength, "1"));
     gGeometry.setRotation(GetParametrString(domElement, AttrRotation, "90"));
     gGeometry.setArrowType(static_cast<ArrowType>(GetParametrUInt(domElement, AttrArrows, "0")));
+    gGeometry.setArrowLength(GetParametrString(domElement, AttrArrowLength, ".5"));
     gGeometry.setCenterAnchorPoint(GetParametrUInt(domElement, PatternPieceTool::AttrCenterAnchor, NULL_ID_STR));
     gGeometry.setTopAnchorPoint(GetParametrUInt(domElement, PatternPieceTool::AttrTopAnchorPoint, NULL_ID_STR));
     gGeometry.setBottomAnchorPoint(GetParametrUInt(domElement, PatternPieceTool::AttrBottomAnchorPoint, NULL_ID_STR));

--- a/src/libs/ifc/schema.qrc
+++ b/src/libs/ifc/schema.qrc
@@ -61,5 +61,6 @@
         <file>schema/pattern/v0.7.0.xsd</file>
         <file>schema/pattern/v0.7.1.xsd</file>
         <file>schema/pattern/v0.7.2.xsd</file>
+        <file>schema/pattern/v0.7.3.xsd</file>
     </qresource>
 </RCC>

--- a/src/libs/ifc/schema/pattern/v0.7.3.xsd
+++ b/src/libs/ifc/schema/pattern/v0.7.3.xsd
@@ -1,0 +1,1047 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+  <!-- XML Schema Generated from XML Document-->
+  <xs:element name="pattern">
+    <xs:complexType>
+      <xs:sequence minOccurs="1" maxOccurs="unbounded">
+        <xs:element name="version" type="formatVersion"/>
+        <xs:element name="unit" type="units"/>
+        <xs:element name="image" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="extension" type="imageExtension"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="notes" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="gradation" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="heights">
+                <xs:complexType>
+                  <xs:attribute name="all" type="xs:boolean" use="required"/>
+                  <xs:attribute name="h50" type="xs:boolean"/>
+                  <xs:attribute name="h56" type="xs:boolean"/>
+                  <xs:attribute name="h62" type="xs:boolean"/>
+                  <xs:attribute name="h68" type="xs:boolean"/>
+                  <xs:attribute name="h74" type="xs:boolean"/>
+                  <xs:attribute name="h80" type="xs:boolean"/>
+                  <xs:attribute name="h86" type="xs:boolean"/>
+                  <xs:attribute name="h92" type="xs:boolean"/>
+                  <xs:attribute name="h98" type="xs:boolean"/>
+                  <xs:attribute name="h104" type="xs:boolean"/>
+                  <xs:attribute name="h110" type="xs:boolean"/>
+                  <xs:attribute name="h116" type="xs:boolean"/>
+                  <xs:attribute name="h122" type="xs:boolean"/>
+                  <xs:attribute name="h128" type="xs:boolean"/>
+                  <xs:attribute name="h134" type="xs:boolean"/>
+                  <xs:attribute name="h140" type="xs:boolean"/>
+                  <xs:attribute name="h146" type="xs:boolean"/>
+                  <xs:attribute name="h152" type="xs:boolean"/>
+                  <xs:attribute name="h158" type="xs:boolean"/>
+                  <xs:attribute name="h164" type="xs:boolean"/>
+                  <xs:attribute name="h170" type="xs:boolean"/>
+                  <xs:attribute name="h176" type="xs:boolean"/>
+                  <xs:attribute name="h182" type="xs:boolean"/>
+                  <xs:attribute name="h188" type="xs:boolean"/>
+                  <xs:attribute name="h194" type="xs:boolean"/>
+                  <xs:attribute name="h200" type="xs:boolean"/>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="sizes">
+                <xs:complexType>
+                  <xs:attribute name="all" type="xs:boolean" use="required"/>
+                  <xs:attribute name="s22" type="xs:boolean"/>
+                  <xs:attribute name="s24" type="xs:boolean"/>
+                  <xs:attribute name="s26" type="xs:boolean"/>
+                  <xs:attribute name="s28" type="xs:boolean"/>
+                  <xs:attribute name="s30" type="xs:boolean"/>
+                  <xs:attribute name="s32" type="xs:boolean"/>
+                  <xs:attribute name="s34" type="xs:boolean"/>
+                  <xs:attribute name="s36" type="xs:boolean"/>
+                  <xs:attribute name="s38" type="xs:boolean"/>
+                  <xs:attribute name="s40" type="xs:boolean"/>
+                  <xs:attribute name="s42" type="xs:boolean"/>
+                  <xs:attribute name="s44" type="xs:boolean"/>
+                  <xs:attribute name="s46" type="xs:boolean"/>
+                  <xs:attribute name="s48" type="xs:boolean"/>
+                  <xs:attribute name="s50" type="xs:boolean"/>
+                  <xs:attribute name="s52" type="xs:boolean"/>
+                  <xs:attribute name="s54" type="xs:boolean"/>
+                  <xs:attribute name="s56" type="xs:boolean"/>
+                  <xs:attribute name="s58" type="xs:boolean"/>
+                  <xs:attribute name="s60" type="xs:boolean"/>
+                  <xs:attribute name="s62" type="xs:boolean"/>
+                  <xs:attribute name="s64" type="xs:boolean"/>
+                  <xs:attribute name="s66" type="xs:boolean"/>
+                  <xs:attribute name="s68" type="xs:boolean"/>
+                  <xs:attribute name="s70" type="xs:boolean"/>
+                  <xs:attribute name="s72" type="xs:boolean"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="custom" type="xs:boolean"/>
+            <xs:attribute name="defHeight" type="baseHeight"/>
+            <xs:attribute name="defSize" type="baseSize"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="patternName" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="patternNumber" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="company" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="customer" type="xs:string" minOccurs="0" maxOccurs="1"/>
+        <xs:element name="patternLabel" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="line" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="text" type="xs:string" use="required"/>
+                  <xs:attribute name="bold" type="xs:boolean"/>
+                  <xs:attribute name="italic" type="xs:boolean"/>
+                  <xs:attribute name="alignment" type="alignmentType"/>
+                  <xs:attribute name="sfIncrement" type="xs:unsignedInt"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="dateFormat" type="xs:string"/>
+            <xs:attribute name="timeFormat" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="measurements" type="xs:string"/>
+        <xs:element name="variables" minOccurs="0" maxOccurs="1">
+          <xs:complexType>
+            <xs:sequence minOccurs="0" maxOccurs="unbounded">
+              <xs:element name="variable" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:attribute name="description" type="xs:string" use="required"/>
+                  <xs:attribute name="name" type="shortName" use="required"/>
+                  <xs:attribute name="formula" type="xs:string" use="required"/>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+          <xs:unique name="variableName">
+            <xs:selector xpath="variable"/>
+            <xs:field xpath="@name"/>
+          </xs:unique>
+        </xs:element>
+        <xs:element name="draftBlock" minOccurs="1" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="calculation" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                      <xs:element name="point" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="x" type="xs:double"/>
+                          <xs:attribute name="y" type="xs:double"/>
+                          <xs:attribute name="mx" type="xs:double"/>
+                          <xs:attribute name="my" type="xs:double"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="name" type="shortName"/>
+                          <xs:attribute name="firstPoint" type="xs:unsignedInt"/>
+                          <xs:attribute name="secondPoint" type="xs:unsignedInt"/>
+                          <xs:attribute name="thirdPoint" type="xs:unsignedInt"/>
+                          <xs:attribute name="basePoint" type="xs:unsignedInt"/>
+                          <xs:attribute name="pShoulder" type="xs:unsignedInt"/>
+                          <xs:attribute name="p1Line" type="xs:unsignedInt"/>
+                          <xs:attribute name="p2Line" type="xs:unsignedInt"/>
+                          <xs:attribute name="length" type="xs:string"/>
+                          <xs:attribute name="angle" type="xs:string"/>
+                          <xs:attribute name="lineType" type="linePenStyle"/>
+                          <xs:attribute name="lineWeight" type="lineWeights"/>
+                          <xs:attribute name="splinePath" type="xs:unsignedInt"/>
+                          <xs:attribute name="spline" type="xs:unsignedInt"/>
+                          <xs:attribute name="p1Line1" type="xs:unsignedInt"/>
+                          <xs:attribute name="p1Line2" type="xs:unsignedInt"/>
+                          <xs:attribute name="p2Line1" type="xs:unsignedInt"/>
+                          <xs:attribute name="p2Line2" type="xs:unsignedInt"/>
+                          <xs:attribute name="center" type="xs:unsignedInt"/>
+                          <xs:attribute name="radius" type="xs:string"/>
+                          <xs:attribute name="axisP1" type="xs:unsignedInt"/>
+                          <xs:attribute name="axisP2" type="xs:unsignedInt"/>
+                          <xs:attribute name="arc" type="xs:unsignedInt"/>
+                          <xs:attribute name="elArc" type="xs:unsignedInt"/>
+                          <xs:attribute name="curve" type="xs:unsignedInt"/>
+                          <xs:attribute name="curve1" type="xs:unsignedInt"/>
+                          <xs:attribute name="curve2" type="xs:unsignedInt"/>
+                          <xs:attribute name="lineColor" type="colors"/>
+                          <xs:attribute name="color" type="colors"/>
+                          <xs:attribute name="firstArc" type="xs:unsignedInt"/>
+                          <xs:attribute name="secondArc" type="xs:unsignedInt"/>
+                          <xs:attribute name="crossPoint" type="crossType"/>
+                          <xs:attribute name="vCrossPoint" type="crossType"/>
+                          <xs:attribute name="hCrossPoint" type="crossType"/>
+                          <xs:attribute name="c1Center" type="xs:unsignedInt"/>
+                          <xs:attribute name="c2Center" type="xs:unsignedInt"/>
+                          <xs:attribute name="c1Radius" type="xs:string"/>
+                          <xs:attribute name="c2Radius" type="xs:string"/>
+                          <xs:attribute name="cRadius" type="xs:string"/>
+                          <xs:attribute name="tangent" type="xs:unsignedInt"/>
+                          <xs:attribute name="cCenter" type="xs:unsignedInt"/>
+                          <xs:attribute name="name1" type="shortName"/>
+                          <xs:attribute name="mx1" type="xs:double"/>
+                          <xs:attribute name="my1" type="xs:double"/>
+                          <xs:attribute name="name2" type="shortName"/>
+                          <xs:attribute name="mx2" type="xs:double"/>
+                          <xs:attribute name="my2" type="xs:double"/>
+                          <xs:attribute name="point1" type="xs:unsignedInt"/>
+                          <xs:attribute name="point2" type="xs:unsignedInt"/>
+                          <xs:attribute name="dartP1" type="xs:unsignedInt"/>
+                          <xs:attribute name="dartP2" type="xs:unsignedInt"/>
+                          <xs:attribute name="dartP3" type="xs:unsignedInt"/>
+                          <xs:attribute name="baseLineP1" type="xs:unsignedInt"/>
+                          <xs:attribute name="baseLineP2" type="xs:unsignedInt"/>
+                          <xs:attribute name="showPointName" type="xs:boolean"/>
+                          <xs:attribute name="showPointName1" type="xs:boolean"/>
+                          <xs:attribute name="showPointName2" type="xs:boolean"/>
+                          <xs:attribute name="direction" type="directionType"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="line" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="firstPoint" type="xs:unsignedInt"/>
+                          <xs:attribute name="secondPoint" type="xs:unsignedInt"/>
+                          <xs:attribute name="lineType" type="linePenStyle"/>
+                          <xs:attribute name="lineWeight" type="lineWeights"/>
+                          <xs:attribute name="lineColor" type="colors"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="operation" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="source" minOccurs="1" maxOccurs="1">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="item" minOccurs="1" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                      <xs:attribute name="idObject" type="xs:unsignedInt" use="required"/>
+                                      <xs:attribute name="alias" type="xs:string"/>
+                                      <xs:attribute name="color" type="colors"/>
+                                      <xs:attribute name="lineType" type="linePenStyle"/>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                            <xs:element name="destination" minOccurs="1" maxOccurs="1">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="item" minOccurs="1" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                      <xs:attribute name="idObject" type="xs:unsignedInt" use="required"/>
+                                      <xs:attribute name="mx" type="xs:double"/>
+                                      <xs:attribute name="my" type="xs:double"/>
+                                      <xs:attribute name="showPointName" type="xs:boolean"/>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="center" type="xs:unsignedInt"/>
+                          <xs:attribute name="angle" type="xs:string"/>
+                          <xs:attribute name="rotationAngle" type="xs:string"/>
+                          <xs:attribute name="length" type="xs:string"/>
+                          <xs:attribute name="suffix" type="xs:string"/>
+                          <xs:attribute name="type" type="xs:string" use="required"/>
+                          <xs:attribute name="p1Line" type="xs:unsignedInt"/>
+                          <xs:attribute name="p2Line" type="xs:unsignedInt"/>
+                          <xs:attribute name="axisType" type="axisType"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="arc" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="angle1" type="xs:string"/>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="angle2" type="xs:string"/>
+                          <xs:attribute name="radius" type="xs:string"/>
+                          <xs:attribute name="center" type="xs:unsignedInt"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="color" type="colors"/>
+                          <xs:attribute name="penStyle" type="curvePenStyle"/>
+                          <xs:attribute name="lineWeight" type="lineWeights"/>
+                          <xs:attribute name="length" type="xs:string"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="elArc" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="angle1" type="xs:string"/>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="angle2" type="xs:string"/>
+                          <xs:attribute name="rotationAngle" type="xs:string"/>
+                          <xs:attribute name="radius1" type="xs:string"/>
+                          <xs:attribute name="radius2" type="xs:string"/>
+                          <xs:attribute name="center" type="xs:unsignedInt"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="color" type="colors"/>
+                          <xs:attribute name="penStyle" type="curvePenStyle"/>
+                          <xs:attribute name="lineWeight" type="lineWeights"/>
+                          <xs:attribute name="length" type="xs:string"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="spline" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="pathPoint" minOccurs="0" maxOccurs="unbounded">
+                              <xs:complexType>
+                                <xs:attribute name="kAsm2" type="xs:string"/>
+                                <xs:attribute name="pSpline" type="xs:unsignedInt"/>
+                                <xs:attribute name="angle" type="xs:string"/>
+                                <xs:attribute name="angle1" type="xs:string"/>
+                                <xs:attribute name="angle2" type="xs:string"/>
+                                <xs:attribute name="length1" type="xs:string"/>
+                                <xs:attribute name="length2" type="xs:string"/>
+                                <xs:attribute name="kAsm1" type="xs:string"/>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="kCurve" type="xs:double"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="kAsm1" type="xs:double"/>
+                          <xs:attribute name="kAsm2" type="xs:double"/>
+                          <xs:attribute name="angle1" type="xs:string"/>
+                          <xs:attribute name="angle2" type="xs:string"/>
+                          <xs:attribute name="length1" type="xs:string"/>
+                          <xs:attribute name="length2" type="xs:string"/>
+                          <xs:attribute name="point1" type="xs:unsignedInt"/>
+                          <xs:attribute name="point2" type="xs:unsignedInt"/>
+                          <xs:attribute name="point3" type="xs:unsignedInt"/>
+                          <xs:attribute name="point4" type="xs:unsignedInt"/>
+                          <xs:attribute name="color" type="colors"/>
+                          <xs:attribute name="penStyle" type="curvePenStyle"/>
+                          <xs:attribute name="lineWeight" type="lineWeights"/>
+                          <xs:attribute name="duplicate" type="xs:unsignedInt"/>
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:choice>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="modeling" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                      <xs:element name="point" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="idObject" type="xs:unsignedInt"/>
+                          <xs:attribute name="mx" type="xs:double"/>
+                          <xs:attribute name="my" type="xs:double"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="idTool" type="xs:unsignedInt"/>
+                          <xs:attribute name="inUse" type="xs:boolean"/>
+                          <xs:attribute name="showPointName" type="xs:boolean"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="arc" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="idObject" type="xs:unsignedInt"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="idTool" type="xs:unsignedInt"/>
+                          <xs:attribute name="inUse" type="xs:boolean"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="elArc" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="idObject" type="xs:unsignedInt"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="idTool" type="xs:unsignedInt"/>
+                          <xs:attribute name="inUse" type="xs:boolean"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="spline" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="idObject" type="xs:unsignedInt"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="idTool" type="xs:unsignedInt"/>
+                          <xs:attribute name="inUse" type="xs:boolean"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="path" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="nodes" minOccurs="1" maxOccurs="1">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="node" minOccurs="1" maxOccurs="unbounded">
+                                    <xs:complexType>
+                                      <xs:attribute name="type" type="xs:string" use="required"/>
+                                      <xs:attribute name="idObject" type="xs:unsignedInt" use="required"/>
+                                      <xs:attribute name="reverse" type="xs:unsignedInt"/>
+                                      <xs:attribute name="excluded" type="xs:boolean"/>
+                                      <xs:attribute name="before" type="xs:double"/>
+                                      <xs:attribute name="after" type="xs:double"/>
+                                      <xs:attribute name="angle" type="nodeAngle"/>
+                                      <xs:attribute name="notch" type="xs:boolean"/>
+                                      <xs:attribute name="notchType" type="notchTypes"/>
+                                      <xs:attribute name="notchSubtype" type="notchSubtypes"/>
+                                      <xs:attribute name="showNotch" type="xs:boolean"/>
+                                      <xs:attribute name="showSecondNotch" type="xs:boolean"/>
+                                      <xs:attribute name="notchAngle" type="xs:double"/>
+                                      <xs:attribute name="notchLength" type="xs:double"/>
+                                      <xs:attribute name="notchWidth" type="xs:double"/>
+                                      <xs:attribute name="notchCount" type="xs:unsignedInt"/>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="type" type="piecePathType"/>
+                          <xs:attribute name="idTool" type="xs:unsignedInt"/>
+                          <xs:attribute name="inUse" type="xs:boolean"/>
+                          <xs:attribute name="name" type="xs:string"/>
+                          <xs:attribute name="lineColor" type="colors"/>
+                          <xs:attribute name="lineType" type="curvePenStyle"/>
+                          <xs:attribute name="lineWeight" type="lineWeights"/>
+                          <xs:attribute name="cut" type="xs:boolean"/>
+                          <xs:attribute name="extendStartPoint" type="xs:boolean"/>
+                          <xs:attribute name="extendEndPoint" type="xs:boolean"/>
+                        </xs:complexType>
+                      </xs:element>
+                      <xs:element name="tools" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="unionPiece" minOccurs="2" maxOccurs="2">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="nodes" minOccurs="1" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="node" minOccurs="1" maxOccurs="unbounded">
+                                          <xs:complexType>
+                                            <xs:attribute name="type" type="xs:string" use="required"/>
+                                            <xs:attribute name="idObject" type="xs:unsignedInt" use="required"/>
+                                            <xs:attribute name="reverse" type="xs:unsignedInt"/>
+                                            <xs:attribute name="excluded" type="xs:boolean"/>
+                                            <xs:attribute name="before" type="xs:string"/>
+                                            <xs:attribute name="after" type="xs:string"/>
+                                            <xs:attribute name="angle" type="nodeAngle"/>
+                                            <xs:attribute name="notch" type="xs:boolean"/>
+                                            <xs:attribute name="notchType" type="notchTypes"/>
+                                            <xs:attribute name="notchSubtype" type="notchSubtypes"/>
+                                            <xs:attribute name="showNotch" type="xs:boolean"/>
+                                            <xs:attribute name="showSecondNotch" type="xs:boolean"/>
+                                            <xs:attribute name="notchAngle" type="xs:double"/>
+                                            <xs:attribute name="notchLength" type="xs:double"/>
+                                            <xs:attribute name="notchWidth" type="xs:double"/>
+                                            <xs:attribute name="notchCount" type="xs:unsignedInt"/>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                  <xs:element name="csa" minOccurs="0" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="record" minOccurs="1" maxOccurs="unbounded">
+                                          <xs:complexType>
+                                            <xs:attribute name="start" type="xs:unsignedInt"/>
+                                            <xs:attribute name="path" type="xs:unsignedInt" use="required"/>
+                                            <xs:attribute name="end" type="xs:unsignedInt"/>
+                                            <xs:attribute name="reverse" type="xs:boolean"/>
+                                            <xs:attribute name="includeAs" type="piecePathIncludeType"/>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                  <xs:element name="iPaths" minOccurs="0" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="record" minOccurs="1" maxOccurs="unbounded">
+                                          <xs:complexType>
+                                            <xs:attribute name="path" type="xs:unsignedInt" use="required"/>
+                                          </xs:complexType>
+                                        </xs:element>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                  <xs:element name="anchors" minOccurs="0" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="record" type="xs:unsignedInt" minOccurs="1" maxOccurs="unbounded"/>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                            <xs:element name="children" minOccurs="1" maxOccurs="1">
+                              <xs:complexType>
+                                <xs:sequence>
+                                  <xs:element name="nodes" minOccurs="0" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="child" type="xs:unsignedInt" minOccurs="1" maxOccurs="unbounded"/>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                  <xs:element name="csa" minOccurs="0" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="child" type="xs:unsignedInt" minOccurs="0" maxOccurs="unbounded"/>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                  <xs:element name="iPaths" minOccurs="0" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="child" type="xs:unsignedInt" minOccurs="0" maxOccurs="unbounded"/>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                  <xs:element name="anchors" minOccurs="0" maxOccurs="1">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element name="child" type="xs:unsignedInt" minOccurs="0" maxOccurs="unbounded"/>
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
+                                </xs:sequence>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="type" type="xs:string"/>
+                          <xs:attribute name="indexD1" type="xs:unsignedInt"/>
+                          <xs:attribute name="indexD2" type="xs:unsignedInt"/>
+                          <xs:attribute name="inUse" type="xs:boolean"/>
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:choice>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="pieces" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="piece" minOccurs="0" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="data" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="line" minOccurs="0" maxOccurs="unbounded">
+				                  <xs:complexType>
+				                  <xs:attribute name="text" type="xs:string" use="required"/>
+				                  <xs:attribute name="bold" type="xs:boolean"/>
+				                  <xs:attribute name="italic" type="xs:boolean"/>
+				                  <xs:attribute name="alignment" type="alignmentType"/>
+				                  <xs:attribute name="sfIncrement" type="xs:unsignedInt"/>
+				                  </xs:complexType>
+			                    </xs:element>
+                              </xs:sequence>
+                              <xs:attribute name="letter" type="xs:string"/>
+                              <xs:attribute name="annotation" type="xs:string"/>
+                              <xs:attribute name="orientation" type="xs:string"/>
+                              <xs:attribute name="rotationWay" type="xs:string"/>
+                              <xs:attribute name="tilt" type="xs:string"/>
+                              <xs:attribute name="foldPosition" type="xs:string"/>
+                              <xs:attribute name="visible" type="xs:boolean"/>
+                              <xs:attribute name="onFold" type="xs:boolean"/>
+                              <xs:attribute name="fontSize" type="xs:unsignedInt"/>
+                              <xs:attribute name="mx" type="xs:double"/>
+                              <xs:attribute name="my" type="xs:double"/>
+                              <xs:attribute name="width" type="xs:string"/>
+                              <xs:attribute name="height" type="xs:string"/>
+                              <xs:attribute name="rotation" type="xs:string"/>
+                              <xs:attribute name="centerAnchor" type="xs:unsignedInt"/>
+                              <xs:attribute name="topLeftAnchor" type="xs:unsignedInt"/>
+                              <xs:attribute name="quantity" type="xs:unsignedInt"/>
+                              <xs:attribute name="bottomRightAnchor" type="xs:unsignedInt"/>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="patternInfo" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:attribute name="visible" type="xs:boolean"/>
+                              <xs:attribute name="fontSize" type="xs:unsignedInt"/>
+                              <xs:attribute name="mx" type="xs:double"/>
+                              <xs:attribute name="my" type="xs:double"/>
+                              <xs:attribute name="width" type="xs:string"/>
+                              <xs:attribute name="height" type="xs:string"/>
+                              <xs:attribute name="rotation" type="xs:string"/>
+                              <xs:attribute name="centerAnchor" type="xs:unsignedInt"/>
+                              <xs:attribute name="topLeftAnchor" type="xs:unsignedInt"/>
+                              <xs:attribute name="bottomRightAnchor" type="xs:unsignedInt"/>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="grainline" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:attribute name="visible" type="xs:boolean"/>
+                              <xs:attribute name="mx" type="xs:double"/>
+                              <xs:attribute name="my" type="xs:double"/>
+                              <xs:attribute name="length" type="xs:string"/>
+                              <xs:attribute name="rotation" type="xs:string"/>
+                              <xs:attribute name="arrows" type="arrowType"/>
+                              <xs:attribute name="arrowLength" type="xs:string"/>
+                              <xs:attribute name="centerAnchor" type="xs:unsignedInt"/>
+                              <xs:attribute name="topAnchor" type="xs:unsignedInt"/>
+                              <xs:attribute name="bottomAnchor" type="xs:unsignedInt"/>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="nodes" minOccurs="1" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="node" minOccurs="1" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:attribute name="type" type="xs:string" use="required"/>
+                                    <xs:attribute name="idObject" type="xs:unsignedInt" use="required"/>
+                                    <xs:attribute name="reverse" type="xs:unsignedInt"/>
+                                    <xs:attribute name="excluded" type="xs:boolean"/>
+                                    <xs:attribute name="before" type="xs:string"/>
+                                    <xs:attribute name="after" type="xs:string"/>
+                                    <xs:attribute name="angle" type="nodeAngle"/>
+                                    <xs:attribute name="mx" type="xs:double"/>
+                                    <xs:attribute name="my" type="xs:double"/>
+                                    <xs:attribute name="notch" type="xs:boolean"/>
+                                    <xs:attribute name="notchType" type="notchTypes"/>
+                                    <xs:attribute name="notchSubtype" type="notchSubtypes"/>
+                                    <xs:attribute name="showNotch" type="xs:boolean"/>
+                                    <xs:attribute name="showSecondNotch" type="xs:boolean"/>
+                                    <xs:attribute name="notchAngle" type="xs:double"/>
+                                    <xs:attribute name="notchLength" type="xs:double"/>
+                                    <xs:attribute name="notchWidth" type="xs:double"/>
+                                    <xs:attribute name="notchCount" type="xs:unsignedInt"/>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="csa" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="record" minOccurs="1" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:attribute name="start" type="xs:unsignedInt"/>
+                                    <xs:attribute name="path" type="xs:unsignedInt" use="required"/>
+                                    <xs:attribute name="end" type="xs:unsignedInt"/>
+                                    <xs:attribute name="reverse" type="xs:boolean"/>
+                                    <xs:attribute name="includeAs" type="piecePathIncludeType"/>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="iPaths" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="record" minOccurs="1" maxOccurs="unbounded">
+                                  <xs:complexType>
+                                    <xs:attribute name="path" type="xs:unsignedInt" use="required"/>
+                                  </xs:complexType>
+                                </xs:element>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                          <xs:element name="anchors" minOccurs="0" maxOccurs="1">
+                            <xs:complexType>
+                              <xs:sequence>
+                                <xs:element name="record" type="xs:unsignedInt" minOccurs="0" maxOccurs="unbounded"/>
+                              </xs:sequence>
+                            </xs:complexType>
+                          </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                        <xs:attribute name="version" type="pieceVersion"/>
+                        <xs:attribute name="mx" type="xs:double"/>
+                        <xs:attribute name="my" type="xs:double"/>
+                        <xs:attribute name="name" type="xs:string"/>
+                        <xs:attribute name="color" type="xs:string"/>
+                        <xs:attribute name="fill" type="xs:string"/>
+                        <xs:attribute name="inLayout" type="xs:boolean"/>
+                        <xs:attribute name="forbidFlipping" type="xs:boolean"/>
+                        <xs:attribute name="width" type="xs:string"/>
+                        <xs:attribute name="seamAllowance" type="xs:boolean"/>
+                        <xs:attribute name="seamAllowanceBuiltIn" type="xs:boolean"/>
+                        <xs:attribute name="united" type="xs:boolean"/>
+                        <xs:attribute name="closed" type="xs:unsignedInt"/>
+                        <xs:attribute name="hideMainPath" type="xs:boolean"/>
+                        <xs:attribute name="locked" type="xs:boolean"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="groups" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                  <xs:sequence>
+                      <xs:element name="group" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name="item" minOccurs="0" maxOccurs="unbounded">
+                              <xs:complexType>
+                                <xs:attribute name="object" type="xs:unsignedInt"/>
+                                <xs:attribute name="tool" type="xs:unsignedInt"/>
+                              </xs:complexType>
+                            </xs:element>
+                          </xs:sequence>
+                          <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                          <xs:attribute name="name" type="xs:string"/>
+                          <xs:attribute name="visible" type="xs:boolean"/>
+                          <xs:attribute name="locked" type="xs:boolean"/>
+                          <xs:attribute name="groupColor" type="colors"/>
+                          <xs:attribute name="lineType" type="linePenStyle"/>
+                          <xs:attribute name="lineWeight" type="lineWeights"/>
+                        </xs:complexType>
+                      </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="images" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="image" minOccurs="0" maxOccurs="unbounded">
+                      <xs:complexType>
+                        <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
+                        <xs:attribute name="name" type="xs:string" use="required"/>
+                        <xs:attribute name="src" type="xs:string" use="required"/>
+                        <xs:attribute name="width" type="xs:double" use="required"/>
+                        <xs:attribute name="height" type="xs:double" use="required"/>
+                        <xs:attribute name="aspectRatio" type="xs:boolean" use="required"/>
+                        <xs:attribute name="rotation" type="xs:double" use="required"/>
+                        <xs:attribute name="xPos" type="xs:double" use="required"/>
+                        <xs:attribute name="yPos" type="xs:double" use="required"/>
+                        <xs:attribute name="locked" type="xs:boolean" use="required"/>
+                        <xs:attribute name="units" type="xs:string" use="required"/>
+                        <xs:attribute name="opacity" type="xs:double" use="required"/>
+                        <xs:attribute name="order" type="xs:double" use="required"/>
+                        <xs:attribute name="xOffset" type="xs:double" use="required"/>
+                        <xs:attribute name="yOffset" type="xs:double" use="required"/>
+                        <xs:attribute name="basepoint" type="xs:unsignedInt" use="required"/>
+                        <xs:attribute name="visible" type="xs:boolean" use="required"/>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+      <xs:attribute name="readOnly" type="xs:boolean"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:simpleType name="shortName">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="([^\p{Nd}\\\p{Zs}*\\/&amp;|!&lt;&gt;^&#10;\()\-−+.,٫, ٬.’=?:;'\\&quot;]){1,1}([^\\\p{Zs}*\\/&amp;|!&lt;&gt;^&#10;\()\-−+.,٫, ٬.’=?:;\\&quot;]){0,}"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="units">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="mm"/>
+      <xs:enumeration value="cm"/>
+      <xs:enumeration value="inch"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="measurementsTypes">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="standard"/>
+      <xs:enumeration value="individual"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="formatVersion">
+    <xs:restriction base="xs:string">
+      <xs:pattern value="(0|([1-9][0-9]*))\.(0|([1-9][0-9]*))\.(0|([1-9][0-9]*))"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="imageExtension">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="PNG"/>
+      <xs:enumeration value="JPG"/>
+      <xs:enumeration value="BMP"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="colors">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="byGroup"/>
+      <xs:enumeration value="black"/>
+      <xs:enumeration value="green"/>
+      <xs:enumeration value="blue"/>
+      <xs:enumeration value="darkRed"/>
+      <xs:enumeration value="darkGreen"/>
+      <xs:enumeration value="darkBlue"/>
+      <xs:enumeration value="yellow"/>
+      <xs:enumeration value="lightsalmon"/>
+      <xs:enumeration value="goldenrod"/>
+      <xs:enumeration value="orange"/>
+      <xs:enumeration value="deeppink"/>
+      <xs:enumeration value="violet"/>
+      <xs:enumeration value="darkviolet"/>
+      <xs:enumeration value="mediumseagreen"/>
+      <xs:enumeration value="lime"/>
+      <xs:enumeration value="deepskyblue"/>
+      <xs:enumeration value="cornflowerblue"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="linePenStyle">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="byGroup"/>
+      <xs:enumeration value="none"/>
+      <xs:enumeration value="solidLine"/>
+      <xs:enumeration value="dashLine"/>
+      <xs:enumeration value="dotLine"/>
+      <xs:enumeration value="dashDotLine"/>
+      <xs:enumeration value="dashDotDotLine"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="curvePenStyle">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="solidLine"/>
+      <xs:enumeration value="dashLine"/>
+      <xs:enumeration value="dotLine"/>
+      <xs:enumeration value="dashDotLine"/>
+      <xs:enumeration value="dashDotDotLine"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="lineWeights">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="byGroup"/>
+      <xs:enumeration value="0"/>
+      <xs:enumeration value="0.05"/>
+      <xs:enumeration value="0.09"/>
+      <xs:enumeration value="0.13"/>
+      <xs:enumeration value="0.15"/>
+      <xs:enumeration value="0.18"/>
+      <xs:enumeration value="0.35"/>
+      <xs:enumeration value="0.2"/>
+      <xs:enumeration value="0.25"/>
+      <xs:enumeration value="0.3"/>
+      <xs:enumeration value="0.35"/>
+      <xs:enumeration value="0.4"/>
+      <xs:enumeration value="0.5"/>
+      <xs:enumeration value="0.53"/>
+      <xs:enumeration value="0.6"/>
+      <xs:enumeration value="0.7"/>
+      <xs:enumeration value="0.8"/>
+      <xs:enumeration value="0.9"/>
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="1.06"/>
+      <xs:enumeration value="1.2"/>
+      <xs:enumeration value="1.4"/>
+      <xs:enumeration value="1.58"/>
+      <xs:enumeration value="2"/>
+      <xs:enumeration value="2.11"/>
+      <xs:enumeration value="3"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="baseHeight">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="50"/>
+      <xs:enumeration value="56"/>
+      <xs:enumeration value="62"/>
+      <xs:enumeration value="68"/>
+      <xs:enumeration value="74"/>
+      <xs:enumeration value="80"/>
+      <xs:enumeration value="86"/>
+      <xs:enumeration value="92"/>
+      <xs:enumeration value="98"/>
+      <xs:enumeration value="104"/>
+      <xs:enumeration value="110"/>
+      <xs:enumeration value="116"/>
+      <xs:enumeration value="122"/>
+      <xs:enumeration value="128"/>
+      <xs:enumeration value="134"/>
+      <xs:enumeration value="140"/>
+      <xs:enumeration value="146"/>
+      <xs:enumeration value="152"/>
+      <xs:enumeration value="158"/>
+      <xs:enumeration value="164"/>
+      <xs:enumeration value="170"/>
+      <xs:enumeration value="176"/>
+      <xs:enumeration value="182"/>
+      <xs:enumeration value="188"/>
+      <xs:enumeration value="194"/>
+      <xs:enumeration value="200"/>
+      <xs:enumeration value="500"/>
+      <xs:enumeration value="560"/>
+      <xs:enumeration value="620"/>
+      <xs:enumeration value="680"/>
+      <xs:enumeration value="740"/>
+      <xs:enumeration value="800"/>
+      <xs:enumeration value="860"/>
+      <xs:enumeration value="920"/>
+      <xs:enumeration value="980"/>
+      <xs:enumeration value="1040"/>
+      <xs:enumeration value="1100"/>
+      <xs:enumeration value="1160"/>
+      <xs:enumeration value="1220"/>
+      <xs:enumeration value="1280"/>
+      <xs:enumeration value="1340"/>
+      <xs:enumeration value="1400"/>
+      <xs:enumeration value="1460"/>
+      <xs:enumeration value="1520"/>
+      <xs:enumeration value="1580"/>
+      <xs:enumeration value="1640"/>
+      <xs:enumeration value="1700"/>
+      <xs:enumeration value="1760"/>
+      <xs:enumeration value="1820"/>
+      <xs:enumeration value="1880"/>
+      <xs:enumeration value="1940"/>
+      <xs:enumeration value="2000"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="baseSize">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="22"/>
+      <xs:enumeration value="24"/>
+      <xs:enumeration value="26"/>
+      <xs:enumeration value="28"/>
+      <xs:enumeration value="30"/>
+      <xs:enumeration value="32"/>
+      <xs:enumeration value="34"/>
+      <xs:enumeration value="36"/>
+      <xs:enumeration value="38"/>
+      <xs:enumeration value="40"/>
+      <xs:enumeration value="42"/>
+      <xs:enumeration value="44"/>
+      <xs:enumeration value="46"/>
+      <xs:enumeration value="48"/>
+      <xs:enumeration value="50"/>
+      <xs:enumeration value="52"/>
+      <xs:enumeration value="54"/>
+      <xs:enumeration value="56"/>
+      <xs:enumeration value="58"/>
+      <xs:enumeration value="60"/>
+      <xs:enumeration value="62"/>
+      <xs:enumeration value="64"/>
+      <xs:enumeration value="66"/>
+      <xs:enumeration value="68"/>
+      <xs:enumeration value="70"/>
+      <xs:enumeration value="72"/>
+      <xs:enumeration value="220"/>
+      <xs:enumeration value="240"/>
+      <xs:enumeration value="260"/>
+      <xs:enumeration value="280"/>
+      <xs:enumeration value="300"/>
+      <xs:enumeration value="320"/>
+      <xs:enumeration value="340"/>
+      <xs:enumeration value="360"/>
+      <xs:enumeration value="380"/>
+      <xs:enumeration value="400"/>
+      <xs:enumeration value="420"/>
+      <xs:enumeration value="440"/>
+      <xs:enumeration value="460"/>
+      <xs:enumeration value="480"/>
+      <xs:enumeration value="500"/>
+      <xs:enumeration value="520"/>
+      <xs:enumeration value="540"/>
+      <xs:enumeration value="560"/>
+      <xs:enumeration value="580"/>
+      <xs:enumeration value="600"/>
+      <xs:enumeration value="620"/>
+      <xs:enumeration value="640"/>
+      <xs:enumeration value="660"/>
+      <xs:enumeration value="680"/>
+      <xs:enumeration value="700"/>
+      <xs:enumeration value="720"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="crossType">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="axisType">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="1"/>
+      <xs:enumeration value="2"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="arrowType">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="0"/>
+      <!--Both-->
+      <xs:enumeration value="1"/>
+      <!--Front-->
+      <xs:enumeration value="2"/>
+      <!--Rear-->
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="pieceVersion">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="1"/>
+      <!--Old version-->
+      <xs:enumeration value="2"/>
+      <!--New version-->
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="nodeAngle">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="0"/>
+      <!--by length-->
+      <xs:enumeration value="1"/>
+      <!--by points intersections-->
+      <xs:enumeration value="2"/>
+      <!--by second edge symmetry-->
+      <xs:enumeration value="3"/>
+      <!--by first edge symmetry-->
+      <xs:enumeration value="4"/>
+      <!--by first edge right angle-->
+      <xs:enumeration value="5"/>
+      <!--by first edge right angle-->
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="piecePathType">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="1"/>
+      <!--custom seam allowance-->
+      <xs:enumeration value="2"/>
+      <!--internal path-->
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="piecePathIncludeType">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="0"/>
+      <!--as main path-->
+      <xs:enumeration value="1"/>
+      <!--as custom seam allowance-->
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="notchTypes">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="slit"/>
+      <xs:enumeration value="tNotch"/>
+      <xs:enumeration value="uNotch"/>
+      <xs:enumeration value="vInternal"/>
+      <xs:enumeration value="vExternal"/>
+      <xs:enumeration value="castle"/>
+      <xs:enumeration value="diamond"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="notchSubtypes">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="straightforward"/>
+      <xs:enumeration value="bisector"/>
+      <xs:enumeration value="intersection"/>
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="alignmentType">
+    <xs:restriction base="xs:unsignedInt">
+      <xs:enumeration value="0"/><!--default (no aligns)-->
+      <xs:enumeration value="1"/><!--aligns with the left edge-->
+      <xs:enumeration value="2"/><!--aligns with the right edge-->
+      <xs:enumeration value="4"/><!--Centers horizontally in the available space-->
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="directionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="forward"/>
+      <xs:enumeration value="backward"/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/src/libs/ifc/xml/vabstractpattern.cpp
+++ b/src/libs/ifc/xml/vabstractpattern.cpp
@@ -162,6 +162,7 @@ const QString VAbstractPattern::AttrOnFold              = QStringLiteral("onFold
 const QString VAbstractPattern::AttrDateFormat          = QStringLiteral("dateFormat");
 const QString VAbstractPattern::AttrTimeFormat          = QStringLiteral("timeFormat");
 const QString VAbstractPattern::AttrArrows              = QStringLiteral("arrows");
+const QString VAbstractPattern::AttrArrowLength         = QStringLiteral("arrowLength");
 const QString VAbstractPattern::AttrNodeReverse         = QStringLiteral("reverse");
 const QString VAbstractPattern::AttrNodeExcluded        = QStringLiteral("excluded");
 const QString VAbstractPattern::AttrNodeIsNotch         = QStringLiteral("notch");

--- a/src/libs/ifc/xml/vabstractpattern.h
+++ b/src/libs/ifc/xml/vabstractpattern.h
@@ -358,6 +358,7 @@ public:
     static const QString AttrDateFormat;
     static const QString AttrTimeFormat;
     static const QString AttrArrows;
+    static const QString AttrArrowLength;
     static const QString AttrNodeReverse;
     static const QString AttrNodeExcluded;
     static const QString AttrNodeIsNotch;

--- a/src/libs/ifc/xml/vpatternconverter.cpp
+++ b/src/libs/ifc/xml/vpatternconverter.cpp
@@ -81,8 +81,8 @@ Q_LOGGING_CATEGORY(PatternConverter, "patternConverter")
  */
 
 const QString VPatternConverter::PatternMinVerStr = QStringLiteral("0.1.0");
-const QString VPatternConverter::PatternMaxVerStr = QStringLiteral("0.7.2");
-const QString VPatternConverter::CurrentSchema    = QStringLiteral("://schema/pattern/v0.7.2.xsd");
+const QString VPatternConverter::PatternMaxVerStr = QStringLiteral("0.7.3");
+const QString VPatternConverter::CurrentSchema    = QStringLiteral("://schema/pattern/v0.7.3.xsd");
 
 //VPatternConverter::PatternMinVer; // <== DON'T FORGET TO UPDATE TOO!!!!
 //VPatternConverter::PatternMaxVer; // <== DON'T FORGET TO UPDATE TOO!!!!
@@ -341,7 +341,9 @@ QString VPatternConverter::getSchema(int ver) const
         case (0x000701):
             return QStringLiteral("://schema/pattern/v0.7.1.xsd");;
         case (0x000702):
-            qCDebug(PatternConverter, "Current schema - ://schema/pattern/v0.7.2.xsd");
+            return QStringLiteral("://schema/pattern/v0.7.2.xsd");;
+        case (0x000703):
+            qCDebug(PatternConverter, "Current schema - ://schema/pattern/v0.7.3.xsd");
             return CurrentSchema;
         default:
             InvalidVersion(ver);
@@ -540,6 +542,10 @@ void VPatternConverter::applyPatches()
             ValidateXML(getSchema(0x000702), m_convertedFileName);
             V_FALLTHROUGH
         case (0x000702):
+            toVersion0_7_3();
+            ValidateXML(getSchema(0x000703), m_convertedFileName);
+            V_FALLTHROUGH
+        case (0x000703):
             break;
         default:
             InvalidVersion(m_ver);
@@ -558,7 +564,7 @@ void VPatternConverter::downgradeToCurrentMaxVersion()
 bool VPatternConverter::isReadOnly() const
 {
     // Check if attribute readOnly was not changed in file format
-    Q_STATIC_ASSERT_X(VPatternConverter::PatternMaxVer == CONVERTER_VERSION_CHECK(0, 7, 2),
+    Q_STATIC_ASSERT_X(VPatternConverter::PatternMaxVer == CONVERTER_VERSION_CHECK(0, 7, 3),
                       "Check attribute readOnly.");
 
     // Possibly in future attribute readOnly will change position etc.
@@ -1411,6 +1417,16 @@ void VPatternConverter::toVersion0_7_2()
     Q_STATIC_ASSERT_X(VPatternConverter::PatternMinVer < CONVERTER_VERSION_CHECK(0, 7, 2),
                       "Time to refactor the code.");
     setVersion(QStringLiteral("0.7.2"));
+    Save();
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VPatternConverter::toVersion0_7_3()
+{
+    // TODO. Delete if minimal supported version is 0.7.3
+    Q_STATIC_ASSERT_X(VPatternConverter::PatternMinVer < CONVERTER_VERSION_CHECK(0, 7, 3),
+                      "Time to refactor the code.");
+    setVersion(QStringLiteral("0.7.3"));
     Save();
 }
 

--- a/src/libs/ifc/xml/vpatternconverter.h
+++ b/src/libs/ifc/xml/vpatternconverter.h
@@ -75,7 +75,7 @@ public:
     static const QString PatternMaxVerStr;
     static const QString CurrentSchema;
     static Q_DECL_CONSTEXPR const int PatternMinVer = CONVERTER_VERSION_CHECK(0, 1, 0);
-    static Q_DECL_CONSTEXPR const int PatternMaxVer = CONVERTER_VERSION_CHECK(0, 7, 2);
+    static Q_DECL_CONSTEXPR const int PatternMaxVer = CONVERTER_VERSION_CHECK(0, 7, 3);
 
 protected:
     virtual int     minVer() const override;
@@ -140,6 +140,7 @@ private:
     void          toVersion0_7_0();
     void          toVersion0_7_1();
     void          toVersion0_7_2();
+    void          toVersion0_7_3();
 
     void          TagUnitToV0_2_0();
     void          TagIncrementToV0_2_0();

--- a/src/libs/vlayout/vlayoutpiece.cpp
+++ b/src/libs/vlayout/vlayoutpiece.cpp
@@ -193,7 +193,7 @@ bool findLabelGeometry(const VPatternLabelData &labelData, const VContainer *pat
 
 //---------------------------------------------------------------------------------------------------------------------
 bool findGrainlineGeometry(const VGrainlineData& data, const VContainer *pattern, qreal &length, qreal &rotationAngle,
-                           QPointF &pos)
+                           qreal &arrowLength, QPointF &pos)
 {
     SCASSERT(pattern != nullptr)
 
@@ -210,6 +210,10 @@ bool findGrainlineGeometry(const VGrainlineData& data, const VContainer *pattern
             QLineF grainline(static_cast<QPointF>(*bottomAnchor_Point), static_cast<QPointF>(*topAnchor_Point));
             length = grainline.length();
             rotationAngle = grainline.angle();
+
+            Calculator cal3;
+            arrowLength = cal3.EvalFormula(pattern->DataVariables(), data.getArrowLength());
+            arrowLength = ToPixel(arrowLength, *pattern->GetPatternUnit());
 
             if (!VFuzzyComparePossibleNulls(rotationAngle, 0))
             {
@@ -236,6 +240,10 @@ bool findGrainlineGeometry(const VGrainlineData& data, const VContainer *pattern
         Calculator cal2;
         length = cal2.EvalFormula(pattern->DataVariables(), data.getLength());
         length = ToPixel(length, *pattern->GetPatternUnit());
+
+        Calculator cal3;
+        arrowLength = cal3.EvalFormula(pattern->DataVariables(), data.getArrowLength());
+        arrowLength = ToPixel(arrowLength, *pattern->GetPatternUnit());
     }
     catch(qmu::QmuParserError &error)
     {
@@ -438,20 +446,20 @@ VLayoutPiece VLayoutPiece::Create(const VPiece &piece, const VContainer *pattern
     }
 
     const VPieceLabelData& pieceLabelData = piece.GetPatternPieceData();
-    if (pieceLabelData.IsVisible() == true)
+    if (pieceLabelData.IsVisible() & qApp->Settings()->showLabels())
     {
         layoutPiece.SetPieceText(piece.GetName(), pieceLabelData, qApp->Settings()->getLabelFont(), pattern);
     }
 
     const VPatternLabelData& patternLabelData = piece.GetPatternInfo();
-    if (patternLabelData.IsVisible() == true)
+    if (patternLabelData.IsVisible() & qApp->Settings()->showLabels())
     {
         VAbstractPattern* pDoc = qApp->getCurrentDocument();
         layoutPiece.SetPatternInfo(pDoc, patternLabelData, qApp->Settings()->getLabelFont(), pattern);
     }
 
     const VGrainlineData& grainlineGeom = piece.GetGrainlineGeometry();
-    if (grainlineGeom.IsVisible() == true)
+    if (grainlineGeom.IsVisible() & qApp->Settings()->showGrainlines())
     {
         layoutPiece.setGrainline(grainlineGeom, pattern);
     }
@@ -633,47 +641,39 @@ void VLayoutPiece::setGrainline(const VGrainlineData& data, const VContainer* pa
     QPointF pt1;
     qreal rotationAngle = 0;
     qreal length = 0;
-    if (!findGrainlineGeometry(data, pattern, length, rotationAngle, pt1))
+    qreal arrowLength = 0;
+    if (!findGrainlineGeometry(data, pattern, length, rotationAngle, arrowLength, pt1))
     {
         return;
     }
 
-    const qreal arrowLength = 45;
-    const qreal arrowAngle = M_PI/9;
-
-    QPointF pt2(pt1.x() + arrowLength * qCos(rotationAngle),
-                pt1.y() - arrowLength * qSin(rotationAngle));
-    QPointF pt3(pt1.x() + length * qCos(rotationAngle),
+    QPointF pt2(pt1.x() + length * qCos(rotationAngle),
                 pt1.y() - length * qSin(rotationAngle));
-    QPointF pt4(pt1.x() + (length - arrowLength) * qCos(rotationAngle),
-                pt1.y() - (length - arrowLength) * qSin(rotationAngle));
 
-    QVector<QPointF> v;
-    v << pt2;
+    QVector<QPointF> path;
+    path << pt1;
     if (data.getArrowType() != ArrowType::Top)
     {
-        v << QPointF(pt1.x() + arrowLength * qCos(rotationAngle + arrowAngle),
-                     pt1.y() - arrowLength * qSin(rotationAngle + arrowAngle));
-        v << pt1;
-        v << QPointF(pt1.x() + arrowLength * qCos(rotationAngle - arrowAngle),
-                     pt1.y() - arrowLength * qSin(rotationAngle - arrowAngle));
-        v << pt2;
-    }
+        path << QPointF(pt1.x() + arrowLength * cos(rotationAngle + M_PI / 9),
+                        pt1.y() - arrowLength * sin(rotationAngle + M_PI / 9));
 
-    v << pt4;
+        path << QPointF(pt1.x() + arrowLength * cos(rotationAngle - M_PI / 9),
+                        pt1.y() - arrowLength * sin(rotationAngle - M_PI / 9));
+    }
+    path << pt1 << pt2;
+
     if (data.getArrowType() != ArrowType::Bottom)
     {
-        rotationAngle += M_PI;
-        v << QPointF(pt3.x() + arrowLength * qCos(rotationAngle + arrowAngle),
-                     pt3.y() - arrowLength * qSin(rotationAngle + arrowAngle));
-        v << pt3;
-        v << QPointF(pt3.x() + arrowLength * qCos(rotationAngle - arrowAngle),
-                     pt3.y() - arrowLength * qSin(rotationAngle - arrowAngle));
-        v << pt4;
+        path << QPointF(pt2.x() + arrowLength * cos(M_PI + rotationAngle + M_PI / 9),
+                        pt2.y() - arrowLength * sin(M_PI + rotationAngle + M_PI / 9));
+
+        path << QPointF(pt2.x() + arrowLength * cos(M_PI + rotationAngle - M_PI / 9),
+                        pt2.y() - arrowLength * sin(M_PI + rotationAngle - M_PI / 9));
     }
+    path << pt2;
 
     QScopedPointer<QGraphicsItem> item(getMainPathItem());
-    d->grainlinePoints = CorrectPosition(item->boundingRect(), v);
+    d->grainlinePoints = CorrectPosition(item->boundingRect(), path);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vlayout/vlayoutpiece.h
+++ b/src/libs/vlayout/vlayoutpiece.h
@@ -1,53 +1,52 @@
-/***************************************************************************
- *                                                                         *
- *   Copyright (C) 2017  Seamly, LLC                                       *
- *                                                                         *
- *   https://github.com/fashionfreedom/seamly2d                            *
- *                                                                         *
- ***************************************************************************
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vlayoutpiece.h
+//  @author Douglas S Caskey
+//  @date   Dec 27, 2022
+//
+//  @copyright
+//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
- ************************************************************************
- **
- **  @file   vlayoutdetail.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   2 1, 2015
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vlayoutdetail.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   2 1, 2015
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #ifndef VLAYOUTDETAIL_H
 #define VLAYOUTDETAIL_H

--- a/src/libs/vlayout/vlayoutpiece_p.h
+++ b/src/libs/vlayout/vlayoutpiece_p.h
@@ -1,54 +1,52 @@
-/***************************************************************************
- **  @file   vlayoutdetail_p.h
- **  @author Douglas S Caskey
- **  @date   Dec 27, 2022
- **
- **  @copyright
- **  Copyright (C) 2017 - 2022 Seamly, LLC
- **  https://github.com/fashionfreedom/seamly2d
- **
- **  @brief
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D. if not, see <http://www.gnu.org/licenses/>.
- **************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vlayoutdetail_p.h
+//  @author Douglas S Caskey
+//  @date   Dec 27, 2022
+//
+//  @copyright
+//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  https://github.com/fashionfreedom/seamly2d
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
-/************************************************************************
- **
- **  @file   vlayoutdetail_p.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   3 1, 2015
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentina project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2013-2015 Valentina project
- **  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
- **
- **  Valentina is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Valentina is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   vlayoutdetail.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   2 1, 2015
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2016 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #ifndef VLAYOUTDETAIL_P_H
 #define VLAYOUTDETAIL_P_H
@@ -110,20 +108,20 @@ public:
 
     ~VLayoutPieceData() {}
 
-    QVector<QPointF>           contour;            //! @brief contour list of contour points.
-    QVector<QPointF>           seamAllowance;      //! @brief seamAllowance list of seam allowance points.
-    QVector<QPointF>           layoutAllowance;    //! @brief layoutAllowance list of layout allowance points.
-    QVector<QLineF>            notches;            //! @brief notches list of notches.
-    QVector<VLayoutPiecePath>  m_internalPaths;    //! @brief m_internalPaths list of internal paths.
-    QVector<VLayoutPiecePath>  m_cutoutPaths;      //! @brief m_cutoutPaths list of internal cutout paths.
-    QTransform                 transform;          //! @brief transform transformation transform
-    qreal                      layoutWidth;        //! @brief layoutWidth value layout allowance width in pixels.
+    QVector<QPointF>           contour;            /// @brief contour list of contour points.
+    QVector<QPointF>           seamAllowance;      /// @brief seamAllowance list of seam allowance points.
+    QVector<QPointF>           layoutAllowance;    /// @brief layoutAllowance list of layout allowance points.
+    QVector<QLineF>            notches;            /// @brief notches list of notches.
+    QVector<VLayoutPiecePath>  m_internalPaths;    /// @brief m_internalPaths list of internal paths.
+    QVector<VLayoutPiecePath>  m_cutoutPaths;      /// @brief m_cutoutPaths list of internal cutout paths.
+    QTransform                 transform;          /// @brief transform transformation transform
+    qreal                      layoutWidth;        /// @brief layoutWidth value layout allowance width in pixels.
     bool                       mirror;
-    QVector<QPointF>           pieceLabel;         //! @brief pieceLabel piece label rectangle
-    QVector<QPointF>           patternInfo;        //! @brief patternInfo pattern info rectangle
-    QVector<QPointF>           grainlinePoints;    //! @brief grainlineInfo line
-    VTextManager               m_tmPiece;          //! @brief m_tmPiece text manager for laying out piece info
-    VTextManager               m_tmPattern;        //! @brief m_tmPattern text manager for laying out pattern info */
+    QVector<QPointF>           pieceLabel;         /// @brief pieceLabel piece label rectangle
+    QVector<QPointF>           patternInfo;        /// @brief patternInfo pattern info rectangle
+    QVector<QPointF>           grainlinePoints;    /// @brief grainlineInfo line
+    VTextManager               m_tmPiece;          /// @brief m_tmPiece text manager for laying out piece info
+    VTextManager               m_tmPattern;        /// @brief m_tmPattern text manager for laying out pattern info */
 
 private:
     VLayoutPieceData &operator=(const VLayoutPieceData &) Q_DECL_EQ_DELETE;

--- a/src/libs/vpatterndb/floatItemData/vgrainlinedata.cpp
+++ b/src/libs/vpatterndb/floatItemData/vgrainlinedata.cpp
@@ -125,6 +125,18 @@ void VGrainlineData::setArrowType(ArrowType type)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+QString VGrainlineData::getArrowLength() const
+{
+    return d->m_arrowLength;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void VGrainlineData::setArrowLength(const QString& length)
+{
+    d->m_arrowLength = length;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 quint32 VGrainlineData::centerAnchorPoint() const
 {
     return d->m_centerAnchorPoint;

--- a/src/libs/vpatterndb/floatItemData/vgrainlinedata.h
+++ b/src/libs/vpatterndb/floatItemData/vgrainlinedata.h
@@ -88,6 +88,9 @@ public:
     ArrowType       getArrowType() const;
     void            setArrowType(ArrowType type);
 
+    QString         getArrowLength() const;
+    void            setArrowLength(const QString& length);
+
     quint32         centerAnchorPoint() const;
     void            setCenterAnchorPoint(quint32 centerAnchor);
 

--- a/src/libs/vpatterndb/floatItemData/vgrainlinedata_p.h
+++ b/src/libs/vpatterndb/floatItemData/vgrainlinedata_p.h
@@ -54,6 +54,7 @@
 #include <QPointF>
 #include <QSharedData>
 
+#include "../vmisc/vcommonsettings.h"
 #include "../vmisc/diagnostic.h"
 #include "floatitemdef.h"
 #include "../ifc/ifcdef.h"
@@ -69,6 +70,7 @@ public:
         : m_length()
         , m_rotation()
         , m_arrowType(ArrowType::Both)
+        , m_arrowLength()
         , m_centerAnchorPoint(NULL_ID)
         , m_topAnchorPoint(NULL_ID)
         , m_bottomAnchorPoint(NULL_ID)
@@ -79,6 +81,7 @@ public:
         , m_length(data.m_length)
         , m_rotation(data.m_rotation)
         , m_arrowType(data.m_arrowType)
+        , m_arrowLength(data.m_arrowLength)
         , m_centerAnchorPoint(data.m_centerAnchorPoint)
         , m_topAnchorPoint(data.m_topAnchorPoint)
         , m_bottomAnchorPoint(data.m_bottomAnchorPoint)
@@ -86,12 +89,13 @@ public:
 
     ~VGrainlineDataPrivate() Q_DECL_EQ_DEFAULT;
 
-    QString   m_length;            /** @brief m_dLength formula to calculate the length of grainline */
-    QString   m_rotation;          /** @brief m_rotation formula to calculate the rotation of grainline in [degrees] */
-    ArrowType m_arrowType;         /** @brief m_arrowType type of arrow on the grainline */
-    quint32   m_centerAnchorPoint; /** @brief m_centerAnchorPoint center anchor point id */
-    quint32   m_topAnchorPoint;    /** @brief m_topAnchorPoint top anchor point id */
-    quint32   m_bottomAnchorPoint; /** @brief m_bottomAnchorPoint bottom anchor point id */
+    QString   m_length;            /// @brief m_length formula to calculate the length of grainline */
+    QString   m_rotation;          /// @brief m_rotation formula to calculate the rotation of grainline in [degrees] */
+    ArrowType m_arrowType;         /// @brief m_arrowType type of arrow on the grainline */
+    QString   m_arrowLength;       /// @brief m_arrowLength formula to calculate the length of arrowheads */
+    quint32   m_centerAnchorPoint; /// @brief m_centerAnchorPoint center anchor point id */
+    quint32   m_topAnchorPoint;    /// @brief m_topAnchorPoint top anchor point id */
+    quint32   m_bottomAnchorPoint; /// @brief m_bottomAnchorPoint bottom anchor point id */
 
 private:
     VGrainlineDataPrivate &operator=(const VGrainlineDataPrivate &) Q_DECL_EQ_DELETE;

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -347,11 +347,14 @@ void PatternPieceDialog::SetPiece(const VPiece &piece)
 
     m_oldGrainline = piece.GetGrainlineGeometry();
     ui->grainline_GroupBox->setChecked(m_oldGrainline.IsVisible());
+    ui->anchorPoints_GroupBox->setEnabled(m_oldGrainline.IsVisible());
+    ui->arrows_GroupBox->setEnabled(m_oldGrainline.IsVisible());
     changeCurrentData(ui->grainlineCenterAnchor_ComboBox, m_oldGrainline.centerAnchorPoint());
     changeCurrentData(ui->grainlineTopAnchor_ComboBox, m_oldGrainline.topAnchorPoint());
     changeCurrentData(ui->grainlineBottomAnchor_ComboBox, m_oldGrainline.bottomAnchorPoint());
     setGrainlineAngle(m_oldGrainline.getRotation());
     setGrainlineLength(m_oldGrainline.getLength());
+    setGrainlineArrowLength(m_oldGrainline.getArrowLength());
 
     validateObjects(isMainPathValid());
     enabledGrainline();
@@ -722,6 +725,7 @@ void PatternPieceDialog::closeEvent(QCloseEvent *event)
     ui->afterWidthFormula_PlainTextEdit->blockSignals(true);
     ui->rotationFormula_LineEdit->blockSignals(true);
     ui->lengthFormula_LineEdit->blockSignals(true);
+    ui->arrowlLengthFormula_LineEdit->blockSignals(true);
     DialogTool::closeEvent(event);
 }
 
@@ -1706,24 +1710,30 @@ void PatternPieceDialog::notchCountChanged(int value)
 //---------------------------------------------------------------------------------------------------------------------
 void PatternPieceDialog::updateGrainlineValues()
 {
-    QPlainTextEdit *lineEdit[2] = {ui->rotationFormula_LineEdit, ui->lengthFormula_LineEdit};
-    bool formulasOK[2] = {true, true};
+    QPlainTextEdit *lineEdit[3] = {ui->rotationFormula_LineEdit, ui->lengthFormula_LineEdit, ui->arrowlLengthFormula_LineEdit};
+    bool formulasOK[3] = {true, true, true};
 
-    for (int i = 0; i < 2; ++i)
+    for (int i = 0; i < 3; ++i)
     {
         QLabel *labelValue;
         QLabel *labelText;
         QString labelUnits;
         if (i == 0)
         {
-            labelValue = ui->labelRot;
-            labelText  = ui->labelEditRot;
+            labelValue = ui->rotationCalc_Label;
+            labelText  = ui->rotation_Label;
             labelUnits = degreeSymbol;
+        }
+        else if (i == 1)
+        {
+            labelValue = ui->lengthCalc_Label;
+            labelText  = ui->length_Label;
+            labelUnits = QLatin1String(" ") + UnitsToStr(qApp->patternUnit());
         }
         else
         {
-            labelValue = ui->labelLen;
-            labelText  = ui->labelEditLen;
+            labelValue = ui->arowLengthCalc_Label;
+            labelText  = ui->arrowLength_Label;
             labelUnits = QLatin1String(" ") + UnitsToStr(qApp->patternUnit());
         }
 
@@ -1737,11 +1747,22 @@ void PatternPieceDialog::updateGrainlineValues()
             formula = qApp->translateVariables()->FormulaFromUser(formula, qApp->Settings()->getOsSeparator());
             Calculator calculation;
             qreal calculatedValue = calculation.EvalFormula(data->DataVariables(), formula);
+
+            QString arrowFormula = lineEdit[2]->toPlainText().simplified();
+            arrowFormula.replace("\n", " ");
+            arrowFormula = qApp->translateVariables()->FormulaFromUser(arrowFormula, qApp->Settings()->getOsSeparator());
+            Calculator arrowCalculation;
+            qreal arrowCalculatedValue = arrowCalculation.EvalFormula(data->DataVariables(), arrowFormula);
+
             if (qIsInf(calculatedValue) == true || qIsNaN(calculatedValue) == true)
             {
                 throw qmu::QmuParserError(tr("Infinite/undefined result"));
             }
-            else if (i == 1 && calculatedValue <= 0.0)
+            else if (i == 1 && calculatedValue < arrowCalculatedValue * 2.0)
+            {
+                throw qmu::QmuParserError(tr("Length can't be less than length of 2 arrows"));
+            }
+            else if (i ==2 && calculatedValue <= 0.0)
             {
                 throw qmu::QmuParserError(tr("Length should be positive"));
             }
@@ -1766,7 +1787,7 @@ void PatternPieceDialog::updateGrainlineValues()
         labelValue->setText(formulaValueStr);
     }
 
-    flagGrainlineFormula = formulasOK[0] && formulasOK[1];
+    flagGrainlineFormula = formulasOK[0] && formulasOK[1] && formulasOK[2];
     if (!flagGrainlineFormula && !flagGrainlineAnchor)
     {
         setErrorText(TabOrder::Grainline, tr("Grainline"));
@@ -1951,6 +1972,9 @@ void PatternPieceDialog::updatePatternLabelValues()
 //---------------------------------------------------------------------------------------------------------------------
 void PatternPieceDialog::enabledGrainline()
 {
+    ui->anchorPoints_GroupBox->setEnabled(ui->grainline_GroupBox->isChecked());
+    ui->arrows_GroupBox->setEnabled(ui->grainline_GroupBox->isChecked());
+
     if (ui->grainline_GroupBox->isChecked() == true)
     {
         updateGrainlineValues();
@@ -2017,6 +2041,12 @@ void PatternPieceDialog::editGrainlineFormula()
         checkForZero = false;
         title = tr("Edit angle");
     }
+    else if (sender() == ui->arrowLength_PushButton)
+    {
+        labelFormula = ui->arrowlLengthFormula_LineEdit;
+        checkForZero = false;
+        title = tr("Edit length");
+    }
     else
     {
         // should not get here!
@@ -2039,6 +2069,10 @@ void PatternPieceDialog::editGrainlineFormula()
         else if (sender() == ui->rotation_PushButton)
         {
             setGrainlineAngle(formula);
+        }
+        else if (sender() == ui->arrowLength_PushButton)
+        {
+            setGrainlineArrowLength(formula);
         }
         else
         {
@@ -2498,6 +2532,7 @@ VPiece PatternPieceDialog::CreatePiece() const
     piece.GetGrainlineGeometry().SetVisible(ui->grainline_GroupBox->isChecked());
     piece.GetGrainlineGeometry().setRotation(getFormulaFromUser(ui->rotationFormula_LineEdit));
     piece.GetGrainlineGeometry().setLength(getFormulaFromUser(ui->lengthFormula_LineEdit));
+    piece.GetGrainlineGeometry().setArrowLength(getFormulaFromUser(ui->arrowlLengthFormula_LineEdit));
     piece.GetGrainlineGeometry().setArrowType(static_cast<ArrowType>(ui->arrow_ComboBox->currentIndex()));
     piece.GetGrainlineGeometry().setCenterAnchorPoint(getCurrentObjectId(ui->grainlineCenterAnchor_ComboBox));
     piece.GetGrainlineGeometry().setTopAnchorPoint(getCurrentObjectId(ui->grainlineTopAnchor_ComboBox));
@@ -2520,7 +2555,6 @@ VPiece PatternPieceDialog::CreatePiece() const
 
         xPos = rect.center().x();
         yPos = rect.center().y() + getFormulaValue(ui->lengthFormula_LineEdit)/2.0;
-
         piece.GetGrainlineGeometry().SetPos(QPointF(xPos, yPos));
     }
     return piece;
@@ -3179,17 +3213,24 @@ void PatternPieceDialog::initializeLabelsTab()
 void PatternPieceDialog::initializeGrainlineTab()
 {
     ui->grainline_GroupBox->setChecked(qApp->Settings()->getDefaultGrainlineVisibilty());
+    ui->anchorPoints_GroupBox->setEnabled(qApp->Settings()->getDefaultGrainlineVisibilty());
+    ui->arrows_GroupBox->setEnabled(qApp->Settings()->getDefaultGrainlineVisibilty());
 
     ui->lengthFormula_LineEdit->setPlainText(QString::number(qApp->Settings()->getDefaultGrainlineLength()));
 
-    connect(ui->grainline_GroupBox,  &QGroupBox::toggled,   this, &PatternPieceDialog::enabledGrainline);
-    connect(ui->rotation_PushButton, &QPushButton::clicked, this, &PatternPieceDialog::editGrainlineFormula);
-    connect(ui->length_PushButton,   &QPushButton::clicked, this, &PatternPieceDialog::editGrainlineFormula);
-    connect(ui->lengthFormula_LineEdit, &QPlainTextEdit::textChanged, this,
-            &PatternPieceDialog::updateGrainlineValues);
+    qreal arrowLength = FromPixel(qApp->Settings()->getDefaultArrowLength(), *data->GetPatternUnit());
+    ui->arrowlLengthFormula_LineEdit->setPlainText(QString::number(arrowLength));
 
-    connect(ui->rotationFormula_LineEdit, &QPlainTextEdit::textChanged, this,
-            &PatternPieceDialog::updateGrainlineValues);
+    connect(ui->grainline_GroupBox,     &QGroupBox::toggled,   this, &PatternPieceDialog::enabledGrainline);
+    connect(ui->rotation_PushButton,    &QPushButton::clicked, this, &PatternPieceDialog::editGrainlineFormula);
+    connect(ui->length_PushButton,      &QPushButton::clicked, this, &PatternPieceDialog::editGrainlineFormula);
+    connect(ui->arrowLength_PushButton, &QPushButton::clicked, this, &PatternPieceDialog::editGrainlineFormula);
+    connect(ui->lengthFormula_LineEdit, &QPlainTextEdit::textChanged,
+            this, &PatternPieceDialog::updateGrainlineValues);
+    connect(ui->rotationFormula_LineEdit, &QPlainTextEdit::textChanged,
+            this, &PatternPieceDialog::updateGrainlineValues);
+    connect(ui->arrowlLengthFormula_LineEdit, &QPlainTextEdit::textChanged,
+            this, &PatternPieceDialog::updateGrainlineValues);
 
     enabledGrainline();
 
@@ -3388,6 +3429,20 @@ void PatternPieceDialog::setGrainlineLength(QString lengthFormula)
     ui->lengthFormula_LineEdit->setPlainText(formula);
 
     MoveCursorToEnd(ui->lengthFormula_LineEdit);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+void PatternPieceDialog::setGrainlineArrowLength(QString lengthFormula)
+{
+    if (lengthFormula.isEmpty())
+    {
+        lengthFormula = QString().setNum(UnitConvertor(1, Unit::Cm, *data->GetPatternUnit()));
+    }
+
+    const QString formula = qApp->translateVariables()->FormulaToUser(lengthFormula, qApp->Settings()->getOsSeparator());
+    ui->arrowlLengthFormula_LineEdit->setPlainText(formula);
+
+    MoveCursorToEnd(ui->arrowlLengthFormula_LineEdit);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.h
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.h
@@ -271,6 +271,7 @@ private:
 
     void                        setGrainlineAngle(QString angleFormula);
     void                        setGrainlineLength(QString lengthFormula);
+    void                        setGrainlineArrowLength(QString lengthFormula);
 
     void                        setPieceLabelWidth(QString widthFormula);
     void                        setPieceLabelHeight(QString heightFormula);

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
@@ -325,7 +325,7 @@ QListWidget::item:selected {
         <enum>QFrame::Sunken</enum>
        </property>
        <property name="currentIndex">
-        <number>6</number>
+        <number>5</number>
        </property>
        <widget class="QWidget" name="properties_Page">
         <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -4133,7 +4133,7 @@ QListWidget::item:selected {
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_11">
               <item alignment="Qt::AlignLeft">
-               <widget class="QLabel" name="labelEditRot">
+               <widget class="QLabel" name="rotation_Label">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
                   <horstretch>0</horstretch>
@@ -4198,7 +4198,7 @@ QListWidget::item:selected {
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="labelRot">
+               <widget class="QLabel" name="rotationCalc_Label">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                   <horstretch>0</horstretch>
@@ -4323,7 +4323,7 @@ QListWidget::item:selected {
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_13">
               <item alignment="Qt::AlignLeft">
-               <widget class="QLabel" name="labelEditLen">
+               <widget class="QLabel" name="length_Label">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
                   <horstretch>0</horstretch>
@@ -4388,7 +4388,7 @@ QListWidget::item:selected {
                </widget>
               </item>
               <item>
-               <widget class="QLabel" name="labelLen">
+               <widget class="QLabel" name="lengthCalc_Label">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
                   <horstretch>0</horstretch>
@@ -4700,7 +4700,7 @@ QListWidget::item:selected {
            <property name="minimumSize">
             <size>
              <width>0</width>
-             <height>0</height>
+             <height>150</height>
             </size>
            </property>
            <property name="font">
@@ -4767,6 +4767,141 @@ QListWidget::item:selected {
               </item>
              </layout>
             </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_6">
+              <item>
+               <widget class="QLabel" name="arrowLength_Label">
+                <property name="minimumSize">
+                 <size>
+                  <width>90</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                  <bold>false</bold>
+                 </font>
+                </property>
+                <property name="text">
+                 <string>Length:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="arowLengthCalc_Label">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>40</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="text">
+                 <string notr="true">_</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_30">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QToolButton" name="arrowLength_PushButton">
+                <property name="maximumSize">
+                 <size>
+                  <width>24</width>
+                  <height>24</height>
+                 </size>
+                </property>
+                <property name="toolTip">
+                 <string>Formula wizard</string>
+                </property>
+                <property name="text">
+                 <string notr="true">...</string>
+                </property>
+                <property name="icon">
+                 <iconset resource="../../../../vmisc/share/resources/icon.qrc">
+                  <normaloff>:/icon/24x24/fx.png</normaloff>:/icon/24x24/fx.png</iconset>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>24</width>
+                  <height>24</height>
+                 </size>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QFormLayout" name="formLayout_16">
+              <item row="0" column="0">
+               <spacer name="horizontalSpacer_31">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>90</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="0" column="1">
+               <widget class="QPlainTextEdit" name="arrowlLengthFormula_LineEdit">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>80</height>
+                 </size>
+                </property>
+                <property name="font">
+                 <font>
+                  <pointsize>9</pointsize>
+                  <bold>false</bold>
+                 </font>
+                </property>
+                <property name="toolTip">
+                 <string>Calculation</string>
+                </property>
+                <property name="tabChangesFocus">
+                 <bool>true</bool>
+                </property>
+                <property name="plainText">
+                 <string notr="true">.5</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
            </layout>
           </widget>
          </item>
@@ -4797,8 +4932,8 @@ QListWidget::item:selected {
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>264</width>
-              <height>486</height>
+              <width>362</width>
+              <height>558</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -5727,8 +5862,8 @@ QListWidget::item:selected {
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../../../vmisc/share/resources/icon.qrc"/>
   <include location="../../../../vmisc/share/resources/theme.qrc"/>
+  <include location="../../../../vmisc/share/resources/icon.qrc"/>
  </resources>
  <connections>
   <connection>

--- a/src/libs/vtools/tools/pattern_piece_tool.cpp
+++ b/src/libs/vtools/tools/pattern_piece_tool.cpp
@@ -71,6 +71,7 @@
 #include "../vpatterndb/floatItemData/vpatternlabeldata.h"
 #include "../vpatterndb/floatItemData/vpiecelabeldata.h"
 #include "../vpatterndb/floatItemData/vgrainlinedata.h"
+#include "../vtools/tools/vdatatool.h"
 #include "../qmuparser/qmutokenparser.h"
 #include "../undocommands/addpiece.h"
 #include "../undocommands/deletepiece.h"
@@ -443,12 +444,13 @@ void PatternPieceTool::addGrainline(VAbstractPattern *doc, QDomElement &domEleme
     // grainline
     QDomElement domData = doc->createElement(VAbstractPattern::TagGrainline);
     const VGrainlineData &data = piece.GetGrainlineGeometry();
-    doc->SetAttribute(domData, VAbstractPattern::AttrVisible,  data.IsVisible());
-    doc->SetAttribute(domData, AttrMx,                         data.GetPos().x());
-    doc->SetAttribute(domData, AttrMy,                         data.GetPos().y());
-    doc->SetAttribute(domData, AttrLength,                     data.getLength());
-    doc->SetAttribute(domData, VAbstractPattern::AttrRotation, data.getRotation());
-    doc->SetAttribute(domData, VAbstractPattern::AttrArrows,   int(data.getArrowType()));
+    doc->SetAttribute(domData, VAbstractPattern::AttrVisible,     data.IsVisible());
+    doc->SetAttribute(domData, AttrMx,                            data.GetPos().x());
+    doc->SetAttribute(domData, AttrMy,                            data.GetPos().y());
+    doc->SetAttribute(domData, AttrLength,                        data.getLength());
+    doc->SetAttribute(domData, VAbstractPattern::AttrRotation,    data.getRotation());
+    doc->SetAttribute(domData, VAbstractPattern::AttrArrows,      int(data.getArrowType()));
+    doc->SetAttribute(domData, VAbstractPattern::AttrArrowLength, data.getArrowLength());
 
     if (data.centerAnchorPoint() > NULL_ID)
     {
@@ -685,10 +687,11 @@ void PatternPieceTool::updateGrainline()
     if (data.IsVisible() & qApp->Settings()->showGrainlines())
     {
         QPointF pos;
-        qreal dRotation = 0;
-        qreal dLength = 0;
+        qreal rotation = 0;
+        qreal length = 0;
+        qreal arrowLength = 0;
 
-        const VGrainlineItem::MoveTypes type = findGrainlineGeometry(data, dLength, dRotation, pos);
+        const VGrainlineItem::MoveTypes type = findGrainlineGeometry(data, length, rotation, arrowLength, pos);
         if (type & VGrainlineItem::Error)
         {
             m_grainLine->hide();
@@ -696,8 +699,8 @@ void PatternPieceTool::updateGrainline()
         }
 
         m_grainLine->setMoveType(type);
-        m_grainLine->updateGeometry(pos, dRotation, ToPixel(dLength, *VDataTool::data.GetPatternUnit()),
-                                    data.getArrowType());
+        m_grainLine->updateGeometry(pos, rotation, ToPixel(length, *VDataTool::data.GetPatternUnit()),
+                                    data.getArrowType(), ToPixel(arrowLength, *VDataTool::data.GetPatternUnit()));
         m_grainLine->show();
     }
     else
@@ -1854,7 +1857,7 @@ VPieceItem::MoveTypes PatternPieceTool::findLabelGeometry(const VPatternLabelDat
 
 //---------------------------------------------------------------------------------------------------------------------
 VPieceItem::MoveTypes PatternPieceTool::findGrainlineGeometry(const VGrainlineData &data, qreal &length,
-                                                               qreal &rotationAngle, QPointF &pos)
+                                                              qreal &rotationAngle, qreal &arrowLength, QPointF &pos)
 {
     const quint32 topAnchorPoint = data.topAnchorPoint();
     const quint32 bottomAnchorPoint = data.bottomAnchorPoint();
@@ -1869,6 +1872,9 @@ VPieceItem::MoveTypes PatternPieceTool::findGrainlineGeometry(const VGrainlineDa
             QLineF grainline(static_cast<QPointF>(*bottomAnchor_Point), static_cast<QPointF>(*topAnchor_Point));
             length = FromPixel(grainline.length(), *VDataTool::data.GetPatternUnit());
             rotationAngle = grainline.angle();
+
+            Calculator cal3;
+            arrowLength = cal3.EvalFormula(VAbstractTool::data.DataVariables(), data.getArrowLength());
 
             if (!VFuzzyComparePossibleNulls(rotationAngle, 0))
             {
@@ -1903,6 +1909,9 @@ VPieceItem::MoveTypes PatternPieceTool::findGrainlineGeometry(const VGrainlineDa
 
         Calculator cal2;
         length = cal2.EvalFormula(VAbstractTool::data.DataVariables(), data.getLength());
+
+        Calculator cal3;
+        arrowLength = cal3.EvalFormula(VAbstractTool::data.DataVariables(), data.getArrowLength());
     }
     catch(qmu::QmuParserError &error)
     {

--- a/src/libs/vtools/tools/pattern_piece_tool.h
+++ b/src/libs/vtools/tools/pattern_piece_tool.h
@@ -201,7 +201,7 @@ private:
                                             qreal &labelHeight, QPointF &pos);
 
     VPieceItem::MoveTypes findGrainlineGeometry(const VGrainlineData &geom, qreal &length, qreal &rotationAngle,
-                                                QPointF &pos);
+                                                qreal &arrowLength, QPointF &pos);
 
     void                  initializeNodes(const VPiece &piece, VMainGraphicsScene *scene);
     static void           initializeNode(const VPieceNode &node, VMainGraphicsScene *scene, VContainer *data,

--- a/src/libs/vwidgets/vgrainlineitem.cpp
+++ b/src/libs/vwidgets/vgrainlineitem.cpp
@@ -4,7 +4,7 @@
 //  @date   11 Nov, 2024
 //
 //  @copyright
-//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  Copyright (C) 2017 - 2025 Seamly, LLC
 //  https://github.com/fashionfreedom/seamly2d
 //
 //  @brief
@@ -65,7 +65,9 @@
 
 #include "vgrainlineitem.h"
 
-#define ARROW_ANGLE                     M_PI/9
+#define TOP_ARROW                       0
+#define BOTTOM_ARROW                    M_PI
+#define ARROW_ANGLE                     M_PI / 9
 #define RECT_WIDTH                      30
 #define RESIZE_RECT_SIZE                10
 #define ROTATE_CIRC_R                   7
@@ -91,6 +93,7 @@ VGrainlineItem::VGrainlineItem(QGraphicsItem* parent)
     , m_centerPoint()
     , m_angle(0)
     , m_arrowType(ArrowType::Both)
+    , m_arrowLength(qApp->Settings()->getDefaultArrowLength()) // length in pixels
     , m_penWidth(LINE_PEN_WIDTH)
 {
     setAcceptHoverEvents(true);
@@ -137,15 +140,14 @@ void VGrainlineItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
 
     painter->setBrush(color);
 
-    if (m_arrowType != ArrowType::Bottom)
-    {
-        // first arrow
-        painter->drawPolygon(firstArrow());
-    }
     if (m_arrowType != ArrowType::Top)
     {
-        // second arrow
-        painter->drawPolygon(secondArrow());
+        drawArrow(painter, mainLine().p1(), TOP_ARROW);
+    }
+
+    if (m_arrowType != ArrowType::Bottom)
+    {
+        drawArrow(painter, mainLine().p2(), BOTTOM_ARROW);
     }
 
     if (m_mode != Mode::Normal)
@@ -202,10 +204,13 @@ void VGrainlineItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
 /// @param length length of the grainline in user's units.
 /// @param type type of arrowhead.
 //---------------------------------------------------------------------------------------------------------------------
-void VGrainlineItem::updateGeometry(const QPointF& position, qreal rotation, qreal length, ArrowType type)
+void VGrainlineItem::updateGeometry(const QPointF& position, qreal rotation, qreal length,
+                                    ArrowType type, qreal arrowLength)
 {
     m_rotation = qDegreesToRadians(rotation);
     m_length = length;
+    m_arrowLength = arrowLength;
+    m_arrowType = type;
 
     qreal dX;
     qreal dY;
@@ -216,7 +221,6 @@ void VGrainlineItem::updateGeometry(const QPointF& position, qreal rotation, qre
         point.setY(point.y() + dY);
     }
     setPos(point);
-    m_arrowType = type;
 
     updateRectangle();
     updateItem();
@@ -402,7 +406,7 @@ void VGrainlineItem::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
             deltaLength *= 2;
         }
         // limit length of grainline to twice the length of the arrowheads.
-        qreal minLength = qApp->Settings()->getDefaultArrowLength() * 2.0;
+        qreal minLength = m_arrowLength * 2.0;
         if (m_startLength + deltaLength < minLength)
         {
             return;
@@ -634,31 +638,21 @@ QLineF VGrainlineItem::mainLine() const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QPolygonF VGrainlineItem::firstArrow() const
+void VGrainlineItem::drawArrow(QPainter *painter, const QPointF &point, const qreal &addValue) const
 {
-    qreal arrowLength = qApp->Settings()->getDefaultArrowLength();
-    QPointF point2 = mainLine().p2();
-    QPolygonF polygon;
-    polygon << point2;
-    polygon << QPointF(point2.x() + arrowLength * cos(M_PI + m_rotation + ARROW_ANGLE),
-                       point2.y() - arrowLength * sin(M_PI + m_rotation + ARROW_ANGLE));
-    polygon << QPointF(point2.x() + arrowLength * cos(M_PI + m_rotation - ARROW_ANGLE),
-                       point2.y() - arrowLength * sin(M_PI + m_rotation - ARROW_ANGLE));
-    return polygon;
+    painter->drawPolygon(arrow(point, addValue));
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-QPolygonF VGrainlineItem::secondArrow() const
+QPolygonF VGrainlineItem::arrow(const QPointF &point, const qreal &addValue) const
 {
-    qreal arrowLength = qApp->Settings()->getDefaultArrowLength();
-    QPointF point1 = mainLine().p1();
     QPolygonF polygon;
-    polygon << point1;
-    polygon << QPointF(point1.x() + arrowLength * cos(m_rotation + ARROW_ANGLE),
-                       point1.y() - arrowLength * sin(m_rotation + ARROW_ANGLE));
-    polygon << QPointF(point1.x() + arrowLength * cos(m_rotation - ARROW_ANGLE),
-                       point1.y() - arrowLength * sin(m_rotation - ARROW_ANGLE));
-    return polygon;
+    polygon << point;
+    polygon << QPointF(point.x() + m_arrowLength * cos(addValue + m_rotation + ARROW_ANGLE),
+                       point.y() - m_arrowLength * sin(addValue + m_rotation + ARROW_ANGLE));
+    polygon << QPointF(point.x() + m_arrowLength * cos(addValue + m_rotation - ARROW_ANGLE),
+                       point.y() - m_arrowLength * sin(addValue + m_rotation - ARROW_ANGLE));
+     return polygon;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -677,20 +671,18 @@ QPainterPath VGrainlineItem::mainShape() const
     path.addPath((stroker.createStroke(linePath) + linePath).simplified());
     path.closeSubpath();
 
-    if (m_arrowType != ArrowType::Bottom)
+    if (m_arrowType != ArrowType::Top)
     {
-        // first arrow
         QPainterPath polyPath;
-        polyPath.addPolygon(firstArrow());
+        polyPath.addPolygon(arrow(mainLine().p1(), TOP_ARROW));
         path.addPath((stroker.createStroke(polyPath) + polyPath).simplified());
         path.closeSubpath();
     }
 
-    if (m_arrowType != ArrowType::Top)
+    if (m_arrowType != ArrowType::Bottom)
     {
-        // second arrow
         QPainterPath polyPath;
-        polyPath.addPolygon(secondArrow());
+        polyPath.addPolygon(arrow(mainLine().p2(), BOTTOM_ARROW));
         path.addPath((stroker.createStroke(polyPath) + polyPath).simplified());
         path.closeSubpath();
     }

--- a/src/libs/vwidgets/vgrainlineitem.h
+++ b/src/libs/vwidgets/vgrainlineitem.h
@@ -4,7 +4,7 @@
 //  @date   11 Nov, 2024
 //
 //  @copyright
-//  Copyright (C) 2017 - 2024 Seamly, LLC
+//  Copyright (C) 2017 - 2025 Seamly, LLC
 //  https://github.com/fashionfreedom/seamly2d
 //
 //  @brief
@@ -65,7 +65,7 @@ public:
     virtual QPainterPath shape() const Q_DECL_OVERRIDE;
 
     virtual void         paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) Q_DECL_OVERRIDE;
-    void                 updateGeometry(const QPointF& pos, qreal rotation, qreal length, ArrowType type);
+    void                 updateGeometry(const QPointF& pos, qreal rotation, qreal length, ArrowType type, qreal arrowLength);
 
     virtual int          type() const Q_DECL_OVERRIDE {return Type;}
     enum                 {Type = UserType + static_cast<int>(Vis::GrainlineItem)};
@@ -105,12 +105,12 @@ private:
     QPointF              m_centerPoint;
     qreal                m_angle;
     ArrowType            m_arrowType;
+    qreal                m_arrowLength;
     qreal                m_penWidth;
 
     QLineF               mainLine() const;
-    QPolygonF            firstArrow() const;
-    QPolygonF            secondArrow() const;
-
+    void                 drawArrow(QPainter *painter, const QPointF &point, const qreal &addValue) const;
+    QPolygonF            arrow(const QPointF &point, const qreal &addValue) const;
     QPainterPath         mainShape() const;
 
     void                 allUserModifications(const QPointF &pos);


### PR DESCRIPTION
This PR address issue #1387. It adds and fixes the following:

- Add a formula field fo the length of the grainline arrowheads instead of relying on a fixed length set in the preferences. This will alow a user to set different lengths for the arrowheads based ont he size of a pattern piece. 

<img width="1014" height="545" alt="Screenshot 2025-09-17 215104" src="https://github.com/user-attachments/assets/431d38ac-332f-4026-9ee3-0695dff35739" />


- Fixes the potential of a user entering a value in the grainline length formula less than the length of 2 arrows. 


<img width="430" height="89" alt="Screenshot 2025-09-17 231421" src="https://github.com/user-attachments/assets/72a00a49-694e-41cd-9f47-c69af6059f14" />

- Fixes the issue where toggling the grainline or labels had no effect on the layouts. Toggling either one off now hides   them in all pieces in Piece and Layout modes. 

<img width="207" height="38" alt="Screenshot 2025-09-18 165321" src="https://github.com/user-attachments/assets/6847962b-4b27-4adf-8ff6-d1f18356a2c3" />

- Fixes the geometry of the arrow heads in Layouts to match that of pieces in Piece mode. 

Now produces this:

<img width="203" height="243" alt="Screenshot 2025-09-18 235732" src="https://github.com/user-attachments/assets/1fd65d4e-7649-4a7a-bba4-f87824c2df0d" />


Instead of this:

<img width="243" height="230" alt="image" src="https://github.com/user-attachments/assets/39dd313e-e37e-451f-a578-a963149ef2c9" />


- Lupdate for changes in the grainline length error tooltip. 
 
<img width="525" height="58" alt="image" src="https://github.com/user-attachments/assets/0e1b65ed-1325-41ba-91fe-2b7989071e6c" />


Closes issue #1387 
