### PR TITLE
chore: replace deprecated macros

### DIFF
--- a/src/app/seamly2d/core/application_2d.cpp
+++ b/src/app/seamly2d/core/application_2d.cpp
@@ -86,7 +86,7 @@ Q_LOGGING_CATEGORY(vApp, "v.application")
 
 QT_WARNING_POP
 
-Q_DECL_CONSTEXPR auto DAYS_TO_KEEP_LOGS = 3;
+constexpr auto DAYS_TO_KEEP_LOGS = 3;
 
 //---------------------------------------------------------------------------------------------------------------------
 inline void noisyFailureMsgHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)

--- a/src/app/seamly2d/core/application_2d.h
+++ b/src/app/seamly2d/core/application_2d.h
@@ -72,9 +72,9 @@ class Application2D : public VAbstractApplication
     Q_OBJECT
 public:
                                        Application2D(int &argc, char **argv);
-    virtual                           ~Application2D() Q_DECL_OVERRIDE;
+    virtual                           ~Application2D() override;
     static void                        startNewSeamly2D(const QString &fileName = QString());
-    virtual bool                       notify(QObject *receiver, QEvent *event) Q_DECL_OVERRIDE;
+    virtual bool                       notify(QObject *receiver, QEvent *event) override;
 
     void                               initOptions();
 
@@ -88,17 +88,17 @@ public:
     void                               startLogging();
     QTextStream                       *logFile();
 
-    virtual const VTranslateVars      *translateVariables() Q_DECL_OVERRIDE;
+    virtual const VTranslateVars      *translateVariables() override;
 
     bool static                        isGUIMode();
-    virtual bool                       isAppInGUIMode() const Q_DECL_OVERRIDE;
+    virtual bool                       isAppInGUIMode() const override;
 
-    virtual void                       openSettings() Q_DECL_OVERRIDE;
+    virtual void                       openSettings() override;
     VSettings                         *Seamly2DSettings();
 
 protected:
-    virtual void                       initTranslateVariables() Q_DECL_OVERRIDE;
-    virtual bool	                   event(QEvent *e) Q_DECL_OVERRIDE;
+    virtual void                       initTranslateVariables() override;
+    virtual bool	                   event(QEvent *e) override;
 
 private:
     Q_DISABLE_COPY(Application2D)

--- a/src/app/seamly2d/core/vformulaproperty.h
+++ b/src/app/seamly2d/core/vformulaproperty.h
@@ -63,10 +63,10 @@ public:
     explicit VFormulaProperty(const QString &name);
 
     //! Get the data how it should be displayed
-    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const override;
 
     //! Returns item flags
-    virtual Qt::ItemFlags flags(int column = DPC_Name) const Q_DECL_OVERRIDE;
+    virtual Qt::ItemFlags flags(int column = DPC_Name) const override;
 
     //! Returns an editor widget, or NULL if it doesn't supply one
     //! \param parent The widget to which the editor will be added as a child
@@ -74,16 +74,16 @@ public:
     //! \delegate A pointer to the QAbstractItemDelegate requesting the editor. This can be used to connect signals and
     //! slots.
     virtual QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& options,
-                                  const QAbstractItemDelegate* delegate) Q_DECL_OVERRIDE;
+                                  const QAbstractItemDelegate* delegate) override;
 
     //! Sets the property's data to the editor (returns false, if the standard delegate should do that)
-    virtual bool setEditorData(QWidget* editor) Q_DECL_OVERRIDE;
+    virtual bool setEditorData(QWidget* editor) override;
 
     //! Gets the data from the widget
-    virtual QVariant getEditorData(const QWidget* editor) const Q_DECL_OVERRIDE;
+    virtual QVariant getEditorData(const QWidget* editor) const override;
 
     //! Returns a string containing the type of the property
-    virtual QString type() const Q_DECL_OVERRIDE;
+    virtual QString type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
@@ -91,13 +91,13 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty* clone(bool include_children = true,
-                                               VProperty* container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty* container = nullptr) const override;
 
     //! Sets the value of the property
-    virtual void setValue(const QVariant& value) Q_DECL_OVERRIDE;
+    virtual void setValue(const QVariant& value) override;
 
     //! Returns the value of the property as a QVariant
-    virtual QVariant getValue() const Q_DECL_OVERRIDE;
+    virtual QVariant getValue() const override;
 
     //! Returns the formula
     VFormula GetFormula() const;
@@ -106,7 +106,7 @@ public:
     void SetFormula(const VFormula &formula);
 
 public slots:
-    virtual void childValueChanged(const QVariant &value, int typeForParent) Q_DECL_OVERRIDE;
+    virtual void childValueChanged(const QVariant &value, int typeForParent) override;
 
 };
 

--- a/src/app/seamly2d/core/vformulapropertyeditor.h
+++ b/src/app/seamly2d/core/vformulapropertyeditor.h
@@ -80,7 +80,7 @@ public:
     VFormula      GetFormula() const;
 
     //! Needed for proper event handling
-    virtual bool  eventFilter(QObject *obj, QEvent *ev) Q_DECL_OVERRIDE;
+    virtual bool  eventFilter(QObject *obj, QEvent *ev) override;
 
 signals:
     //! This is emitted, when the user changes the color

--- a/src/app/seamly2d/dialogs/about2d_dialog.h
+++ b/src/app/seamly2d/dialogs/about2d_dialog.h
@@ -70,7 +70,7 @@ public:
     virtual              ~About2DAppDialog();
 
 protected:
-    virtual void          showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    virtual void          showEvent(QShowEvent *event) override;
 
 public slots:
 	void                  setProgressValue(int val);

--- a/src/app/seamly2d/dialogs/calculator_dialog.h
+++ b/src/app/seamly2d/dialogs/calculator_dialog.h
@@ -51,7 +51,7 @@ public:
     virtual ~CalculatorDialog();
 
 protected:
-    virtual void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    virtual void showEvent(QShowEvent *event) override;
 
 private:
     Ui::CalculatorDialog *ui;

--- a/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.h
+++ b/src/app/seamly2d/dialogs/configpages/preferencesconfigurationpage.h
@@ -73,7 +73,7 @@ public:
     void         apply();
 
 protected:
-    virtual void changeEvent(QEvent* event) Q_DECL_OVERRIDE;
+    virtual void changeEvent(QEvent* event) override;
 
 private:
     Q_DISABLE_COPY(PreferencesConfigurationPage)

--- a/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.h
+++ b/src/app/seamly2d/dialogs/configpages/preferencesgraphicsviewpage.h
@@ -47,7 +47,7 @@ public:
 
 protected:
     void                              enableOffsets();
-    virtual void                      changeEvent(QEvent *event) Q_DECL_OVERRIDE;
+    virtual void                      changeEvent(QEvent *event) override;
 
 private:
     Q_DISABLE_COPY(PreferencesGraphicsViewPage )

--- a/src/app/seamly2d/dialogs/configpages/preferencespathpage.h
+++ b/src/app/seamly2d/dialogs/configpages/preferencespathpage.h
@@ -71,7 +71,7 @@ public:
     void          Apply();
 
 protected:
-    virtual void  changeEvent(QEvent* event) Q_DECL_OVERRIDE;
+    virtual void  changeEvent(QEvent* event) override;
 
 private slots:
     void          defaultPath();

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.h
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.h
@@ -78,7 +78,7 @@ public:
     void          initDefaultSeamAllowance();
 
 protected:
-    virtual void  changeEvent(QEvent* event) Q_DECL_OVERRIDE;
+    virtual void  changeEvent(QEvent* event) override;
 
 private slots:
     void          editDateTimeFormats();

--- a/src/app/seamly2d/dialogs/decimalchart_dialog.h
+++ b/src/app/seamly2d/dialogs/decimalchart_dialog.h
@@ -45,7 +45,7 @@ public:
     virtual ~DecimalChartDialog();
 
 protected:
-    virtual void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    virtual void showEvent(QShowEvent *event) override;
 
 private:
     Ui::DecimalChartDialog *ui;

--- a/src/app/seamly2d/dialogs/dialoglayoutprogress.h
+++ b/src/app/seamly2d/dialogs/dialoglayoutprogress.h
@@ -79,7 +79,7 @@ public slots:
     void Finished();
 
 protected:
-    virtual void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    virtual void showEvent(QShowEvent *event) override;
 
 private:
     Q_DISABLE_COPY(DialogLayoutProgress)

--- a/src/app/seamly2d/dialogs/dialogpatternproperties.h
+++ b/src/app/seamly2d/dialogs/dialogpatternproperties.h
@@ -70,7 +70,7 @@ class DialogPatternProperties : public QDialog
     Q_OBJECT
 public:
     explicit DialogPatternProperties(VPattern *doc, VContainer *pattern, QWidget *parent = nullptr);
-    virtual ~DialogPatternProperties() Q_DECL_OVERRIDE;
+    virtual ~DialogPatternProperties() override;
 signals:
     void UpdateGradation();
 private slots:

--- a/src/app/seamly2d/dialogs/dialogpreferences.h
+++ b/src/app/seamly2d/dialogs/dialogpreferences.h
@@ -82,9 +82,9 @@ signals:
     void                          updateProperties();
 
 protected:
-    virtual void                  changeEvent(QEvent* event) Q_DECL_OVERRIDE;
-    virtual void                  showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
-    virtual void                  resizeEvent(QResizeEvent *event) Q_DECL_OVERRIDE;
+    virtual void                  changeEvent(QEvent* event) override;
+    virtual void                  showEvent(QShowEvent *event) override;
+    virtual void                  resizeEvent(QResizeEvent *event) override;
 
 private slots:
     void                          pageChanged(QListWidgetItem *current, QListWidgetItem *previous);

--- a/src/app/seamly2d/dialogs/dialogvariables.h
+++ b/src/app/seamly2d/dialogs/dialogvariables.h
@@ -74,17 +74,17 @@ class DialogVariables : public DialogTool
     Q_OBJECT
 public:
                                      DialogVariables(VContainer *data, VPattern *doc, QWidget *parent = nullptr);
-    virtual                         ~DialogVariables() Q_DECL_OVERRIDE;
+    virtual                         ~DialogVariables() override;
 
 signals:
     void                             updateProperties();
 
 protected:
-    virtual void                     closeEvent ( QCloseEvent * event ) Q_DECL_OVERRIDE;
-    virtual void                     changeEvent ( QEvent * event) Q_DECL_OVERRIDE;
-    virtual bool                     eventFilter(QObject *object, QEvent *event) Q_DECL_OVERRIDE;
-    virtual void                     showEvent( QShowEvent *event ) Q_DECL_OVERRIDE;
-    virtual void                     resizeEvent(QResizeEvent *event) Q_DECL_OVERRIDE;
+    virtual void                     closeEvent ( QCloseEvent * event ) override;
+    virtual void                     changeEvent ( QEvent * event) override;
+    virtual bool                     eventFilter(QObject *object, QEvent *event) override;
+    virtual void                     showEvent( QShowEvent *event ) override;
+    virtual void                     resizeEvent(QResizeEvent *event) override;
 
 private slots:
     void                             showCustomVariableDetails();

--- a/src/app/seamly2d/dialogs/export_layout_dialog.h
+++ b/src/app/seamly2d/dialogs/export_layout_dialog.h
@@ -77,7 +77,7 @@ public:
     void                  setTextAsPaths(bool textAsPaths);
 
 protected:
-    virtual void          showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    virtual void          showEvent(QShowEvent *event) override;
     void                  initTemplates(QComboBox *templates);
 
 private slots:

--- a/src/app/seamly2d/dialogs/groups_widget.h
+++ b/src/app/seamly2d/dialogs/groups_widget.h
@@ -99,7 +99,7 @@ private slots:
     void              groupContextMenu(const QPoint &pos);
     void              draftBlockHasGroups(bool value);
  protected:
-    virtual void      changeEvent(QEvent* event) Q_DECL_OVERRIDE;
+    virtual void      changeEvent(QEvent* event) override;
 
 private:
     Q_DISABLE_COPY(GroupsWidget)

--- a/src/app/seamly2d/dialogs/layoutsettings_dialog.h
+++ b/src/app/seamly2d/dialogs/layoutsettings_dialog.h
@@ -127,7 +127,7 @@ public:
     static QString    MakeGroupsHelp();
 
 protected:
-    virtual void      showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    virtual void      showEvent(QShowEvent *event) override;
     QSizeF            getTemplateSize(const PaperSizeFormat &tmpl, const Unit &unit) const;
 
 public slots:

--- a/src/app/seamly2d/dialogs/pieces_widget.h
+++ b/src/app/seamly2d/dialogs/pieces_widget.h
@@ -87,7 +87,7 @@ private slots:
     void               showContextMenu(const QPoint &pos);
 
 protected:
-    virtual void       changeEvent(QEvent* event) Q_DECL_OVERRIDE;
+    virtual void       changeEvent(QEvent* event) override;
 
 private:
     Q_DISABLE_COPY(PiecesWidget)

--- a/src/app/seamly2d/dialogs/shortcuts_dialog.h
+++ b/src/app/seamly2d/dialogs/shortcuts_dialog.h
@@ -45,7 +45,7 @@ public:
     virtual ~ShortcutsDialog();
 
 protected:
-    virtual void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    virtual void showEvent(QShowEvent *event) override;
 
 private:
     Ui::ShortcutsDialog *ui;

--- a/src/app/seamly2d/dialogs/show_info_dialog.h
+++ b/src/app/seamly2d/dialogs/show_info_dialog.h
@@ -48,7 +48,7 @@ public:
     virtual            ~ShowInfoDialog();
 
 protected:
-    virtual void        showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    virtual void        showEvent(QShowEvent *event) override;
 
 private:
     Ui::ShowInfoDialog *ui;

--- a/src/app/seamly2d/mainwindow.h
+++ b/src/app/seamly2d/mainwindow.h
@@ -103,7 +103,7 @@ class MainWindow : public MainWindowsNoGUI
     Q_OBJECT
 public:
     explicit MainWindow(QWidget *parent = nullptr);
-    virtual ~MainWindow() Q_DECL_OVERRIDE;
+    virtual ~MainWindow() override;
 
     bool LoadPattern(const QString &fileName, const QString &customMeasureFile = QString());
 
@@ -112,9 +112,9 @@ public slots:
     void penChanged(Pen pen);
     void basePointChanged();
 
-    virtual void setStatusMessage(const QString &message) Q_DECL_OVERRIDE;
-    virtual void updateGroups() Q_DECL_OVERRIDE;
-    virtual void zoomToSelected() Q_DECL_OVERRIDE;
+    virtual void setStatusMessage(const QString &message) override;
+    virtual void updateGroups() override;
+    virtual void zoomToSelected() override;
     void         showAllGroups();
     void         hideAllGroups();
     void         lockAllGroups();
@@ -156,15 +156,15 @@ signals:
     void signalZoomPanActive(bool enable) const;
 
 protected:
-    virtual void keyPressEvent(QKeyEvent *event) Q_DECL_OVERRIDE;
-    virtual void keyReleaseEvent(QKeyEvent *event) Q_DECL_OVERRIDE;
-    virtual void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
-    virtual void changeEvent(QEvent* event) Q_DECL_OVERRIDE;
-    virtual void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
-    virtual void customEvent(QEvent * event) Q_DECL_OVERRIDE;
-    virtual void CleanLayout() Q_DECL_OVERRIDE;
-    virtual void PrepareSceneList() Q_DECL_OVERRIDE;
-    virtual void exportToCSVData(const QString &fileName, const DialogExportToCSV &dialog) Q_DECL_FINAL;
+    virtual void keyPressEvent(QKeyEvent *event) override;
+    virtual void keyReleaseEvent(QKeyEvent *event) override;
+    virtual void showEvent(QShowEvent *event) override;
+    virtual void changeEvent(QEvent* event) override;
+    virtual void closeEvent(QCloseEvent *event) override;
+    virtual void customEvent(QEvent * event) override;
+    virtual void CleanLayout() override;
+    virtual void PrepareSceneList() override;
+    virtual void exportToCSVData(const QString &fileName, const DialogExportToCSV &dialog) final;
     void         handleExportToCSV();
 
 private slots:

--- a/src/app/seamly2d/mainwindowsnogui.h
+++ b/src/app/seamly2d/mainwindowsnogui.h
@@ -72,7 +72,7 @@ class MainWindowsNoGUI : public VAbstractMainWindow
     Q_OBJECT
 public:
     explicit MainWindowsNoGUI(QWidget *parent = nullptr);
-    virtual ~MainWindowsNoGUI() Q_DECL_OVERRIDE;
+    virtual ~MainWindowsNoGUI() override;
 
 public slots:
     void toolLayoutSettings(QToolButton *tButton, bool checked);

--- a/src/app/seamly2d/xml/vpattern.h
+++ b/src/app/seamly2d/xml/vpattern.h
@@ -71,15 +71,15 @@ public:
     VPattern(VContainer *data, VMainGraphicsScene *draftScene, VMainGraphicsScene *pieceScene,
              QObject *parent = nullptr);
 
-    virtual void   CreateEmptyFile() Q_DECL_OVERRIDE;
+    virtual void   CreateEmptyFile() override;
 
     void           Parse(const Document &parse);
 
     void           setCurrentData();
-    virtual void   UpdateToolData(const quint32 &id, VContainer *data) Q_DECL_OVERRIDE;
+    virtual void   UpdateToolData(const quint32 &id, VContainer *data) override;
 
-    virtual void   IncrementReferens(quint32 id) const Q_DECL_OVERRIDE;
-    virtual void   DecrementReferens(quint32 id) const Q_DECL_OVERRIDE;
+    virtual void   IncrementReferens(quint32 id) const override;
+    virtual void   DecrementReferens(quint32 id) const override;
 
     quint32        getActiveBasePoint();
 
@@ -88,8 +88,8 @@ public:
 
     QVector<quint32> getActivePatternPieces() const;
 
-    virtual void   setXMLContent(const QString &fileName) Q_DECL_OVERRIDE;
-    virtual bool   SaveDocument(const QString &fileName, QString &error) Q_DECL_OVERRIDE;
+    virtual void   setXMLContent(const QString &fileName) override;
+    virtual bool   SaveDocument(const QString &fileName, QString &error) override;
 
     QRectF         ActiveDrawBoundingRect() const;
 
@@ -107,8 +107,8 @@ public:
 
     QStringList    GetCurrentAlphabet() const;
 
-    virtual QString GenerateLabel(const LabelType &type, const QString &reservedName = QString())const Q_DECL_OVERRIDE;
-    virtual QString GenerateSuffix(const QString &type) const Q_DECL_OVERRIDE;
+    virtual QString GenerateLabel(const LabelType &type, const QString &reservedName = QString())const override;
+    virtual QString GenerateSuffix(const QString &type) const override;
 
     bool IsDefCustom() const;
     void SetDefCustom(bool value);
@@ -130,10 +130,10 @@ signals:
     void             setStatusMessage(QString message);
 
 public slots:
-    virtual void LiteParseTree(const Document &parse) Q_DECL_OVERRIDE;
+    virtual void LiteParseTree(const Document &parse) override;
 
 protected:
-    virtual void   customEvent(QEvent * event) Q_DECL_OVERRIDE;
+    virtual void   customEvent(QEvent * event) override;
 
 private:
     Q_DISABLE_COPY(VPattern)

--- a/src/app/seamlyme/application_me.h
+++ b/src/app/seamlyme/application_me.h
@@ -76,21 +76,21 @@ class ApplicationME : public VAbstractApplication
 
 public:
                                         ApplicationME(int &argc, char **argv);
-    virtual                            ~ApplicationME() Q_DECL_OVERRIDE;
+    virtual                            ~ApplicationME() override;
 
-    virtual bool                        notify(QObject * receiver, QEvent * event) Q_DECL_OVERRIDE;
+    virtual bool                        notify(QObject * receiver, QEvent * event) override;
 
     bool                                isTestMode() const;
-    virtual bool                        isAppInGUIMode() const Q_DECL_OVERRIDE;
+    virtual bool                        isAppInGUIMode() const override;
     TMainWindow                        *mainWindow();
     QList<TMainWindow*>                 mainWindows();
     TMainWindow                        *newMainWindow();
 
     void                                initOptions();
 
-    virtual const VTranslateVars       *translateVariables() Q_DECL_OVERRIDE;
+    virtual const VTranslateVars       *translateVariables() override;
 
-    virtual void                        openSettings() Q_DECL_OVERRIDE;
+    virtual void                        openSettings() override;
     VSeamlyMeSettings                  *seamlyMeSettings();
 
     void                                showDataBase();
@@ -103,8 +103,8 @@ public slots:
     void                                processCommandLine();
 
 protected:
-    virtual void                        initTranslateVariables() Q_DECL_OVERRIDE;
-    virtual bool                        event(QEvent *e) Q_DECL_OVERRIDE;
+    virtual void                        initTranslateVariables() override;
+    virtual bool                        event(QEvent *e) override;
 
 private slots:
     void                                newLocalSocketConnection();

--- a/src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.h
+++ b/src/app/seamlyme/dialogs/configpages/seamlymepreferencesconfigurationpage.h
@@ -76,7 +76,7 @@ public:
     void          Apply();
 
 protected:
-    virtual void  changeEvent(QEvent* event) Q_DECL_OVERRIDE;
+    virtual void  changeEvent(QEvent* event) override;
 
 private:
     Q_DISABLE_COPY(SeamlyMePreferencesConfigurationPage)

--- a/src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.h
+++ b/src/app/seamlyme/dialogs/configpages/seamlymepreferencespathpage.h
@@ -74,7 +74,7 @@ public:
     void          Apply();
 
 protected:
-    virtual void  changeEvent(QEvent* event) Q_DECL_OVERRIDE;
+    virtual void  changeEvent(QEvent* event) override;
 
 private slots:
     void          defaultPath();

--- a/src/app/seamlyme/dialogs/dialogaboutseamlyme.h
+++ b/src/app/seamlyme/dialogs/dialogaboutseamlyme.h
@@ -68,8 +68,8 @@ public:
     virtual ~DialogAboutSeamlyMe();
 
 protected:
-    virtual void changeEvent(QEvent* event) Q_DECL_OVERRIDE;
-    virtual void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    virtual void changeEvent(QEvent* event) override;
+    virtual void showEvent(QShowEvent *event) override;
 
 public slots:
 	void setProgressValue(int val);

--- a/src/app/seamlyme/dialogs/dialogmdatabase.h
+++ b/src/app/seamlyme/dialogs/dialogmdatabase.h
@@ -68,7 +68,7 @@ class MeasurementDatabaseDialog : public QDialog
 public:
     explicit             MeasurementDatabaseDialog(const QStringList &measurements, QWidget *parent = nullptr);
     explicit             MeasurementDatabaseDialog(QWidget *parent = nullptr);
-    virtual             ~MeasurementDatabaseDialog() Q_DECL_OVERRIDE;
+    virtual             ~MeasurementDatabaseDialog() override;
 
     void                 retranslateGroups();
 
@@ -76,8 +76,8 @@ public:
     static QString       imageUrl(const QString &number);
 
 protected:
-    virtual void         changeEvent(QEvent* event) Q_DECL_OVERRIDE;
-    virtual bool         eventFilter(QObject *target, QEvent *event) Q_DECL_OVERRIDE;
+    virtual void         changeEvent(QEvent* event) override;
+    virtual bool         eventFilter(QObject *target, QEvent *event) override;
 
 private slots:
     void                 updateChecks(QTreeWidgetItem *item, int column);

--- a/src/app/seamlyme/dialogs/dialogseamlymepreferences.h
+++ b/src/app/seamlyme/dialogs/dialogseamlymepreferences.h
@@ -79,9 +79,9 @@ signals:
     void          updateProperties();
 
 protected:
-    virtual void  changeEvent(QEvent* event) Q_DECL_OVERRIDE;
-    virtual void  showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
-    virtual void  resizeEvent(QResizeEvent *event) Q_DECL_OVERRIDE;
+    virtual void  changeEvent(QEvent* event) override;
+    virtual void  showEvent(QShowEvent *event) override;
+    virtual void  resizeEvent(QResizeEvent *event) override;
 
 private slots:
     void          Apply();

--- a/src/app/seamlyme/dialogs/me_shortcuts_dialog.h
+++ b/src/app/seamlyme/dialogs/me_shortcuts_dialog.h
@@ -45,7 +45,7 @@ public:
     virtual ~MeShortcutsDialog();
 
 protected:
-    virtual void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    virtual void showEvent(QShowEvent *event) override;
 
 private:
     Ui::MeShortcutsDialog *ui;

--- a/src/app/seamlyme/dialogs/new_measurements_dialog.h
+++ b/src/app/seamlyme/dialogs/new_measurements_dialog.h
@@ -76,8 +76,8 @@ public:
     int                        baseHeight() const;
 
 protected:
-    virtual void               changeEvent(QEvent* event) Q_DECL_OVERRIDE;
-    virtual void               showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    virtual void               changeEvent(QEvent* event) override;
+    virtual void               showEvent(QShowEvent *event) override;
 
 private slots:
     void                       currentTypeChanged(int index);

--- a/src/app/seamlyme/tmainwindow.h
+++ b/src/app/seamlyme/tmainwindow.h
@@ -80,7 +80,7 @@ class TMainWindow : public VAbstractMainWindow
 
 public:
     explicit            TMainWindow(QWidget *parent = nullptr);
-    virtual            ~TMainWindow() Q_DECL_OVERRIDE;
+    virtual            ~TMainWindow() override;
 
     QString             CurrentFile() const;
 
@@ -93,16 +93,16 @@ public:
     bool                LoadFile(const QString &path);
 
 public slots:
-    virtual void        setStatusMessage(const QString &toolTip) Q_DECL_OVERRIDE;
-    virtual void        zoomToSelected() Q_DECL_OVERRIDE;
-    virtual void        updateGroups() Q_DECL_OVERRIDE;
+    virtual void        setStatusMessage(const QString &toolTip) override;
+    virtual void        zoomToSelected() override;
+    virtual void        updateGroups() override;
 
 protected:
-    virtual void        closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
-    virtual void        changeEvent(QEvent* event) Q_DECL_OVERRIDE;
-    virtual void        showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
-    virtual bool        eventFilter(QObject *object, QEvent *event) Q_DECL_OVERRIDE;
-    virtual void        exportToCSVData(const QString &fileName, const DialogExportToCSV &dialog) Q_DECL_FINAL;
+    virtual void        closeEvent(QCloseEvent *event) override;
+    virtual void        changeEvent(QEvent* event) override;
+    virtual void        showEvent(QShowEvent *event) override;
+    virtual bool        eventFilter(QObject *object, QEvent *event) override;
+    virtual void        exportToCSVData(const QString &fileName, const DialogExportToCSV &dialog) final;
     void                handleExportToCSV();
 
 private slots:

--- a/src/app/seamlyme/vlitepattern.h
+++ b/src/app/seamlyme/vlitepattern.h
@@ -60,18 +60,18 @@ class VLitePattern : public VAbstractPattern
 public:
     explicit VLitePattern(QObject *parent = nullptr);
 
-    virtual void    CreateEmptyFile() Q_DECL_OVERRIDE;
+    virtual void    CreateEmptyFile() override;
 
-    virtual void    IncrementReferens(quint32 id) const Q_DECL_OVERRIDE;
-    virtual void    DecrementReferens(quint32 id) const Q_DECL_OVERRIDE;
-    virtual QStringList GetCurrentAlphabet() const Q_DECL_OVERRIDE;
-    virtual QString GenerateLabel(const LabelType &type, const QString &reservedName = QString())const Q_DECL_OVERRIDE;
-    virtual QString GenerateSuffix(const QString &type) const Q_DECL_OVERRIDE;
+    virtual void    IncrementReferens(quint32 id) const override;
+    virtual void    DecrementReferens(quint32 id) const override;
+    virtual QStringList GetCurrentAlphabet() const override;
+    virtual QString GenerateLabel(const LabelType &type, const QString &reservedName = QString())const override;
+    virtual QString GenerateSuffix(const QString &type) const override;
 
-    virtual void    UpdateToolData(const quint32 &id, VContainer *data) Q_DECL_OVERRIDE;
+    virtual void    UpdateToolData(const quint32 &id, VContainer *data) override;
 
 public slots:
-    virtual void    LiteParseTree(const Document &parse) Q_DECL_OVERRIDE;
+    virtual void    LiteParseTree(const Document &parse) override;
 
 private:
     Q_DISABLE_COPY(VLitePattern)

--- a/src/libs/ifc/exception/vexception.h
+++ b/src/libs/ifc/exception/vexception.h
@@ -71,17 +71,17 @@ public:
     VException &operator=(const VException &error);
     virtual ~VException() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
 
-    Q_NORETURN virtual void raise() const Q_DECL_OVERRIDE;
+    Q_NORETURN virtual void raise() const override;
 
     // cppcheck-suppress unusedFunction
-    Q_REQUIRED_RESULT virtual VException *clone() const Q_DECL_OVERRIDE;
+    Q_REQUIRED_RESULT virtual VException *clone() const override;
 
     virtual QString ErrorMessage() const;
     virtual QString DetailedInformation() const;
     QString         WhatUtf8() const V_NOEXCEPT_EXPR (true);
     void            AddMoreInformation(const QString &info);
     QString         MoreInformation() const;
-    virtual const char* what() const V_NOEXCEPT_EXPR (true) Q_DECL_OVERRIDE;
+    virtual const char* what() const V_NOEXCEPT_EXPR (true) override;
 
 protected:
     /** @brief error string with error */
@@ -123,9 +123,9 @@ public:
     VExceptionToolWasDeleted &operator=(const VExceptionToolWasDeleted &error);
     virtual ~VExceptionToolWasDeleted() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
 
-    Q_NORETURN virtual void raise() const Q_DECL_OVERRIDE;
+    Q_NORETURN virtual void raise() const override;
     // cppcheck-suppress unusedFunction
-    virtual VExceptionToolWasDeleted *clone() const Q_DECL_OVERRIDE;
+    virtual VExceptionToolWasDeleted *clone() const override;
 };
 
 #endif // VEXCEPTION_H

--- a/src/libs/ifc/exception/vexceptionbadid.h
+++ b/src/libs/ifc/exception/vexceptionbadid.h
@@ -70,7 +70,7 @@ public:
     VExceptionBadId(const VExceptionBadId &error);
     VExceptionBadId &operator=(const VExceptionBadId &error);
     virtual         ~VExceptionBadId() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
-    virtual QString ErrorMessage() const Q_DECL_OVERRIDE;
+    virtual QString ErrorMessage() const override;
     quint32         BadId() const;
     QString         BadKey() const;
 protected:

--- a/src/libs/ifc/exception/vexceptionconversionerror.h
+++ b/src/libs/ifc/exception/vexceptionconversionerror.h
@@ -69,7 +69,7 @@ public:
     VExceptionConversionError(const VExceptionConversionError &error);
     VExceptionConversionError &operator=(const VExceptionConversionError &error);
     virtual         ~VExceptionConversionError() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
-    virtual QString ErrorMessage() const Q_DECL_OVERRIDE;
+    virtual QString ErrorMessage() const override;
     QString         String() const;
 protected:
     /** @brief str string, where happend error */

--- a/src/libs/ifc/exception/vexceptionemptyparameter.h
+++ b/src/libs/ifc/exception/vexceptionemptyparameter.h
@@ -71,8 +71,8 @@ public:
     VExceptionEmptyParameter(const VExceptionEmptyParameter &error);
     VExceptionEmptyParameter &operator=(const VExceptionEmptyParameter &error);
     virtual         ~VExceptionEmptyParameter() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
-    virtual QString ErrorMessage() const Q_DECL_OVERRIDE;
-    virtual QString DetailedInformation() const Q_DECL_OVERRIDE;
+    virtual QString ErrorMessage() const override;
+    virtual QString DetailedInformation() const override;
     QString         Name() const;
     QString         TagText() const;
     QString         TagName() const;

--- a/src/libs/ifc/exception/vexceptionobjecterror.h
+++ b/src/libs/ifc/exception/vexceptionobjecterror.h
@@ -71,8 +71,8 @@ public:
     VExceptionObjectError(const VExceptionObjectError &error);
     VExceptionObjectError &operator=(const VExceptionObjectError &error);
     virtual ~VExceptionObjectError() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
-    virtual QString ErrorMessage() const Q_DECL_OVERRIDE;
-    virtual QString DetailedInformation() const Q_DECL_OVERRIDE;
+    virtual QString ErrorMessage() const override;
+    virtual QString DetailedInformation() const override;
     QString         TagText() const;
     QString         TagName() const;
     qint32          LineNumber() const;

--- a/src/libs/ifc/exception/vexceptionwrongid.h
+++ b/src/libs/ifc/exception/vexceptionwrongid.h
@@ -72,8 +72,8 @@ public:
                     VExceptionWrongId(const VExceptionWrongId &error);
                     VExceptionWrongId &operator=(const VExceptionWrongId &error);
     virtual        ~VExceptionWrongId() V_NOEXCEPT_EXPR (true) Q_DECL_EQ_DEFAULT;
-    virtual QString ErrorMessage() const Q_DECL_OVERRIDE;
-    virtual QString DetailedInformation() const Q_DECL_OVERRIDE;
+    virtual QString ErrorMessage() const override;
+    virtual QString DetailedInformation() const override;
     QString         TagText() const;
     QString         TagName() const;
     qint32          LineNumber() const;

--- a/src/libs/ifc/xml/individual_size_converter.h
+++ b/src/libs/ifc/xml/individual_size_converter.h
@@ -78,24 +78,24 @@ public:
 
 // GCC 4.6 doesn't allow constexpr and const together
 #if !defined(__INTEL_COMPILER) && !defined(__clang__) && defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) <= 406
-    static Q_DECL_CONSTEXPR int MeasurementMinVer = CONVERTER_VERSION_CHECK(0, 2, 0);
-    static Q_DECL_CONSTEXPR int MeasurementMaxVer = CONVERTER_VERSION_CHECK(0, 3, 4);
+    static constexpr int MeasurementMinVer = CONVERTER_VERSION_CHECK(0, 2, 0);
+    static constexpr int MeasurementMaxVer = CONVERTER_VERSION_CHECK(0, 3, 4);
 #else
-    static Q_DECL_CONSTEXPR const int MeasurementMinVer = CONVERTER_VERSION_CHECK(0, 2, 0);
-    static Q_DECL_CONSTEXPR const int MeasurementMaxVer = CONVERTER_VERSION_CHECK(0, 3, 4);
+    static constexpr const int MeasurementMinVer = CONVERTER_VERSION_CHECK(0, 2, 0);
+    static constexpr const int MeasurementMaxVer = CONVERTER_VERSION_CHECK(0, 3, 4);
 #endif
 
 protected:
-    virtual int          minVer() const Q_DECL_OVERRIDE;
-    virtual int          maxVer() const Q_DECL_OVERRIDE;
+    virtual int          minVer() const override;
+    virtual int          maxVer() const override;
 
-    virtual QString      minVerStr() const Q_DECL_OVERRIDE;
-    virtual QString      maxVerStr() const Q_DECL_OVERRIDE;
+    virtual QString      minVerStr() const override;
+    virtual QString      maxVerStr() const override;
 
-    virtual QString      getSchema(int ver) const Q_DECL_OVERRIDE;
-    virtual void         applyPatches() Q_DECL_OVERRIDE;
-    virtual void         downgradeToCurrentMaxVersion() Q_DECL_OVERRIDE;
-    virtual bool         isReadOnly() const Q_DECL_OVERRIDE;
+    virtual QString      getSchema(int ver) const override;
+    virtual void         applyPatches() override;
+    virtual void         downgradeToCurrentMaxVersion() override;
+    virtual bool         isReadOnly() const override;
 
 private:
     Q_DISABLE_COPY(IndividualSizeConverter)

--- a/src/libs/ifc/xml/multi_size_converter.h
+++ b/src/libs/ifc/xml/multi_size_converter.h
@@ -77,24 +77,24 @@ public:
     static const QString CurrentSchema;
 // GCC 4.6 doesn't allow constexpr and const together
 #if !defined(__INTEL_COMPILER) && !defined(__clang__) && defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__) <= 406
-    static Q_DECL_CONSTEXPR int MeasurementMinVer = CONVERTER_VERSION_CHECK(0, 3, 0);
-    static Q_DECL_CONSTEXPR int MeasurementMaxVer = CONVERTER_VERSION_CHECK(0, 4, 5);
+    static constexpr int MeasurementMinVer = CONVERTER_VERSION_CHECK(0, 3, 0);
+    static constexpr int MeasurementMaxVer = CONVERTER_VERSION_CHECK(0, 4, 5);
 #else
-    static Q_DECL_CONSTEXPR const int MeasurementMinVer = CONVERTER_VERSION_CHECK(0, 3, 0);
-    static Q_DECL_CONSTEXPR const int MeasurementMaxVer = CONVERTER_VERSION_CHECK(0, 4, 5);
+    static constexpr const int MeasurementMinVer = CONVERTER_VERSION_CHECK(0, 3, 0);
+    static constexpr const int MeasurementMaxVer = CONVERTER_VERSION_CHECK(0, 4, 5);
 #endif
 
 protected:
-    virtual int     minVer() const Q_DECL_OVERRIDE;
-    virtual int     maxVer() const Q_DECL_OVERRIDE;
+    virtual int     minVer() const override;
+    virtual int     maxVer() const override;
 
-    virtual QString minVerStr() const Q_DECL_OVERRIDE;
-    virtual QString maxVerStr() const Q_DECL_OVERRIDE;
+    virtual QString minVerStr() const override;
+    virtual QString maxVerStr() const override;
 
-    virtual QString getSchema(int ver) const Q_DECL_OVERRIDE;
-    virtual void    applyPatches() Q_DECL_OVERRIDE;
-    virtual void    downgradeToCurrentMaxVersion() Q_DECL_OVERRIDE;
-    virtual bool    isReadOnly() const Q_DECL_OVERRIDE;
+    virtual QString getSchema(int ver) const override;
+    virtual void    applyPatches() override;
+    virtual void    downgradeToCurrentMaxVersion() override;
+    virtual bool    isReadOnly() const override;
 
 private:
     Q_DISABLE_COPY(MultiSizeConverter)

--- a/src/libs/ifc/xml/vlabeltemplateconverter.h
+++ b/src/libs/ifc/xml/vlabeltemplateconverter.h
@@ -66,21 +66,21 @@ public:
 
     static const QString LabelTemplateMaxVerStr;
     static const QString CurrentSchema;
-    static Q_DECL_CONSTEXPR const int LabelTemplateMinVer = CONVERTER_VERSION_CHECK(1, 0, 0);
-    static Q_DECL_CONSTEXPR const int LabelTemplateMaxVer = CONVERTER_VERSION_CHECK(1, 0, 0);
+    static constexpr const int LabelTemplateMinVer = CONVERTER_VERSION_CHECK(1, 0, 0);
+    static constexpr const int LabelTemplateMaxVer = CONVERTER_VERSION_CHECK(1, 0, 0);
 
 protected:
-    virtual int     minVer() const Q_DECL_OVERRIDE;
-    virtual int     maxVer() const Q_DECL_OVERRIDE;
+    virtual int     minVer() const override;
+    virtual int     maxVer() const override;
 
-    virtual QString minVerStr() const Q_DECL_OVERRIDE;
-    virtual QString maxVerStr() const Q_DECL_OVERRIDE;
+    virtual QString minVerStr() const override;
+    virtual QString maxVerStr() const override;
 
-    virtual QString getSchema(int ver) const Q_DECL_OVERRIDE;
-    virtual void    applyPatches() Q_DECL_OVERRIDE;
-    virtual void    downgradeToCurrentMaxVersion() Q_DECL_OVERRIDE;
+    virtual QString getSchema(int ver) const override;
+    virtual void    applyPatches() override;
+    virtual void    downgradeToCurrentMaxVersion() override;
 
-    virtual bool isReadOnly() const Q_DECL_OVERRIDE {return false;}
+    virtual bool isReadOnly() const override {return false;}
 
 private:
     Q_DISABLE_COPY(VLabelTemplateConverter)

--- a/src/libs/ifc/xml/vpatternconverter.h
+++ b/src/libs/ifc/xml/vpatternconverter.h
@@ -74,8 +74,8 @@ public:
 
     static const QString PatternMaxVerStr;
     static const QString CurrentSchema;
-    static Q_DECL_CONSTEXPR const int PatternMinVer = CONVERTER_VERSION_CHECK(0, 1, 0);
-    static Q_DECL_CONSTEXPR const int PatternMaxVer = CONVERTER_VERSION_CHECK(0, 7, 3);
+    static constexpr const int PatternMinVer = CONVERTER_VERSION_CHECK(0, 1, 0);
+    static constexpr const int PatternMaxVer = CONVERTER_VERSION_CHECK(0, 7, 3);
 
 protected:
     virtual int     minVer() const override;

--- a/src/libs/qmuparser/qmuformulabase.h
+++ b/src/libs/qmuparser/qmuformulabase.h
@@ -61,9 +61,9 @@ class QmuFormulaBase : public QmuParser
 {
 public:
                   QmuFormulaBase();
-    virtual      ~QmuFormulaBase() Q_DECL_OVERRIDE;
+    virtual      ~QmuFormulaBase() override;
 
-    virtual void  InitCharSets() Q_DECL_OVERRIDE;
+    virtual void  InitCharSets() override;
 
     static void   RemoveAll(QMap<int, QString> &map, const QString &val);
 

--- a/src/libs/qmuparser/qmuparser.h
+++ b/src/libs/qmuparser/qmuparser.h
@@ -50,11 +50,11 @@ namespace qmu
     {
     public:
         QmuParser();
-        virtual void InitCharSets() Q_DECL_OVERRIDE;
-        virtual void InitFun() Q_DECL_OVERRIDE;
-        virtual void InitConst() Q_DECL_OVERRIDE;
-        virtual void InitOprt() Q_DECL_OVERRIDE;
-        virtual void OnDetectVar(const QString &pExpr, int &nStart, int &nEnd) Q_DECL_OVERRIDE;
+        virtual void InitCharSets() override;
+        virtual void InitFun() override;
+        virtual void InitConst() override;
+        virtual void InitOprt() override;
+        virtual void OnDetectVar(const QString &pExpr, int &nStart, int &nEnd) override;
         qreal        Diff(qreal *a_Var, qreal a_fPos, qreal a_fEpsilon = 0) const;
     protected:
         static int   IsVal(const QString &a_szExpr, int *a_iPos, qreal *a_fVal, const QLocale &locale,

--- a/src/libs/qmuparser/qmuparserbase.h
+++ b/src/libs/qmuparser/qmuparserbase.h
@@ -180,17 +180,17 @@ protected:
             :std::numpunct<TChar>(), m_nGroup(nGroup), m_cDecPoint(cDecSep), m_cThousandsSep(cThousandsSep)
             {}
         protected:
-            virtual char_type do_decimal_point() const Q_DECL_OVERRIDE
+            virtual char_type do_decimal_point() const override
             {
                 return m_cDecPoint;
             }
 
-            virtual char_type do_thousands_sep() const Q_DECL_OVERRIDE
+            virtual char_type do_thousands_sep() const override
             {
                 return m_cThousandsSep;
             }
 
-            virtual std::string do_grouping() const Q_DECL_OVERRIDE
+            virtual std::string do_grouping() const override
             {
                 // fix for issue 4: https://code.google.com/p/muparser/issues/detail?id=4
                 // courtesy of Jens Bartsch

--- a/src/libs/qmuparser/qmuparsererror.h
+++ b/src/libs/qmuparser/qmuparsererror.h
@@ -144,7 +144,7 @@ public:
     QmuParserError ( const QString &szMsg, int iPos, const QString &sTok = QString() );
     QmuParserError ( const QmuParserError &a_Obj );
     QmuParserError& operator= ( const QmuParserError &a_Obj );
-    virtual ~QmuParserError() QMUP_NOEXCEPT_EXPR (true) Q_DECL_OVERRIDE {}
+    virtual ~QmuParserError() QMUP_NOEXCEPT_EXPR (true) override {}
 
     void           SetFormula ( const QString &a_strFormula );
     const QString& GetExpr() const;
@@ -152,8 +152,8 @@ public:
     int            GetPos() const;
     const QString& GetToken() const;
     EErrorCodes    GetCode() const;
-    Q_NORETURN virtual void   raise() const Q_DECL_OVERRIDE;
-    Q_REQUIRED_RESULT virtual QmuParserError *clone() const Q_DECL_OVERRIDE;
+    Q_NORETURN virtual void   raise() const override;
+    Q_REQUIRED_RESULT virtual QmuParserError *clone() const override;
 private:
     QString m_sMsg;      ///< The message string
     QString m_sExpr;     ///< Formula string

--- a/src/libs/qmuparser/qmutokenparser.h
+++ b/src/libs/qmuparser/qmutokenparser.h
@@ -35,7 +35,7 @@ class QmuTokenParser : public QmuFormulaBase
 {
 public:
     QmuTokenParser(const QString &formula, bool osSeparator, bool fromUser = true);
-    virtual ~QmuTokenParser() Q_DECL_OVERRIDE;
+    virtual ~QmuTokenParser() override;
 
     static bool IsSingle(const QString &formula);
 

--- a/src/libs/vdxf/vdxfengine.h
+++ b/src/libs/vdxf/vdxfengine.h
@@ -57,19 +57,19 @@ public:
     VDxfEngine();
     virtual ~VDxfEngine();
 
-    virtual bool begin(QPaintDevice *pdev) Q_DECL_OVERRIDE;
-    virtual bool end() Q_DECL_OVERRIDE;
-    virtual void updateState(const QPaintEngineState &state) Q_DECL_OVERRIDE;
-    virtual void drawPath(const QPainterPath &path) Q_DECL_OVERRIDE;
-    virtual void drawLines(const QLineF * lines, int lineCount) Q_DECL_OVERRIDE;
-    virtual void drawLines(const QLine * lines, int lineCount) Q_DECL_OVERRIDE;
-    virtual void drawPolygon(const QPointF *points, int pointCount, PolygonDrawMode mode) Q_DECL_OVERRIDE;
-    virtual void drawPolygon(const QPoint *points, int pointCount, PolygonDrawMode mode) Q_DECL_OVERRIDE;
-    virtual void drawEllipse(const QRectF & rect) Q_DECL_OVERRIDE;
-    virtual void drawEllipse(const QRect & rect) Q_DECL_OVERRIDE;
-    virtual void drawTextItem(const QPointF & p, const QTextItem & textItem) Q_DECL_OVERRIDE;
-    virtual Type type() const Q_DECL_OVERRIDE;
-    virtual void drawPixmap(const QRectF &r, const QPixmap &pm, const QRectF &sr) Q_DECL_OVERRIDE;
+    virtual bool begin(QPaintDevice *pdev) override;
+    virtual bool end() override;
+    virtual void updateState(const QPaintEngineState &state) override;
+    virtual void drawPath(const QPainterPath &path) override;
+    virtual void drawLines(const QLineF * lines, int lineCount) override;
+    virtual void drawLines(const QLine * lines, int lineCount) override;
+    virtual void drawPolygon(const QPointF *points, int pointCount, PolygonDrawMode mode) override;
+    virtual void drawPolygon(const QPoint *points, int pointCount, PolygonDrawMode mode) override;
+    virtual void drawEllipse(const QRectF & rect) override;
+    virtual void drawEllipse(const QRect & rect) override;
+    virtual void drawTextItem(const QPointF & p, const QTextItem & textItem) override;
+    virtual Type type() const override;
+    virtual void drawPixmap(const QRectF &r, const QPixmap &pm, const QRectF &sr) override;
 
     QSize getSize() const;
     void setSize(const QSize &value);

--- a/src/libs/vdxf/vdxfpaintdevice.h
+++ b/src/libs/vdxf/vdxfpaintdevice.h
@@ -45,8 +45,8 @@ class VDxfPaintDevice : public QPaintDevice
 {
 public:
     VDxfPaintDevice();
-    virtual ~VDxfPaintDevice() Q_DECL_OVERRIDE;
-    virtual QPaintEngine *paintEngine() const Q_DECL_OVERRIDE;
+    virtual ~VDxfPaintDevice() override;
+    virtual QPaintEngine *paintEngine() const override;
 
     QString getFileName() const;
     void setFileName(const QString &value);
@@ -69,7 +69,7 @@ public:
     bool ExportToAAMA(const QVector<VLayoutPiece> &details) const;
 
 protected:
-    virtual int metric(PaintDeviceMetric metric) const Q_DECL_OVERRIDE;
+    virtual int metric(PaintDeviceMetric metric) const override;
 private:
     Q_DISABLE_COPY(VDxfPaintDevice)
     VDxfEngine *engine;

--- a/src/libs/vformat/measurements.h
+++ b/src/libs/vformat/measurements.h
@@ -78,8 +78,8 @@ public:
                      MeasurementDoc(Unit unit, int baseSize, int baseHeight, VContainer *data);
     virtual         ~MeasurementDoc() Q_DECL_EQ_DEFAULT;
 
-    virtual void     setXMLContent(const QString &fileName) Q_DECL_OVERRIDE;
-    virtual bool     SaveDocument(const QString &fileName, QString &error) Q_DECL_OVERRIDE;
+    virtual void     setXMLContent(const QString &fileName) override;
+    virtual bool     SaveDocument(const QString &fileName, QString &error) override;
 
     void             addEmpty(const QString &name, const QString &formula = QString());
     void             AddEmptyAfter(const QString &after, const QString &name, const QString &formula = QString());

--- a/src/libs/vgeometry/vabstractarc.cpp
+++ b/src/libs/vgeometry/vabstractarc.cpp
@@ -58,13 +58,13 @@
 #include "vpointf.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VAbstractArc &VAbstractArc::operator=(VAbstractArc &&arc) Q_DECL_NOTHROW
+VAbstractArc &VAbstractArc::operator=(VAbstractArc &&arc) noexcept
 {
     Swap(arc); return *this;
 }
 #endif
 
-void VAbstractArc::Swap(VAbstractArc &arc) Q_DECL_NOTHROW
+void VAbstractArc::Swap(VAbstractArc &arc) noexcept
 { VAbstractCurve::Swap(arc); std::swap(d, arc.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vgeometry/vabstractarc.h
+++ b/src/libs/vgeometry/vabstractarc.h
@@ -88,18 +88,18 @@ public:
 
     VAbstractArc    &operator= (const VAbstractArc &arc);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VAbstractArc    &operator=(VAbstractArc &&arc) Q_DECL_NOTHROW ;
+	VAbstractArc    &operator=(VAbstractArc &&arc) noexcept ;
 #endif
 
-	void             Swap(VAbstractArc &arc) Q_DECL_NOTHROW;
+	void             Swap(VAbstractArc &arc) noexcept;
 
     QString          GetFormulaF1 () const;
     void             SetFormulaF1 (const QString &formula, qreal value);
-    virtual qreal    GetStartAngle () const Q_DECL_OVERRIDE;
+    virtual qreal    GetStartAngle () const override;
 
     QString          GetFormulaF2 () const;
     void             SetFormulaF2 (const QString &formula, qreal value);
-    virtual qreal    GetEndAngle () const Q_DECL_OVERRIDE;
+    virtual qreal    GetEndAngle () const override;
 
     virtual VPointF  GetCenter () const;
     void             SetCenter (const VPointF &point);
@@ -107,8 +107,8 @@ public:
     QString          GetFormulaLength () const;
     void             SetFormulaLength (const QString &formula, qreal value);
 
-    virtual void     setId(const quint32 &id) Q_DECL_OVERRIDE;
-    virtual QString  NameForHistory(const QString &toolName) const Q_DECL_OVERRIDE;
+    virtual void     setId(const quint32 &id) override;
+    virtual QString  NameForHistory(const QString &toolName) const override;
 
     bool             IsFlipped() const;
     qreal            AngleArc() const;

--- a/src/libs/vgeometry/vabstractcubicbezier.h
+++ b/src/libs/vgeometry/vabstractcubicbezier.h
@@ -79,13 +79,13 @@ public:
 
     QPointF CutSpline ( qreal length, QPointF &spl1p2, QPointF &spl1p3, QPointF &spl2p2, QPointF &spl2p3) const;
 
-    virtual QString NameForHistory(const QString &toolName) const Q_DECL_OVERRIDE;
+    virtual QString NameForHistory(const QString &toolName) const override;
 
     qreal GetParmT(qreal length) const;
     qreal LengthT(qreal t) const;
 
 protected:
-    virtual void CreateName() Q_DECL_OVERRIDE;
+    virtual void CreateName() override;
 
     static qreal            CalcSqDistance(qreal x1, qreal y1, qreal x2, qreal y2);
     static void             PointBezier_r(qreal x1, qreal y1, qreal x2, qreal y2, qreal x3, qreal y3, qreal x4,

--- a/src/libs/vgeometry/vabstractcubicbezierpath.h
+++ b/src/libs/vgeometry/vabstractcubicbezierpath.h
@@ -79,24 +79,24 @@ public:
     virtual VSpline                 GetSpline(qint32 index) const =0;
     virtual QVector<VSplinePoint>   GetSplinePath() const =0;
 
-    virtual QPainterPath            GetPath() const Q_DECL_OVERRIDE;
-    virtual QVector<QPointF>        getPoints() const Q_DECL_OVERRIDE;
-    virtual qreal                   GetLength() const Q_DECL_OVERRIDE;
+    virtual QPainterPath            GetPath() const override;
+    virtual QVector<QPointF>        getPoints() const override;
+    virtual qreal                   GetLength() const override;
 
-    virtual QVector<DirectionArrow> DirectionArrows() const Q_DECL_OVERRIDE;
+    virtual QVector<DirectionArrow> DirectionArrows() const override;
 
     int                             Segment(const QPointF &p) const;
 
     QPointF                         CutSplinePath(qreal length, qint32 &p1, qint32 &p2, QPointF &spl1p2,
                                                   QPointF &spl1p3, QPointF &spl2p2, QPointF &spl2p3) const;
 
-    virtual QString                 NameForHistory(const QString &toolName) const Q_DECL_OVERRIDE;
+    virtual QString                 NameForHistory(const QString &toolName) const override;
 
     virtual VPointF                 FirstPoint() const =0;
     virtual VPointF                 LastPoint() const =0;
 
 protected:
-    virtual void CreateName() Q_DECL_OVERRIDE;
+    virtual void CreateName() override;
 };
 
 #endif // VABSTRACTCUBICBEZIERPATH_H

--- a/src/libs/vgeometry/vabstractcurve.cpp
+++ b/src/libs/vgeometry/vabstractcurve.cpp
@@ -63,11 +63,11 @@
 const qreal VAbstractCurve::lengthCurveDirectionArrow = 14;
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VAbstractCurve &VAbstractCurve::operator=(VAbstractCurve &&curve) Q_DECL_NOTHROW
+VAbstractCurve &VAbstractCurve::operator=(VAbstractCurve &&curve) noexcept
 { Swap(curve); return *this; }
 #endif
 
-void VAbstractCurve::Swap(VAbstractCurve &curve) Q_DECL_NOTHROW
+void VAbstractCurve::Swap(VAbstractCurve &curve) noexcept
 { VGObject::Swap(curve); std::swap(d, curve.d); }
 
 VAbstractCurve::VAbstractCurve(const GOType &type, const quint32 &idObject, const Draw &mode)

--- a/src/libs/vgeometry/vabstractcurve.h
+++ b/src/libs/vgeometry/vabstractcurve.h
@@ -71,14 +71,14 @@ public:
     explicit VAbstractCurve(const GOType &type, const quint32 &idObject = NULL_ID,
                             const Draw &mode = Draw::Calculation);
     explicit VAbstractCurve(const VAbstractCurve &curve);
-    virtual ~VAbstractCurve() Q_DECL_OVERRIDE;
+    virtual ~VAbstractCurve() override;
 
     VAbstractCurve &operator = (const VAbstractCurve &curve);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VAbstractCurve &operator = (VAbstractCurve &&curve) Q_DECL_NOTHROW;
+	VAbstractCurve &operator = (VAbstractCurve &&curve) noexcept;
 #endif
 
-	void                     Swap(VAbstractCurve &curve) Q_DECL_NOTHROW;
+	void                     Swap(VAbstractCurve &curve) noexcept;
 
     virtual QVector<QPointF> getPoints() const =0;
     static QVector<QPointF>  GetSegmentPoints(const QVector<QPointF> &points, const QPointF &begin, const QPointF &end,

--- a/src/libs/vgeometry/varc.cpp
+++ b/src/libs/vgeometry/varc.cpp
@@ -80,11 +80,11 @@ VArc::VArc ()
  */
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VArc &VArc::operator=(VArc &&arc) Q_DECL_NOTHROW
+VArc &VArc::operator=(VArc &&arc) noexcept
 { Swap(arc); return *this; }
 #endif
 
-void VArc::Swap(VArc &arc) Q_DECL_NOTHROW
+void VArc::Swap(VArc &arc) noexcept
 { VAbstractArc::Swap(arc); std::swap(d, arc.d); }
 
 VArc::VArc (const VPointF &center, qreal radius, const QString &formulaRadius, qreal f1, const QString &formulaF1,

--- a/src/libs/vgeometry/varc.h
+++ b/src/libs/vgeometry/varc.h
@@ -87,33 +87,33 @@ public:
                                         const QString &prefix = QString()) const;
     VArc                         Flip(const QLineF &axis, const QString &prefix = QString()) const;
     VArc                         Move(qreal length, qreal angle, const QString &prefix = QString()) const;
-    virtual                     ~VArc() Q_DECL_OVERRIDE;
+    virtual                     ~VArc() override;
 
     VArc                        &operator= (const VArc &arc);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VArc                        &operator=(VArc &&arc) Q_DECL_NOTHROW;
+	VArc                        &operator=(VArc &&arc) noexcept;
 #endif
 
-	void                         Swap(VArc &arc) Q_DECL_NOTHROW;
+	void                         Swap(VArc &arc) noexcept;
 
     QString                      GetFormulaRadius () const;
     void                         SetFormulaRadius (const QString &formula, qreal value);
     qreal                        GetRadius () const;
 
-    virtual qreal                GetLength () const Q_DECL_OVERRIDE;
+    virtual qreal                GetLength () const override;
 
     QPointF                      GetP1() const;
     QPointF                      GetP2 () const;
 
-    virtual QVector<QPointF>     getPoints() const Q_DECL_OVERRIDE;
+    virtual QVector<QPointF>     getPoints() const override;
     QVector<QLineF>              getSegments() const;
 
     QPointF                      CutArc (qreal length, VArc &segment1, VArc &segment2) const;
     QPointF                      CutArc (qreal length) const;
 
 protected:
-    virtual void                 CreateName() Q_DECL_OVERRIDE;
-    virtual void                 FindF2(qreal length) Q_DECL_OVERRIDE;
+    virtual void                 CreateName() override;
+    virtual void                 FindF2(qreal length) override;
 
 private:
     QSharedDataPointer<VArcData> d;

--- a/src/libs/vgeometry/vcubicbezier.cpp
+++ b/src/libs/vgeometry/vcubicbezier.cpp
@@ -56,11 +56,11 @@
 #include "vcubicbezier_p.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VCubicBezier &VCubicBezier::operator=(VCubicBezier &&curve) Q_DECL_NOTHROW
+VCubicBezier &VCubicBezier::operator=(VCubicBezier &&curve) noexcept
 { Swap(curve); return *this; }
 #endif
 
-void VCubicBezier::Swap(VCubicBezier &curve) Q_DECL_NOTHROW
+void VCubicBezier::Swap(VCubicBezier &curve) noexcept
 { VAbstractCubicBezier::Swap(curve); std::swap(d, curve.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vgeometry/vcubicbezier.h
+++ b/src/libs/vgeometry/vcubicbezier.h
@@ -80,34 +80,34 @@ public:
 
     VCubicBezier &operator=(const VCubicBezier &curve);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VCubicBezier &operator=(VCubicBezier &&curve) Q_DECL_NOTHROW;
+	VCubicBezier &operator=(VCubicBezier &&curve) noexcept;
 #endif
 
-	void Swap(VCubicBezier &curve) Q_DECL_NOTHROW;
+	void Swap(VCubicBezier &curve) noexcept;
 
-    virtual VPointF GetP1() const Q_DECL_OVERRIDE;
+    virtual VPointF GetP1() const override;
     void            SetP1(const VPointF &p);
 
-    virtual VPointF GetP2() const Q_DECL_OVERRIDE;
+    virtual VPointF GetP2() const override;
     void    SetP2(const VPointF &p);
 
-    virtual VPointF GetP3() const Q_DECL_OVERRIDE;
+    virtual VPointF GetP3() const override;
     void    SetP3(const VPointF &p);
 
-    virtual VPointF GetP4() const Q_DECL_OVERRIDE;
+    virtual VPointF GetP4() const override;
     void            SetP4(const VPointF &p);
 
-    virtual qreal            GetStartAngle() const Q_DECL_OVERRIDE;
-    virtual qreal            GetEndAngle() const Q_DECL_OVERRIDE;
-    virtual qreal            GetLength() const Q_DECL_OVERRIDE;
-    virtual QVector<QPointF> getPoints() const Q_DECL_OVERRIDE;
+    virtual qreal            GetStartAngle() const override;
+    virtual qreal            GetEndAngle() const override;
+    virtual qreal            GetLength() const override;
+    virtual QVector<QPointF> getPoints() const override;
 
-    virtual qreal GetC1Length() const Q_DECL_OVERRIDE;
-    virtual qreal GetC2Length() const Q_DECL_OVERRIDE;
+    virtual qreal GetC1Length() const override;
+    virtual qreal GetC2Length() const override;
 
 protected:
-    virtual QPointF GetControlPoint1() const Q_DECL_OVERRIDE;
-    virtual QPointF GetControlPoint2() const Q_DECL_OVERRIDE;
+    virtual QPointF GetControlPoint1() const override;
+    virtual QPointF GetControlPoint2() const override;
 
 private:
     QSharedDataPointer<VCubicBezierData> d;

--- a/src/libs/vgeometry/vcubicbezierpath.cpp
+++ b/src/libs/vgeometry/vcubicbezierpath.cpp
@@ -62,11 +62,11 @@
 #include "vsplinepoint.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VCubicBezierPath &VCubicBezierPath::operator=(VCubicBezierPath &&curve) Q_DECL_NOTHROW
+VCubicBezierPath &VCubicBezierPath::operator=(VCubicBezierPath &&curve) noexcept
 { Swap(curve); return *this; }
 #endif
 
-void VCubicBezierPath::Swap(VCubicBezierPath &curve) Q_DECL_NOTHROW
+void VCubicBezierPath::Swap(VCubicBezierPath &curve) noexcept
 { VAbstractCubicBezierPath::Swap(curve); std::swap(d, curve.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vgeometry/vcubicbezierpath.h
+++ b/src/libs/vgeometry/vcubicbezierpath.h
@@ -79,10 +79,10 @@ public:
     VCubicBezierPath             &operator=(const VCubicBezierPath &curve);
 
 #ifdef Q_COMPILER_RVALUE_REFS
-	VCubicBezierPath             &operator=(VCubicBezierPath &&curve) Q_DECL_NOTHROW;
+	VCubicBezierPath             &operator=(VCubicBezierPath &&curve) noexcept;
 #endif
 
-    void                          Swap(VCubicBezierPath &curve) Q_DECL_NOTHROW;
+    void                          Swap(VCubicBezierPath &curve) noexcept;
 
     VPointF                      &operator[](int indx);
 
@@ -90,25 +90,25 @@ public:
 
     void                          append(const VPointF &point);
 
-    virtual qint32                CountSubSpl() const Q_DECL_OVERRIDE;
-    virtual qint32                CountPoints() const Q_DECL_OVERRIDE;
-    virtual void                  Clear() Q_DECL_OVERRIDE;
-    virtual VSpline               GetSpline(qint32 index) const Q_DECL_OVERRIDE;
-    virtual qreal                 GetStartAngle () const Q_DECL_OVERRIDE;
-    virtual qreal                 GetEndAngle () const Q_DECL_OVERRIDE;
+    virtual qint32                CountSubSpl() const override;
+    virtual qint32                CountPoints() const override;
+    virtual void                  Clear() override;
+    virtual VSpline               GetSpline(qint32 index) const override;
+    virtual qreal                 GetStartAngle () const override;
+    virtual qreal                 GetEndAngle () const override;
 
-    virtual qreal                 GetC1Length() const Q_DECL_OVERRIDE;
-    virtual qreal                 GetC2Length() const Q_DECL_OVERRIDE;
+    virtual qreal                 GetC1Length() const override;
+    virtual qreal                 GetC2Length() const override;
 
-    virtual QVector<VSplinePoint> GetSplinePath() const Q_DECL_OVERRIDE;
+    virtual QVector<VSplinePoint> GetSplinePath() const override;
     QVector<VPointF>              GetCubicPath() const;
 
     static qint32                 CountSubSpl(qint32 size);
     static qint32                 SubSplOffset(qint32 subSplIndex);
     static qint32                 SubSplPointsCount(qint32 countSubSpl);
 
-    virtual VPointF               FirstPoint() const  Q_DECL_OVERRIDE;
-    virtual VPointF               LastPoint() const  Q_DECL_OVERRIDE;
+    virtual VPointF               FirstPoint() const  override;
+    virtual VPointF               LastPoint() const  override;
 
 private:
     QSharedDataPointer<VCubicBezierPathData> d;

--- a/src/libs/vgeometry/vellipticalarc.cpp
+++ b/src/libs/vgeometry/vellipticalarc.cpp
@@ -41,10 +41,10 @@
 #include "vspline.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VEllipticalArc &VEllipticalArc::operator=(VEllipticalArc &&arc) Q_DECL_NOTHROW { Swap(arc); return *this; }
+VEllipticalArc &VEllipticalArc::operator=(VEllipticalArc &&arc) noexcept { Swap(arc); return *this; }
 #endif
 
-void VEllipticalArc::Swap(VEllipticalArc &arc) Q_DECL_NOTHROW
+void VEllipticalArc::Swap(VEllipticalArc &arc) noexcept
 { VAbstractArc::Swap(arc); std::swap(d, arc.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vgeometry/vellipticalarc.h
+++ b/src/libs/vgeometry/vellipticalarc.h
@@ -70,15 +70,15 @@ public:
     VEllipticalArc  Flip(const QLineF &axis, const QString &prefix = QString()) const;
     VEllipticalArc  Move(qreal length, qreal angle, const QString &prefix = QString()) const;
 
-    virtual        ~VEllipticalArc() Q_DECL_OVERRIDE;
+    virtual        ~VEllipticalArc() override;
 
     VEllipticalArc &operator= (const VEllipticalArc &arc);
 
 #ifdef Q_COMPILER_RVALUE_REFS
-	VEllipticalArc &operator=(VEllipticalArc &&arc) Q_DECL_NOTHROW;
+	VEllipticalArc &operator=(VEllipticalArc &&arc) noexcept;
 #endif
 
-	void            Swap(VEllipticalArc &arc) Q_DECL_NOTHROW;
+	void            Swap(VEllipticalArc &arc) noexcept;
 
     QString         GetFormulaRotationAngle () const;
     void            SetFormulaRotationAngle (const QString &formula, qreal value);
@@ -92,7 +92,7 @@ public:
     void            SetFormulaRadius2 (const QString &formula, qreal value);
     qreal           GetRadius2 () const;
 
-    virtual qreal   GetLength () const Q_DECL_OVERRIDE;
+    virtual qreal   GetLength () const override;
 
     QPointF         GetP1() const;
     QPointF         GetP2() const;
@@ -100,10 +100,10 @@ public:
     QTransform      getTransform() const;
     void            setTransform(const QTransform &matrix, bool combine = false);
 
-    virtual VPointF GetCenter () const Q_DECL_OVERRIDE;
-    virtual QVector<QPointF> getPoints() const Q_DECL_OVERRIDE;
-    virtual qreal   GetStartAngle () const Q_DECL_OVERRIDE;
-    virtual qreal   GetEndAngle () const Q_DECL_OVERRIDE;
+    virtual VPointF GetCenter () const override;
+    virtual QVector<QPointF> getPoints() const override;
+    virtual qreal   GetStartAngle () const override;
+    virtual qreal   GetEndAngle () const override;
 
     QPointF         CutArc (const qreal &length, VEllipticalArc &arc1, VEllipticalArc &arc2) const;
     QPointF         CutArc (const qreal &length) const;
@@ -111,8 +111,8 @@ public:
     static qreal    normalizeAngle(qreal angle);
 
 protected:
-    virtual void    CreateName() Q_DECL_OVERRIDE;
-    virtual void    FindF2(qreal length) Q_DECL_OVERRIDE;
+    virtual void    CreateName() override;
+    virtual void    FindF2(qreal length) override;
 
 private:
     QSharedDataPointer<VEllipticalArcData> d;

--- a/src/libs/vgeometry/vgobject.cpp
+++ b/src/libs/vgeometry/vgobject.cpp
@@ -66,10 +66,10 @@
 const double VGObject::accuracyPointOnLine = (0.1555/*mm*/ / 25.4) * 96.0;
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VGObject &VGObject::operator=(VGObject &&obj) Q_DECL_NOTHROW { Swap(obj); return *this; }
+VGObject &VGObject::operator=(VGObject &&obj) noexcept { Swap(obj); return *this; }
 #endif
 
-void VGObject::Swap(VGObject &obj) Q_DECL_NOTHROW
+void VGObject::Swap(VGObject &obj) noexcept
 { std::swap(d, obj.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vgeometry/vgobject.h
+++ b/src/libs/vgeometry/vgobject.h
@@ -81,10 +81,10 @@ public:
 
     VGObject& operator= (const VGObject &obj);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VGObject &operator=(VGObject &&obj) Q_DECL_NOTHROW;
+	VGObject &operator=(VGObject &&obj) noexcept;
 #endif
 
-	void Swap(VGObject &obj) Q_DECL_NOTHROW;
+	void Swap(VGObject &obj) noexcept;
     quint32         getIdObject() const;
     void            setIdObject(const quint32 &value);
 

--- a/src/libs/vgeometry/vpointf.cpp
+++ b/src/libs/vgeometry/vpointf.cpp
@@ -57,10 +57,10 @@
 #include <QTransform>
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VPointF &VPointF::operator=(VPointF &&point) Q_DECL_NOTHROW { Swap(point); return *this; }
+VPointF &VPointF::operator=(VPointF &&point) noexcept { Swap(point); return *this; }
 #endif
 
-void VPointF::Swap(VPointF &point) Q_DECL_NOTHROW
+void VPointF::Swap(VPointF &point) noexcept
 { VGObject::Swap(point); std::swap(d, point.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vgeometry/vpointf.h
+++ b/src/libs/vgeometry/vpointf.h
@@ -81,14 +81,14 @@ public:
                               const Draw &mode = Draw::Calculation);
                       VPointF(const QPointF &point, const QString &name, qreal mx, qreal my, quint32 idObject = 0,
                               const Draw &mode = Draw::Calculation);
-    virtual          ~VPointF() Q_DECL_OVERRIDE;
+    virtual          ~VPointF() override;
 
     VPointF &operator=(const VPointF &point);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VPointF &operator=(VPointF &&point) Q_DECL_NOTHROW;
+	VPointF &operator=(VPointF &&point) noexcept;
 #endif
 
-	void              Swap(VPointF &point) Q_DECL_NOTHROW;
+	void              Swap(VPointF &point) noexcept;
 
     explicit operator QPointF() const;
     VPointF           Rotate(const QPointF &originPoint, qreal degrees, const QString &prefix = QString()) const;

--- a/src/libs/vgeometry/vspline.cpp
+++ b/src/libs/vgeometry/vspline.cpp
@@ -58,10 +58,10 @@
 #include "../vmisc/vmath.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VSpline &VSpline::operator=(VSpline &&spline) Q_DECL_NOTHROW { Swap(spline); return *this; }
+VSpline &VSpline::operator=(VSpline &&spline) noexcept { Swap(spline); return *this; }
 #endif
 
-void VSpline::Swap(VSpline &spline) Q_DECL_NOTHROW
+void VSpline::Swap(VSpline &spline) noexcept
 { VAbstractCubicBezier::Swap(spline); std::swap(d, spline.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vgeometry/vspline.h
+++ b/src/libs/vgeometry/vspline.h
@@ -90,22 +90,22 @@ public:
 
     VSpline &operator=(const VSpline &spline);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VSpline &operator=(VSpline &&spline) Q_DECL_NOTHROW;
+	VSpline &operator=(VSpline &&spline) noexcept;
 #endif
 
-	void Swap(VSpline &spline) Q_DECL_NOTHROW;
+	void Swap(VSpline &spline) noexcept;
 
-    virtual VPointF GetP1 () const Q_DECL_OVERRIDE;
+    virtual VPointF GetP1 () const override;
     void            SetP1 (const VPointF &p);
 
-    virtual VPointF GetP2 () const Q_DECL_OVERRIDE;
-    virtual VPointF GetP3 () const Q_DECL_OVERRIDE;
+    virtual VPointF GetP2 () const override;
+    virtual VPointF GetP3 () const override;
 
-    virtual VPointF GetP4 () const Q_DECL_OVERRIDE;
+    virtual VPointF GetP4 () const override;
     void            SetP4 (const VPointF &p);
 
-    virtual qreal GetStartAngle () const Q_DECL_OVERRIDE;
-    virtual qreal GetEndAngle() const Q_DECL_OVERRIDE;
+    virtual qreal GetStartAngle () const override;
+    virtual qreal GetEndAngle() const override;
 
     QString GetStartAngleFormula () const;
     QString GetEndAngleFormula() const;
@@ -113,8 +113,8 @@ public:
     void    SetStartAngle(qreal angle, const QString &formula);
     void    SetEndAngle(qreal angle, const QString &formula);
 
-    virtual qreal GetC1Length() const Q_DECL_OVERRIDE;
-    virtual qreal GetC2Length() const Q_DECL_OVERRIDE;
+    virtual qreal GetC1Length() const override;
+    virtual qreal GetC2Length() const override;
 
     QString GetC1LengthFormula() const;
     QString GetC2LengthFormula() const;
@@ -122,7 +122,7 @@ public:
     void    SetC1Length(qreal length, const QString &formula);
     void    SetC2Length(qreal length, const QString &formula);
 
-    virtual qreal   GetLength () const Q_DECL_OVERRIDE;
+    virtual qreal   GetLength () const override;
     qreal   GetKasm1() const;
     qreal   GetKasm2() const;
     qreal   GetKcurve() const;
@@ -130,15 +130,15 @@ public:
     using VAbstractCubicBezier::CutSpline;
     QPointF CutSpline ( qreal length, VSpline &spl1, VSpline &spl2) const;
 
-    virtual QVector<QPointF> getPoints() const Q_DECL_OVERRIDE;
+    virtual QVector<QPointF> getPoints() const override;
     // cppcheck-suppress unusedFunction
     static QVector<QPointF> SplinePoints(const QPointF &p1, const QPointF &p4, qreal angle1, qreal angle2, qreal kAsm1,
                                          qreal kAsm2, qreal kCurve);
     qreal   ParamT(const QPointF &pBt) const;
 
 protected:
-    virtual QPointF GetControlPoint1() const Q_DECL_OVERRIDE;
-    virtual QPointF GetControlPoint2() const Q_DECL_OVERRIDE;
+    virtual QPointF GetControlPoint1() const override;
+    virtual QPointF GetControlPoint2() const override;
 private:
     QSharedDataPointer<VSplineData> d;
     QVector<qreal> CalcT(qreal curveCoord1, qreal curveCoord2, qreal curveCoord3, qreal curveCoord4,

--- a/src/libs/vgeometry/vsplinepath.cpp
+++ b/src/libs/vgeometry/vsplinepath.cpp
@@ -59,10 +59,10 @@
 #include "vsplinepath_p.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VSplinePath &VSplinePath::operator=(VSplinePath &&path) Q_DECL_NOTHROW { Swap(path); return *this; }
+VSplinePath &VSplinePath::operator=(VSplinePath &&path) noexcept { Swap(path); return *this; }
 #endif
 
-void VSplinePath::Swap(VSplinePath &path) Q_DECL_NOTHROW
+void VSplinePath::Swap(VSplinePath &path) noexcept
 { VAbstractCubicBezierPath::Swap(path); std::swap(d, path.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vgeometry/vsplinepath.h
+++ b/src/libs/vgeometry/vsplinepath.h
@@ -84,40 +84,40 @@ public:
     VSplinePath            Rotate(const QPointF &originPoint, qreal degrees, const QString &prefix = QString()) const;
     VSplinePath            Flip(const QLineF &axis, const QString &prefix = QString()) const;
     VSplinePath            Move(qreal length, qreal angle, const QString &prefix = QString()) const;
-    virtual               ~VSplinePath() Q_DECL_OVERRIDE;
+    virtual               ~VSplinePath() override;
 
     VSplinePoint          &operator[](int indx);
     VSplinePath           &operator=(const VSplinePath &path);
 
 #ifdef Q_COMPILER_RVALUE_REFS
-	VSplinePath           &operator=(VSplinePath &&path) Q_DECL_NOTHROW;
+	VSplinePath           &operator=(VSplinePath &&path) noexcept;
 #endif
 
-	void                   Swap(VSplinePath &path) Q_DECL_NOTHROW;
+	void                   Swap(VSplinePath &path) noexcept;
 
     void                   append(const VSplinePoint &point);
 
-    virtual qint32         CountSubSpl() const Q_DECL_OVERRIDE;
-    virtual qint32         CountPoints() const Q_DECL_OVERRIDE;
-    virtual void           Clear() Q_DECL_OVERRIDE;
-    virtual VSpline        GetSpline(qint32 index) const Q_DECL_OVERRIDE;
+    virtual qint32         CountSubSpl() const override;
+    virtual qint32         CountPoints() const override;
+    virtual void           Clear() override;
+    virtual VSpline        GetSpline(qint32 index) const override;
 
-    virtual QVector<VSplinePoint> GetSplinePath() const Q_DECL_OVERRIDE;
+    virtual QVector<VSplinePoint> GetSplinePath() const override;
     QVector<VFSplinePoint> GetFSplinePath() const;
 
-    virtual qreal          GetStartAngle () const Q_DECL_OVERRIDE;
-    virtual qreal          GetEndAngle () const Q_DECL_OVERRIDE;
+    virtual qreal          GetStartAngle () const override;
+    virtual qreal          GetEndAngle () const override;
 
-    virtual qreal          GetC1Length() const Q_DECL_OVERRIDE;
-    virtual qreal          GetC2Length() const Q_DECL_OVERRIDE;
+    virtual qreal          GetC1Length() const override;
+    virtual qreal          GetC2Length() const override;
 
     void                   UpdatePoint(qint32 indexSpline, const SplinePointPosition &pos, const VSplinePoint &point);
     VSplinePoint           GetSplinePoint(qint32 indexSpline, SplinePointPosition pos) const;
 
     const VSplinePoint    &at(int indx) const;
 
-    virtual VPointF        FirstPoint() const  Q_DECL_OVERRIDE;
-    virtual VPointF        LastPoint() const  Q_DECL_OVERRIDE;
+    virtual VPointF        FirstPoint() const  override;
+    virtual VPointF        LastPoint() const  override;
 
 private:
     QSharedDataPointer<VSplinePathData> d;

--- a/src/libs/vgeometry/vsplinepoint.cpp
+++ b/src/libs/vgeometry/vsplinepoint.cpp
@@ -57,11 +57,11 @@
 #include "vsplinepoint_p.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VFSplinePoint &VFSplinePoint::operator=(VFSplinePoint &&point) Q_DECL_NOTHROW
+VFSplinePoint &VFSplinePoint::operator=(VFSplinePoint &&point) noexcept
 { Swap(point); return *this; }
 #endif
 
-void VFSplinePoint::Swap(VFSplinePoint &point) Q_DECL_NOTHROW
+void VFSplinePoint::Swap(VFSplinePoint &point) noexcept
 { std::swap(d, point.d); }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -221,11 +221,11 @@ void VFSplinePoint::SetKAsm2(const qreal &value)
 
 //---------------------------------------------------------------------------------------------------------------------
 #ifdef Q_COMPILER_RVALUE_REFS
-VSplinePoint &VSplinePoint::operator=(VSplinePoint &&point) Q_DECL_NOTHROW
+VSplinePoint &VSplinePoint::operator=(VSplinePoint &&point) noexcept
 { Swap(point); return *this; }
 #endif
 
-void VSplinePoint::Swap(VSplinePoint &point) Q_DECL_NOTHROW
+void VSplinePoint::Swap(VSplinePoint &point) noexcept
 { std::swap(d, point.d); }
 //------------------------------------------VSplinePoint---------------------------------------------------------------
 VSplinePoint::VSplinePoint()

--- a/src/libs/vgeometry/vsplinepoint.h
+++ b/src/libs/vgeometry/vsplinepoint.h
@@ -76,10 +76,10 @@ public:
 
     VFSplinePoint &operator=(const VFSplinePoint &point);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VFSplinePoint &operator=(VFSplinePoint &&point) Q_DECL_NOTHROW;
+	VFSplinePoint &operator=(VFSplinePoint &&point) noexcept;
 #endif
 
-	void Swap(VFSplinePoint &point) Q_DECL_NOTHROW;
+	void Swap(VFSplinePoint &point) noexcept;
 
     VPointF P() const;
     void    SetP(const VPointF &value);
@@ -115,10 +115,10 @@ public:
 
     VSplinePoint &operator=(const VSplinePoint &point);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VSplinePoint &operator=(VSplinePoint &&point) Q_DECL_NOTHROW;
+	VSplinePoint &operator=(VSplinePoint &&point) noexcept;
 #endif
 
-	void Swap(VSplinePoint &point) Q_DECL_NOTHROW;
+	void Swap(VSplinePoint &point) noexcept;
 
     VPointF P() const;
     void    SetP(const VPointF &value);

--- a/src/libs/vlayout/vabstractpiece.cpp
+++ b/src/libs/vlayout/vabstractpiece.cpp
@@ -62,11 +62,11 @@
 const qreal maxL = 2.4;
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VAbstractPiece &VAbstractPiece::operator=(VAbstractPiece &&piece) Q_DECL_NOTHROW
+VAbstractPiece &VAbstractPiece::operator=(VAbstractPiece &&piece) noexcept
 { Swap(piece); return *this; }
 #endif
 
-void VAbstractPiece::Swap(VAbstractPiece &piece) Q_DECL_NOTHROW
+void VAbstractPiece::Swap(VAbstractPiece &piece) noexcept
 { std::swap(d, piece.d); }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -447,7 +447,7 @@ QVector<QPointF> VAbstractPiece::CheckLoops(const QVector<QPointF> &points)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-Q_DECL_CONSTEXPR qreal VAbstractPiece::PointPosition(const QPointF &p, const QLineF &line)
+constexpr qreal VAbstractPiece::PointPosition(const QPointF &p, const QLineF &line)
 {
     return (line.p2().x() - line.p1().x()) * (p.y() - line.p1().y()) -
            (line.p2().y() - line.p1().y()) * (p.x() - line.p1().x());

--- a/src/libs/vlayout/vabstractpiece.h
+++ b/src/libs/vlayout/vabstractpiece.h
@@ -75,19 +75,19 @@ QT_WARNING_DISABLE_GCC("-Wnon-virtual-dtor")
 class VSAPoint : public QPointF
 {
 public:
-    Q_DECL_CONSTEXPR VSAPoint();
-    Q_DECL_CONSTEXPR VSAPoint(qreal xpos, qreal ypos);
-    Q_DECL_CONSTEXPR explicit VSAPoint(const QPointF &p);
+    constexpr VSAPoint();
+    constexpr VSAPoint(qreal xpos, qreal ypos);
+    constexpr explicit VSAPoint(const QPointF &p);
 
-    Q_DECL_CONSTEXPR qreal GetSABefore() const;
+    constexpr qreal GetSABefore() const;
                      qreal GetSABefore(qreal width) const;
                      void  SetSABefore(qreal value);
 
-    Q_DECL_CONSTEXPR qreal GetSAAfter() const;
+    constexpr qreal GetSAAfter() const;
                      qreal GetSAAfter(qreal width) const;
                      void  SetSAAfter(qreal value);
 
-    Q_DECL_CONSTEXPR PieceNodeAngle GetAngleType() const;
+    constexpr PieceNodeAngle GetAngleType() const;
                      void           SetAngleType(PieceNodeAngle value);
 
 private:
@@ -100,7 +100,7 @@ Q_DECLARE_METATYPE(VSAPoint)
 Q_DECLARE_TYPEINFO(VSAPoint, Q_MOVABLE_TYPE);
 
 //---------------------------------------------------------------------------------------------------------------------
-Q_DECL_CONSTEXPR inline VSAPoint::VSAPoint()
+constexpr inline VSAPoint::VSAPoint()
     : QPointF(),
       m_before(-1),
       m_after(-1),
@@ -108,7 +108,7 @@ Q_DECL_CONSTEXPR inline VSAPoint::VSAPoint()
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
-Q_DECL_CONSTEXPR inline VSAPoint::VSAPoint(qreal xpos, qreal ypos)
+constexpr inline VSAPoint::VSAPoint(qreal xpos, qreal ypos)
     : QPointF(xpos, ypos),
       m_before(-1),
       m_after(-1),
@@ -116,7 +116,7 @@ Q_DECL_CONSTEXPR inline VSAPoint::VSAPoint(qreal xpos, qreal ypos)
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
-Q_DECL_CONSTEXPR inline VSAPoint::VSAPoint(const QPointF &p)
+constexpr inline VSAPoint::VSAPoint(const QPointF &p)
     : QPointF(p),
       m_before(-1),
       m_after(-1),
@@ -124,7 +124,7 @@ Q_DECL_CONSTEXPR inline VSAPoint::VSAPoint(const QPointF &p)
 {}
 
 //---------------------------------------------------------------------------------------------------------------------
-Q_DECL_CONSTEXPR inline qreal VSAPoint::GetSABefore() const
+constexpr inline qreal VSAPoint::GetSABefore() const
 {
     return m_before;
 }
@@ -136,7 +136,7 @@ inline void VSAPoint::SetSABefore(qreal value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-Q_DECL_CONSTEXPR inline qreal VSAPoint::GetSAAfter() const
+constexpr inline qreal VSAPoint::GetSAAfter() const
 {
     return m_after;
 }
@@ -148,7 +148,7 @@ inline void VSAPoint::SetSAAfter(qreal value)
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-Q_DECL_CONSTEXPR inline PieceNodeAngle VSAPoint::GetAngleType() const
+constexpr inline PieceNodeAngle VSAPoint::GetAngleType() const
 {
     return m_angle;
 }
@@ -170,10 +170,10 @@ public:
 
     VAbstractPiece &operator=(const VAbstractPiece &piece);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VAbstractPiece &operator=(VAbstractPiece &&piece) Q_DECL_NOTHROW;
+	VAbstractPiece &operator=(VAbstractPiece &&piece) noexcept;
 #endif
 
-	void Swap(VAbstractPiece &piece) Q_DECL_NOTHROW;
+	void Swap(VAbstractPiece &piece) noexcept;
 
     QString GetName() const;
     void    SetName(const QString &value);
@@ -235,7 +235,7 @@ private:
     static bool             ParallelCrossPoint(const QLineF &line1, const QLineF &line2, QPointF &point);
     static bool             Crossing(const QVector<QPointF> &sub1, const QVector<QPointF> &sub2);
     static QVector<QPointF> SubPath(const QVector<QPointF> &path, int startIndex, int endIndex);
-    static Q_DECL_CONSTEXPR qreal PointPosition(const QPointF &p, const QLineF &line);
+    static constexpr qreal PointPosition(const QPointF &p, const QLineF &line);
     static QVector<QPointF> AngleByLength(const QPointF &p2, const QPointF &sp1, const QPointF &sp2, const QPointF &sp3,
                                           qreal width);
     static QVector<QPointF> AngleByIntersection(const QPointF &p1, const QPointF &p2, const QPointF &p3,

--- a/src/libs/vlayout/vcontour.cpp
+++ b/src/libs/vlayout/vcontour.cpp
@@ -64,10 +64,10 @@
 #include "../vmisc/vmath.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VContour &VContour::operator=(VContour &&contour) Q_DECL_NOTHROW { Swap(contour); return *this; }
+VContour &VContour::operator=(VContour &&contour) noexcept { Swap(contour); return *this; }
 #endif
 
-void VContour::Swap(VContour &contour) Q_DECL_NOTHROW
+void VContour::Swap(VContour &contour) noexcept
 { std::swap(d, contour.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vlayout/vcontour.h
+++ b/src/libs/vlayout/vcontour.h
@@ -78,10 +78,10 @@ public:
 
     VContour &operator=(const VContour &contour);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VContour &operator=(VContour &&contour) Q_DECL_NOTHROW;
+	VContour &operator=(VContour &&contour) noexcept;
 #endif
 
-	void Swap(VContour &contour) Q_DECL_NOTHROW;
+	void Swap(VContour &contour) noexcept;
 
     void             SetContour(const QVector<QPointF> &contour);
     QVector<QPointF> GetContour() const;

--- a/src/libs/vlayout/vlayoutgenerator.h
+++ b/src/libs/vlayout/vlayoutgenerator.h
@@ -75,7 +75,7 @@ class VLayoutGenerator :public QObject
     Q_OBJECT
 public:
     explicit     VLayoutGenerator(QObject *parent = nullptr);
-    virtual     ~VLayoutGenerator() Q_DECL_OVERRIDE;
+    virtual     ~VLayoutGenerator() override;
 
     void         setPieces(const QVector<VLayoutPiece> &details);
     void         setLayoutGap(qreal width);

--- a/src/libs/vlayout/vlayoutpaper.cpp
+++ b/src/libs/vlayout/vlayoutpaper.cpp
@@ -73,14 +73,14 @@
 #include "vposition.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VLayoutPaper &VLayoutPaper::operator=(VLayoutPaper &&paper) Q_DECL_NOTHROW
+VLayoutPaper &VLayoutPaper::operator=(VLayoutPaper &&paper) noexcept
 {
     Swap(paper);
     return *this;
 }
 #endif
 
-void VLayoutPaper::Swap(VLayoutPaper &paper) Q_DECL_NOTHROW
+void VLayoutPaper::Swap(VLayoutPaper &paper) noexcept
 { std::swap(d, paper.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vlayout/vlayoutpaper.h
+++ b/src/libs/vlayout/vlayoutpaper.h
@@ -82,10 +82,10 @@ public:
     
 //check if the current compiler supports C++11's rvalue references
 #ifdef Q_COMPILER_RVALUE_REFS
-	VLayoutPaper &operator=(VLayoutPaper &&paper) Q_DECL_NOTHROW;
+	VLayoutPaper &operator=(VLayoutPaper &&paper) noexcept;
 #endif
 
-	void    Swap(VLayoutPaper &paper) Q_DECL_NOTHROW;
+	void    Swap(VLayoutPaper &paper) noexcept;
 
     int     GetHeight() const;
     void    setHeight(int height);

--- a/src/libs/vlayout/vlayoutpiece.cpp
+++ b/src/libs/vlayout/vlayoutpiece.cpp
@@ -388,10 +388,10 @@ QStringList PieceLabelText(const QVector<QPointF> &labelShape, const VTextManage
 //---------------------------------------------------------------------------------------------------------------------
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VLayoutPiece &VLayoutPiece::operator=(VLayoutPiece &&piece) Q_DECL_NOTHROW { Swap(piece); return *this; }
+VLayoutPiece &VLayoutPiece::operator=(VLayoutPiece &&piece) noexcept { Swap(piece); return *this; }
 #endif
 
-void VLayoutPiece::Swap(VLayoutPiece &piece) Q_DECL_NOTHROW
+void VLayoutPiece::Swap(VLayoutPiece &piece) noexcept
 { VAbstractPiece::Swap(piece); std::swap(d, piece.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vlayout/vlayoutpiece.h
+++ b/src/libs/vlayout/vlayoutpiece.h
@@ -82,15 +82,15 @@ public:
                               VLayoutPiece();
                               VLayoutPiece(const VLayoutPiece &detail);
 
-    virtual                  ~VLayoutPiece() Q_DECL_OVERRIDE;
+    virtual                  ~VLayoutPiece() override;
 
     VLayoutPiece              &operator=(const VLayoutPiece &detail);
 
 #ifdef Q_COMPILER_RVALUE_REFS
-	VLayoutPiece                &operator=(VLayoutPiece &&detail) Q_DECL_NOTHROW;
+	VLayoutPiece                &operator=(VLayoutPiece &&detail) noexcept;
 #endif
 
-	  void                      Swap(VLayoutPiece &detail) Q_DECL_NOTHROW;
+	  void                      Swap(VLayoutPiece &detail) noexcept;
 
     static VLayoutPiece       Create(const VPiece &piece, const VContainer *pattern);
 

--- a/src/libs/vlayout/vlayoutpiecepath.cpp
+++ b/src/libs/vlayout/vlayoutpiecepath.cpp
@@ -56,10 +56,10 @@
 #include <QPainterPath>
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VLayoutPiecePath &VLayoutPiecePath::operator=(VLayoutPiecePath &&path) Q_DECL_NOTHROW { Swap(path); return *this; }
+VLayoutPiecePath &VLayoutPiecePath::operator=(VLayoutPiecePath &&path) noexcept { Swap(path); return *this; }
 #endif
 
-void VLayoutPiecePath::Swap(VLayoutPiecePath &path) Q_DECL_NOTHROW
+void VLayoutPiecePath::Swap(VLayoutPiecePath &path) noexcept
 { std::swap(d, path.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vlayout/vlayoutpiecepath.h
+++ b/src/libs/vlayout/vlayoutpiecepath.h
@@ -70,10 +70,10 @@ public:
 
     VLayoutPiecePath &operator=(const VLayoutPiecePath &path);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VLayoutPiecePath &operator=(VLayoutPiecePath &&path) Q_DECL_NOTHROW;
+	VLayoutPiecePath &operator=(VLayoutPiecePath &&path) noexcept;
 #endif
 
-	void Swap(VLayoutPiecePath &path) Q_DECL_NOTHROW;
+	void Swap(VLayoutPiecePath &path) noexcept;
 
     QPainterPath     GetPainterPath() const;
 

--- a/src/libs/vlayout/vposition.h
+++ b/src/libs/vlayout/vposition.h
@@ -68,8 +68,8 @@ class VPosition : public QRunnable
 public:
                  VPosition(const VContour &sheet, int sheetEdgeNum, const VLayoutPiece &piece, int pieceEdgeNum,
                            std::atomic_bool *stop, bool rotate, int rotationIncrement, bool saveLength);
-    virtual     ~VPosition() Q_DECL_OVERRIDE{}
-    virtual void run() Q_DECL_OVERRIDE;
+    virtual     ~VPosition() override{}
+    virtual void run() override;
 
     VBestSquare  getBestResult() const;
 

--- a/src/libs/vmisc/dialogs/dialogexporttocsv.h
+++ b/src/libs/vmisc/dialogs/dialogexporttocsv.h
@@ -75,8 +75,8 @@ public:
     QChar                  Separator() const;
 
 protected:
-    virtual void           changeEvent(QEvent* event) Q_DECL_OVERRIDE;
-    virtual void           showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    virtual void           changeEvent(QEvent* event) override;
+    virtual void           showEvent(QShowEvent *event) override;
 
 private:
                            Q_DISABLE_COPY(DialogExportToCSV)

--- a/src/libs/vmisc/qxtcsvmodel.h
+++ b/src/libs/vmisc/qxtcsvmodel.h
@@ -61,14 +61,14 @@ public:
                          QChar separator = ',');
     virtual ~QxtCsvModel() Q_DECL_EQ_DEFAULT;
 
-    virtual int      rowCount(const QModelIndex& parent = QModelIndex()) const Q_DECL_OVERRIDE;
-    virtual int      columnCount(const QModelIndex& parent = QModelIndex()) const Q_DECL_OVERRIDE;
-    virtual QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
-    virtual bool     setData(const QModelIndex& index, const QVariant& data, int role = Qt::EditRole) Q_DECL_OVERRIDE;
+    virtual int      rowCount(const QModelIndex& parent = QModelIndex()) const override;
+    virtual int      columnCount(const QModelIndex& parent = QModelIndex()) const override;
+    virtual QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    virtual bool     setData(const QModelIndex& index, const QVariant& data, int role = Qt::EditRole) override;
     virtual QVariant headerData(int section, Qt::Orientation orientation,
-                                int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+                                int role = Qt::DisplayRole) const override;
     virtual bool     setHeaderData(int section, Qt::Orientation orientation, const QVariant& value,
-                                   int role = Qt::DisplayRole) Q_DECL_OVERRIDE;
+                                   int role = Qt::DisplayRole) override;
     void             setHeaderData(const QStringList& data);
 
     QString text(int row, int column) const;
@@ -79,16 +79,16 @@ public:
 
 
     bool insertRow(int row, const QModelIndex& parent = QModelIndex());
-    virtual bool insertRows(int row, int count, const QModelIndex& parent = QModelIndex()) Q_DECL_OVERRIDE;
+    virtual bool insertRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
     bool removeRow(int row, const QModelIndex& parent = QModelIndex());
-    virtual bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex()) Q_DECL_OVERRIDE;
+    virtual bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex()) override;
 
     bool insertColumn(int col, const QModelIndex& parent = QModelIndex());
-    virtual bool insertColumns(int col, int count, const QModelIndex& parent = QModelIndex()) Q_DECL_OVERRIDE;
+    virtual bool insertColumns(int col, int count, const QModelIndex& parent = QModelIndex()) override;
 
     bool removeColumn(int col, const QModelIndex& parent = QModelIndex());
-    virtual bool removeColumns(int col, int count, const QModelIndex& parent = QModelIndex()) Q_DECL_OVERRIDE;
+    virtual bool removeColumns(int col, int count, const QModelIndex& parent = QModelIndex()) override;
 
     void setSource(QIODevice *file, bool withHeader = false, QChar separator = ',', QTextCodec* codec = nullptr);
     void setSource(const QString &filename, bool withHeader = false, QChar separator = ',',
@@ -112,7 +112,7 @@ public:
     QuoteMode quoteMode() const;
     void setQuoteMode(QuoteMode mode);
 
-    virtual Qt::ItemFlags flags(const QModelIndex& index) const Q_DECL_OVERRIDE;
+    virtual Qt::ItemFlags flags(const QModelIndex& index) const override;
 
 private:
     Q_DISABLE_COPY(QxtCsvModel)

--- a/src/libs/vmisc/vabstractapplication.h
+++ b/src/libs/vmisc/vabstractapplication.h
@@ -86,7 +86,7 @@ class VAbstractApplication : public QApplication
     Q_OBJECT
 public:
     VAbstractApplication(int &argc, char ** argv);
-    virtual ~VAbstractApplication() Q_DECL_OVERRIDE;
+    virtual ~VAbstractApplication() override;
 
     virtual const VTranslateVars *translateVariables()=0;
 

--- a/src/libs/vobj/vobjengine.h
+++ b/src/libs/vobj/vobjengine.h
@@ -71,18 +71,18 @@ class VObjEngine : public QPaintEngine
 {
 public:
     VObjEngine();
-    virtual ~VObjEngine() Q_DECL_OVERRIDE;
+    virtual ~VObjEngine() override;
 
-    virtual bool begin(QPaintDevice *pdev) Q_DECL_OVERRIDE;
-    virtual bool end() Q_DECL_OVERRIDE;
-    virtual void updateState(const QPaintEngineState &state) Q_DECL_OVERRIDE;
-    virtual void drawPath(const QPainterPath &path) Q_DECL_OVERRIDE;
-    virtual Type type() const Q_DECL_OVERRIDE;
-    virtual void drawPoints(const QPointF *points, int pointCount) Q_DECL_OVERRIDE;
-    virtual void drawPoints(const QPoint *points, int pointCount) Q_DECL_OVERRIDE;
-    virtual void drawPixmap(const QRectF &r, const QPixmap &pm, const QRectF &sr) Q_DECL_OVERRIDE;
-    virtual void drawPolygon(const QPointF *points, int pointCount, PolygonDrawMode mode) Q_DECL_OVERRIDE;
-    virtual void drawPolygon(const QPoint *points, int pointCount, PolygonDrawMode mode) Q_DECL_OVERRIDE;
+    virtual bool begin(QPaintDevice *pdev) override;
+    virtual bool end() override;
+    virtual void updateState(const QPaintEngineState &state) override;
+    virtual void drawPath(const QPainterPath &path) override;
+    virtual Type type() const override;
+    virtual void drawPoints(const QPointF *points, int pointCount) override;
+    virtual void drawPoints(const QPoint *points, int pointCount) override;
+    virtual void drawPixmap(const QRectF &r, const QPixmap &pm, const QRectF &sr) override;
+    virtual void drawPolygon(const QPointF *points, int pointCount, PolygonDrawMode mode) override;
+    virtual void drawPolygon(const QPoint *points, int pointCount, PolygonDrawMode mode) override;
 
     QSize getSize() const;
     void setSize(const QSize &value);

--- a/src/libs/vobj/vobjpaintdevice.h
+++ b/src/libs/vobj/vobjpaintdevice.h
@@ -66,8 +66,8 @@ class VObjPaintDevice : public QPaintDevice
 {
 public:
     VObjPaintDevice();
-    virtual ~VObjPaintDevice() Q_DECL_OVERRIDE;
-    virtual QPaintEngine *paintEngine() const Q_DECL_OVERRIDE;
+    virtual ~VObjPaintDevice() override;
+    virtual QPaintEngine *paintEngine() const override;
 
     QString getFileName() const;
     void setFileName(const QString &value);
@@ -82,7 +82,7 @@ public:
     void setResolution(int dpi);
 
 protected:
-    virtual int metric(PaintDeviceMetric metric) const Q_DECL_OVERRIDE;
+    virtual int metric(PaintDeviceMetric metric) const override;
 private:
     Q_DISABLE_COPY(VObjPaintDevice)
     QSharedPointer<VObjEngine> engine;

--- a/src/libs/vpatterndb/floatItemData/vabstractfloatitemdata.cpp
+++ b/src/libs/vpatterndb/floatItemData/vabstractfloatitemdata.cpp
@@ -54,10 +54,10 @@
 #include <QtDebug>
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VAbstractFloatItemData &VAbstractFloatItemData::operator=(VAbstractFloatItemData &&data) Q_DECL_NOTHROW { Swap(data); return *this; }
+VAbstractFloatItemData &VAbstractFloatItemData::operator=(VAbstractFloatItemData &&data) noexcept { Swap(data); return *this; }
 #endif
 
-void VAbstractFloatItemData::Swap(VAbstractFloatItemData &data) Q_DECL_NOTHROW
+void VAbstractFloatItemData::Swap(VAbstractFloatItemData &data) noexcept
 { std::swap(d, data.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/floatItemData/vabstractfloatitemdata.h
+++ b/src/libs/vpatterndb/floatItemData/vabstractfloatitemdata.h
@@ -67,10 +67,10 @@ public:
 
     VAbstractFloatItemData &operator=(const VAbstractFloatItemData &data);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VAbstractFloatItemData &operator=(VAbstractFloatItemData &&data) Q_DECL_NOTHROW;
+	VAbstractFloatItemData &operator=(VAbstractFloatItemData &&data) noexcept;
 #endif
 
-	void Swap(VAbstractFloatItemData &data) Q_DECL_NOTHROW;
+	void Swap(VAbstractFloatItemData &data) noexcept;
 
     // methods, which set and return values of different parameters
     QPointF GetPos() const;

--- a/src/libs/vpatterndb/floatItemData/vgrainlinedata.cpp
+++ b/src/libs/vpatterndb/floatItemData/vgrainlinedata.cpp
@@ -54,10 +54,10 @@
 #include "vgrainlinedata_p.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VGrainlineData &VGrainlineData::operator=(VGrainlineData &&data) Q_DECL_NOTHROW { Swap(data); return *this; }
+VGrainlineData &VGrainlineData::operator=(VGrainlineData &&data) noexcept { Swap(data); return *this; }
 #endif
 
-void VGrainlineData::Swap(VGrainlineData &data) Q_DECL_NOTHROW
+void VGrainlineData::Swap(VGrainlineData &data) noexcept
 { VAbstractFloatItemData::Swap(data); std::swap(d, data.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/floatItemData/vgrainlinedata.h
+++ b/src/libs/vpatterndb/floatItemData/vgrainlinedata.h
@@ -73,10 +73,10 @@ public:
 
     VGrainlineData &operator=(const VGrainlineData &data);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VGrainlineData &operator=(VGrainlineData &&data) Q_DECL_NOTHROW;
+	VGrainlineData &operator=(VGrainlineData &&data) noexcept;
 #endif
 
-	void            Swap(VGrainlineData &data) Q_DECL_NOTHROW;
+	void            Swap(VGrainlineData &data) noexcept;
 
     // methods, which set and return values of different parameters
     QString         getLength() const;

--- a/src/libs/vpatterndb/floatItemData/vpatternlabeldata.cpp
+++ b/src/libs/vpatterndb/floatItemData/vpatternlabeldata.cpp
@@ -31,11 +31,11 @@
 #include "../ifc/ifcdef.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VPatternLabelData &VPatternLabelData::operator=(VPatternLabelData &&data) Q_DECL_NOTHROW
+VPatternLabelData &VPatternLabelData::operator=(VPatternLabelData &&data) noexcept
 { Swap(data); return *this; }
 #endif
 
-void VPatternLabelData::Swap(VPatternLabelData &data) Q_DECL_NOTHROW
+void VPatternLabelData::Swap(VPatternLabelData &data) noexcept
 { VAbstractFloatItemData::Swap(data); std::swap(d, data.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/floatItemData/vpatternlabeldata.h
+++ b/src/libs/vpatterndb/floatItemData/vpatternlabeldata.h
@@ -48,10 +48,10 @@ public:
 
     VPatternLabelData &operator=(const VPatternLabelData &data);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VPatternLabelData &operator=(VPatternLabelData &&data) Q_DECL_NOTHROW;
+	VPatternLabelData &operator=(VPatternLabelData &&data) noexcept;
 #endif
 
-	void    Swap(VPatternLabelData &data) Q_DECL_NOTHROW;
+	void    Swap(VPatternLabelData &data) noexcept;
 
     // methods, which set up label parameters
     QString GetLabelWidth() const;

--- a/src/libs/vpatterndb/floatItemData/vpiecelabeldata.cpp
+++ b/src/libs/vpatterndb/floatItemData/vpiecelabeldata.cpp
@@ -32,11 +32,11 @@
 #include <QList>
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VPieceLabelData &VPieceLabelData::operator=(VPieceLabelData &&data) Q_DECL_NOTHROW
+VPieceLabelData &VPieceLabelData::operator=(VPieceLabelData &&data) noexcept
 { Swap(data); return *this; }
 #endif
 
-void VPieceLabelData::Swap(VPieceLabelData &data) Q_DECL_NOTHROW
+void VPieceLabelData::Swap(VPieceLabelData &data) noexcept
 { VPatternLabelData::Swap(data); std::swap(d, data.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/floatItemData/vpiecelabeldata.h
+++ b/src/libs/vpatterndb/floatItemData/vpiecelabeldata.h
@@ -51,10 +51,10 @@ public:
 
     VPieceLabelData &operator=(const VPieceLabelData &data);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VPieceLabelData &operator=(VPieceLabelData &&data) Q_DECL_NOTHROW;
+	VPieceLabelData &operator=(VPieceLabelData &&data) noexcept;
 #endif
 
-	void Swap(VPieceLabelData &data) Q_DECL_NOTHROW;
+	void Swap(VPieceLabelData &data) noexcept;
 
     void Clear();
 

--- a/src/libs/vpatterndb/variables/custom_variable.cpp
+++ b/src/libs/vpatterndb/variables/custom_variable.cpp
@@ -55,10 +55,10 @@
 #include "vvariable.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-CustomVariable &CustomVariable::operator=(CustomVariable &&variable) Q_DECL_NOTHROW { Swap(variable); return *this; }
+CustomVariable &CustomVariable::operator=(CustomVariable &&variable) noexcept { Swap(variable); return *this; }
 #endif
 
-void CustomVariable::Swap(CustomVariable &variable) Q_DECL_NOTHROW
+void CustomVariable::Swap(CustomVariable &variable) noexcept
 { VVariable::Swap(variable); std::swap(d, variable.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/variables/custom_variable.h
+++ b/src/libs/vpatterndb/variables/custom_variable.h
@@ -78,10 +78,10 @@ public:
                 CustomVariable &operator=(const CustomVariable &variable);
 
 #ifdef Q_COMPILER_RVALUE_REFS
-	            CustomVariable &operator=(CustomVariable &&variable) Q_DECL_NOTHROW;
+	            CustomVariable &operator=(CustomVariable &&variable) noexcept;
 #endif
 
-    void        Swap(CustomVariable &variable) Q_DECL_NOTHROW;
+    void        Swap(CustomVariable &variable) noexcept;
     quint32     getIndex() const;
     QString     GetFormula() const;
     bool        IsFormulaOk() const;

--- a/src/libs/vpatterndb/variables/measurement_variable.cpp
+++ b/src/libs/vpatterndb/variables/measurement_variable.cpp
@@ -64,11 +64,11 @@
 #include "measurement_variable_p.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-MeasurementVariable &MeasurementVariable::operator=(MeasurementVariable &&m) Q_DECL_NOTHROW
+MeasurementVariable &MeasurementVariable::operator=(MeasurementVariable &&m) noexcept
 { Swap(m); return *this; }
 #endif
 
-void MeasurementVariable::Swap(MeasurementVariable &m) Q_DECL_NOTHROW
+void MeasurementVariable::Swap(MeasurementVariable &m) noexcept
 { VVariable::Swap(m); std::swap(d, m.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/variables/measurement_variable.h
+++ b/src/libs/vpatterndb/variables/measurement_variable.h
@@ -87,15 +87,15 @@ public:
                                            const QString &description = QString(), const QString &tagName = QString());
 
                        MeasurementVariable(const MeasurementVariable &m);
-    virtual           ~MeasurementVariable() Q_DECL_OVERRIDE;
+    virtual           ~MeasurementVariable() override;
 
                        MeasurementVariable &operator=(const MeasurementVariable &m);
 
 #ifdef Q_COMPILER_RVALUE_REFS
-	                   MeasurementVariable &operator=(MeasurementVariable &&m) Q_DECL_NOTHROW;
+	                   MeasurementVariable &operator=(MeasurementVariable &&m) noexcept;
 #endif
 
-    void               Swap(MeasurementVariable &m) Q_DECL_NOTHROW;
+    void               Swap(MeasurementVariable &m) noexcept;
 
     QString            getGuiText() const;
 
@@ -109,10 +109,10 @@ public:
     int                Index() const;
     bool               IsFormulaOk() const;
 
-    virtual bool       isNotUsed() const Q_DECL_OVERRIDE;
+    virtual bool       isNotUsed() const override;
 
-    virtual qreal      GetValue() const Q_DECL_OVERRIDE;
-    virtual qreal     *GetValue() Q_DECL_OVERRIDE;
+    virtual qreal      GetValue() const override;
+    virtual qreal     *GetValue() override;
 
     VContainer        *GetData();
 

--- a/src/libs/vpatterndb/variables/varcradius.h
+++ b/src/libs/vpatterndb/variables/varcradius.h
@@ -71,7 +71,7 @@ public:
                Unit patternUnit);
     VArcRadius(const VArcRadius &var);
     VArcRadius &operator=(const VArcRadius &var);
-    virtual ~VArcRadius() Q_DECL_OVERRIDE;
+    virtual ~VArcRadius() override;
 };
 
 #endif // VARCRADIUS_H

--- a/src/libs/vpatterndb/variables/varcradius_p.h
+++ b/src/libs/vpatterndb/variables/varcradius_p.h
@@ -76,7 +76,7 @@ public:
         :QSharedData(var), arcId(var.arcId)
     {}
 
-    virtual  ~VArcRadiusData() Q_DECL_OVERRIDE;
+    virtual  ~VArcRadiusData() override;
 
     quint32 arcId;
 

--- a/src/libs/vpatterndb/variables/vcurveangle.h
+++ b/src/libs/vpatterndb/variables/vcurveangle.h
@@ -72,7 +72,7 @@ public:
                 CurveAngle angle, qint32 segment);
     VCurveAngle(const VCurveAngle &var);
     VCurveAngle &operator=(const VCurveAngle &var);
-    virtual ~VCurveAngle() Q_DECL_OVERRIDE;
+    virtual ~VCurveAngle() override;
 };
 
 #endif // VCURVEANGLE_H

--- a/src/libs/vpatterndb/variables/vcurveclength.h
+++ b/src/libs/vpatterndb/variables/vcurveclength.h
@@ -73,7 +73,7 @@ public:
                  CurveCLength cType, Unit patternUnit, qint32 segment);
     VCurveCLength(const VCurveCLength &var);
     VCurveCLength &operator=(const VCurveCLength &var);
-    virtual ~VCurveCLength() Q_DECL_OVERRIDE;
+    virtual ~VCurveCLength() override;
 };
 
 #endif // VCURVECLENGTH_H

--- a/src/libs/vpatterndb/variables/vcurvelength.h
+++ b/src/libs/vpatterndb/variables/vcurvelength.h
@@ -72,7 +72,7 @@ public:
                  Unit patternUnit, qint32 segment);
     VCurveLength(const VCurveLength &var);
     VCurveLength &operator=(const VCurveLength &var);
-    virtual ~VCurveLength() Q_DECL_OVERRIDE;
+    virtual ~VCurveLength() override;
 };
 
 #endif // VCURVELENGTH_H

--- a/src/libs/vpatterndb/variables/vcurvevariable.cpp
+++ b/src/libs/vpatterndb/variables/vcurvevariable.cpp
@@ -57,11 +57,11 @@
 #include "vcurvevariable_p.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VCurveVariable &VCurveVariable::operator=(VCurveVariable &&var) Q_DECL_NOTHROW
+VCurveVariable &VCurveVariable::operator=(VCurveVariable &&var) noexcept
 { Swap(var); return *this; }
 #endif
 
-void VCurveVariable::Swap(VCurveVariable &var) Q_DECL_NOTHROW
+void VCurveVariable::Swap(VCurveVariable &var) noexcept
 { VInternalVariable::Swap(var); std::swap(d, var.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/variables/vcurvevariable.h
+++ b/src/libs/vpatterndb/variables/vcurvevariable.h
@@ -68,16 +68,16 @@ public:
     VCurveVariable(const quint32 &id, const quint32 &parentId);
     VCurveVariable(const VCurveVariable &var);
 
-    virtual ~VCurveVariable() Q_DECL_OVERRIDE;
+    virtual ~VCurveVariable() override;
 
     VCurveVariable &operator=(const VCurveVariable &var);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VCurveVariable &operator=(VCurveVariable &&var) Q_DECL_NOTHROW;
+	VCurveVariable &operator=(VCurveVariable &&var) noexcept;
 #endif
 
-	void Swap(VCurveVariable &var) Q_DECL_NOTHROW;
+	void Swap(VCurveVariable &var) noexcept;
 
-    virtual bool Filter(quint32 id) Q_DECL_OVERRIDE;
+    virtual bool Filter(quint32 id) override;
 
     quint32      GetId() const;
     void         SetId(const quint32 &id);

--- a/src/libs/vpatterndb/variables/vinternalvariable.cpp
+++ b/src/libs/vpatterndb/variables/vinternalvariable.cpp
@@ -53,10 +53,10 @@
 #include "vinternalvariable_p.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VInternalVariable &VInternalVariable::operator=(VInternalVariable &&var) Q_DECL_NOTHROW { Swap(var); return *this; }
+VInternalVariable &VInternalVariable::operator=(VInternalVariable &&var) noexcept { Swap(var); return *this; }
 #endif
 
-void VInternalVariable::Swap(VInternalVariable &var) Q_DECL_NOTHROW
+void VInternalVariable::Swap(VInternalVariable &var) noexcept
 { std::swap(d, var.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/variables/vinternalvariable.h
+++ b/src/libs/vpatterndb/variables/vinternalvariable.h
@@ -71,10 +71,10 @@ public:
 
     VInternalVariable &operator=(const VInternalVariable &var);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VInternalVariable &operator=(VInternalVariable &&var) Q_DECL_NOTHROW;
+	VInternalVariable &operator=(VInternalVariable &&var) noexcept;
 #endif
 
-	void Swap(VInternalVariable &var) Q_DECL_NOTHROW;
+	void Swap(VInternalVariable &var) noexcept;
 
     virtual qreal  GetValue() const;
     virtual qreal* GetValue();

--- a/src/libs/vpatterndb/variables/vlineangle.cpp
+++ b/src/libs/vpatterndb/variables/vlineangle.cpp
@@ -64,11 +64,11 @@
 #include "vlineangle_p.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VLineAngle &VLineAngle::operator=(VLineAngle &&var) Q_DECL_NOTHROW
+VLineAngle &VLineAngle::operator=(VLineAngle &&var) noexcept
 { Swap(var); return *this; }
 #endif
 
-void VLineAngle::Swap(VLineAngle &var) Q_DECL_NOTHROW
+void VLineAngle::Swap(VLineAngle &var) noexcept
 { VInternalVariable::Swap(var); std::swap(d, var.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/variables/vlineangle.h
+++ b/src/libs/vpatterndb/variables/vlineangle.h
@@ -69,16 +69,16 @@ public:
     VLineAngle(const VPointF *p1, const quint32 &p1Id, const VPointF *p2, const quint32 &p2Id);
     VLineAngle(const VLineAngle &var);
 
-    virtual ~VLineAngle() Q_DECL_OVERRIDE;
+    virtual ~VLineAngle() override;
 
     VLineAngle &operator=(const VLineAngle &var);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VLineAngle &operator=(VLineAngle &&var) Q_DECL_NOTHROW;
+	VLineAngle &operator=(VLineAngle &&var) noexcept;
 #endif
 
-	void Swap(VLineAngle &var) Q_DECL_NOTHROW;
+	void Swap(VLineAngle &var) noexcept;
 
-    virtual bool Filter(quint32 id) Q_DECL_OVERRIDE;
+    virtual bool Filter(quint32 id) override;
     void         SetValue(const VPointF *p1, const VPointF *p2);
     quint32      GetP1Id() const;
     quint32      GetP2Id() const;

--- a/src/libs/vpatterndb/variables/vlinelength.cpp
+++ b/src/libs/vpatterndb/variables/vlinelength.cpp
@@ -62,11 +62,11 @@
 #include "vlinelength_p.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VLengthLine &VLengthLine::operator=(VLengthLine &&var) Q_DECL_NOTHROW
+VLengthLine &VLengthLine::operator=(VLengthLine &&var) noexcept
 { Swap(var); return *this; }
 #endif
 
-void VLengthLine::Swap(VLengthLine &var) Q_DECL_NOTHROW
+void VLengthLine::Swap(VLengthLine &var) noexcept
 { VInternalVariable::Swap(var); std::swap(d, var.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/variables/vlinelength.h
+++ b/src/libs/vpatterndb/variables/vlinelength.h
@@ -71,16 +71,16 @@ public:
     VLengthLine(const VPointF *p1, const quint32 &p1Id, const VPointF *p2, const quint32 &p2Id, Unit patternUnit);
     VLengthLine(const VLengthLine &var);
 
-    virtual ~VLengthLine() Q_DECL_OVERRIDE;
+    virtual ~VLengthLine() override;
 
     VLengthLine &operator=(const VLengthLine &var);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VLengthLine &operator=(VLengthLine &&var) Q_DECL_NOTHROW;
+	VLengthLine &operator=(VLengthLine &&var) noexcept;
 #endif
 
-	void Swap(VLengthLine &var) Q_DECL_NOTHROW;
+	void Swap(VLengthLine &var) noexcept;
 
-    virtual bool Filter(quint32 id) Q_DECL_OVERRIDE;
+    virtual bool Filter(quint32 id) override;
     void         SetValue(const VPointF *p1, const VPointF *p2);
     quint32      GetP1Id() const;
     quint32      GetP2Id() const;

--- a/src/libs/vpatterndb/variables/vvariable.cpp
+++ b/src/libs/vpatterndb/variables/vvariable.cpp
@@ -58,11 +58,11 @@
 #include "vvariable_p.h"
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VVariable &VVariable::operator=(VVariable &&var) Q_DECL_NOTHROW
+VVariable &VVariable::operator=(VVariable &&var) noexcept
 { Swap(var); return *this; }
 #endif
 
-void VVariable::Swap(VVariable &var) Q_DECL_NOTHROW
+void VVariable::Swap(VVariable &var) noexcept
 { VInternalVariable::Swap(var); std::swap(d, var.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/variables/vvariable.h
+++ b/src/libs/vpatterndb/variables/vvariable.h
@@ -71,14 +71,14 @@ public:
     VVariable(const QString &name, const QString &description = QString());
     VVariable(const VVariable &var);
 
-    virtual ~VVariable() Q_DECL_OVERRIDE;
+    virtual ~VVariable() override;
 
     VVariable &operator=(const VVariable &var);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VVariable &operator=(VVariable &&var) Q_DECL_NOTHROW;
+	VVariable &operator=(VVariable &&var) noexcept;
 #endif
 
-	void Swap(VVariable &var) Q_DECL_NOTHROW;
+	void Swap(VVariable &var) noexcept;
 
     QString GetDescription() const;
     void    SetDescription(const QString &desc);

--- a/src/libs/vpatterndb/vcontainer.cpp
+++ b/src/libs/vpatterndb/vcontainer.cpp
@@ -91,7 +91,7 @@ qreal VContainer::_height = 176;
 QSet<QString> VContainer::uniqueNames = QSet<QString>();
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VContainer &VContainer::operator=(VContainer &&data) Q_DECL_NOTHROW
+VContainer &VContainer::operator=(VContainer &&data) noexcept
 { Swap(data); return *this; }
 #endif
 
@@ -107,7 +107,7 @@ VContainer &VContainer::operator=(VContainer &&data) Q_DECL_NOTHROW
  * - This method uses `std::swap` to exchange the data pointers of the two VContainer instances.
  * - It ensures that the swap operation is performed without throwing exceptions.
  */
-void VContainer::Swap(VContainer &data) Q_DECL_NOTHROW
+void VContainer::Swap(VContainer &data) noexcept
 { std::swap(d, data.d); }
 
 /**

--- a/src/libs/vpatterndb/vcontainer.h
+++ b/src/libs/vpatterndb/vcontainer.h
@@ -190,8 +190,8 @@ QT_WARNING_POP
  * - VContainer(const VContainer &data);
  * - ~VContainer();
  * - VContainer &operator=(const VContainer &data);
- * - VContainer &operator=(VContainer &&data) Q_DECL_NOTHROW;
- * - void Swap(VContainer &data) Q_DECL_NOTHROW;
+ * - VContainer &operator=(VContainer &&data) noexcept;
+ * - void Swap(VContainer &data) noexcept;
  * - template <typename T> const QSharedPointer<T> GeometricObject(const quint32 &id) const;
  * - const QSharedPointer<VGObject> GetGObject(quint32 id) const;
  * - static const QSharedPointer<VGObject> GetFakeGObject(quint32 id);
@@ -269,10 +269,10 @@ public:
 
     VContainer &operator=(const VContainer &data);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VContainer &operator=(VContainer &&data) Q_DECL_NOTHROW;
+	VContainer &operator=(VContainer &&data) noexcept;
 #endif
 
-	void Swap(VContainer &data) Q_DECL_NOTHROW;
+	void Swap(VContainer &data) noexcept;
 
     template <typename T>
     const QSharedPointer<T> GeometricObject(const quint32 &id) const;

--- a/src/libs/vpatterndb/vnodedetail.cpp
+++ b/src/libs/vpatterndb/vnodedetail.cpp
@@ -120,11 +120,11 @@ void ConvertAfter(VPieceNode &node, const QLineF &line, qreal mX, qreal mY)
 }//static functions
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VNodeDetail &VNodeDetail::operator=(VNodeDetail &&node) Q_DECL_NOTHROW
+VNodeDetail &VNodeDetail::operator=(VNodeDetail &&node) noexcept
 { Swap(node); return *this; }
 #endif
 
-void VNodeDetail::Swap(VNodeDetail &node) Q_DECL_NOTHROW
+void VNodeDetail::Swap(VNodeDetail &node) noexcept
 { std::swap(d, node.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/vnodedetail.h
+++ b/src/libs/vpatterndb/vnodedetail.h
@@ -97,10 +97,10 @@ public:
      */
     VNodeDetail &operator=(const VNodeDetail &node);
 #ifdef Q_COMPILER_RVALUE_REFS
-	VNodeDetail &operator=(VNodeDetail &&node) Q_DECL_NOTHROW;
+	VNodeDetail &operator=(VNodeDetail &&node) noexcept;
 #endif
 
-	void Swap(VNodeDetail &node) Q_DECL_NOTHROW;
+	void Swap(VNodeDetail &node) noexcept;
 
     /**
      * @brief getId return object id.

--- a/src/libs/vpatterndb/vpiece.cpp
+++ b/src/libs/vpatterndb/vpiece.cpp
@@ -115,11 +115,11 @@ bool notchesPossible(const QVector<VPieceNode> &path)
 //---------------------------------------------------------------------------------------------------------------------
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VPiece &VPiece::operator=(VPiece &&piece) Q_DECL_NOTHROW
+VPiece &VPiece::operator=(VPiece &&piece) noexcept
 { Swap(piece); return *this; }
 #endif
 
-void VPiece::Swap(VPiece &piece) Q_DECL_NOTHROW
+void VPiece::Swap(VPiece &piece) noexcept
 { VAbstractPiece::Swap(piece); std::swap(d, piece.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/vpiece.h
+++ b/src/libs/vpatterndb/vpiece.h
@@ -94,10 +94,10 @@ public:
     VPiece                  &operator=(const VPiece &piece);
 
 #ifdef Q_COMPILER_RVALUE_REFS
-    VPiece                  &operator=(VPiece &&piece) Q_DECL_NOTHROW;
+    VPiece                  &operator=(VPiece &&piece) noexcept;
 #endif
 
-    void                     Swap(VPiece &piece) Q_DECL_NOTHROW;
+    void                     Swap(VPiece &piece) noexcept;
 
     VPiecePath               GetPath() const;
     VPiecePath              &GetPath();

--- a/src/libs/vpatterndb/vpiecenode.cpp
+++ b/src/libs/vpatterndb/vpiecenode.cpp
@@ -95,11 +95,11 @@ qreal EvalFormula(const VContainer *data, QString formula)
 //---------------------------------------------------------------------------------------------------------------------
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VPieceNode &VPieceNode::operator=(VPieceNode &&node) Q_DECL_NOTHROW
+VPieceNode &VPieceNode::operator=(VPieceNode &&node) noexcept
 { Swap(node); return *this; }
 #endif
 
-void VPieceNode::Swap(VPieceNode &node) Q_DECL_NOTHROW
+void VPieceNode::Swap(VPieceNode &node) noexcept
 { std::swap(d, node.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/vpiecenode.h
+++ b/src/libs/vpatterndb/vpiecenode.h
@@ -72,10 +72,10 @@ public:
     VPieceNode         &operator=(const VPieceNode &node);
 
 #ifdef Q_COMPILER_RVALUE_REFS
-	VPieceNode           &operator=(VPieceNode &&node) Q_DECL_NOTHROW;
+	VPieceNode           &operator=(VPieceNode &&node) noexcept;
 #endif
 
-	void                  Swap(VPieceNode &node) Q_DECL_NOTHROW;
+	void                  Swap(VPieceNode &node) noexcept;
 
     friend QDataStream &operator<<(QDataStream &out, const VPieceNode &);
     friend QDataStream &operator>>(QDataStream &in, VPieceNode &p);

--- a/src/libs/vpatterndb/vpiecepath.cpp
+++ b/src/libs/vpatterndb/vpiecepath.cpp
@@ -197,11 +197,11 @@ bool intersectsWithCutLine(const QVector<QPointF> &cutPath, const QVector<QPoint
 //---------------------------------------------------------------------------------------------------------------------
 
 #ifdef Q_COMPILER_RVALUE_REFS
-VPiecePath &VPiecePath::operator=(VPiecePath &&path) Q_DECL_NOTHROW
+VPiecePath &VPiecePath::operator=(VPiecePath &&path) noexcept
 { Swap(path); return *this; }
 #endif
 
-void VPiecePath::Swap(VPiecePath &path) Q_DECL_NOTHROW
+void VPiecePath::Swap(VPiecePath &path) noexcept
 { std::swap(d, path.d); }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/libs/vpatterndb/vpiecepath.h
+++ b/src/libs/vpatterndb/vpiecepath.h
@@ -77,10 +77,10 @@ public:
     VPiecePath         &operator=(const VPiecePath &path);
 
 #ifdef Q_COMPILER_RVALUE_REFS
-    VPiecePath         &operator=(VPiecePath &&path) Q_DECL_NOTHROW;
+    VPiecePath         &operator=(VPiecePath &&path) noexcept;
 #endif
 
-	void               Swap(VPiecePath &path) Q_DECL_NOTHROW;
+	void               Swap(VPiecePath &path) noexcept;
     void               Append(const VPieceNode &node);
     void               Clear();
     qint32             nodeCount() const;

--- a/src/libs/vpatterndb/vtranslatevars.h
+++ b/src/libs/vpatterndb/vtranslatevars.h
@@ -61,7 +61,7 @@ class VTranslateVars : public VTranslateMeasurements
 {
 public:
     explicit VTranslateVars();
-    virtual ~VTranslateVars() Q_DECL_OVERRIDE;
+    virtual ~VTranslateVars() override;
 
     bool VariablesFromUser(QString &newFormula, int position, const QString &token, int &bias) const;
     bool PostfixOperatorsFromUser(QString &newFormula, int position, const QString &token, int &bias) const;
@@ -87,7 +87,7 @@ public:
     static QString TryFormulaFromUser(const QString &formula, bool osSeparator);
     QString FormulaToUser(const QString &formula, bool osSeparator) const;
 
-    virtual void Retranslate() Q_DECL_OVERRIDE;
+    virtual void Retranslate() override;
 
     QMap<QString, qmu::QmuTranslation> getFunctions() const;
 

--- a/src/libs/vpropertyexplorer/checkablemessagebox.h
+++ b/src/libs/vpropertyexplorer/checkablemessagebox.h
@@ -48,7 +48,7 @@ class CheckableMessageBox : public QDialog
 
 public:
     explicit CheckableMessageBox(QWidget *parent);
-    virtual ~CheckableMessageBox() Q_DECL_OVERRIDE;
+    virtual ~CheckableMessageBox() override;
 
     static QDialogButtonBox::StandardButton
         question(QWidget *parent,

--- a/src/libs/vpropertyexplorer/plugins/Vector3d/vvector3dproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/Vector3d/vvector3dproperty.h
@@ -75,13 +75,13 @@ class QVector3DProperty : public VProperty
 public:
     explicit QVector3DProperty(const QString& name);
 
-    virtual ~QVector3DProperty() Q_DECL_OVERRIDE {}
+    virtual ~QVector3DProperty() override {}
 
     //! Get the data how it should be displayed
-    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const override;
 
     //! Returns item flags
-    virtual Qt::ItemFlags flags(int column = DPC_Name) const Q_DECL_OVERRIDE;
+    virtual Qt::ItemFlags flags(int column = DPC_Name) const override;
 
     //! Returns the Vector3d
     virtual Vector3D getVector() const;
@@ -93,20 +93,20 @@ public:
     virtual void setVector(double x, double y, double z);
 
     //! Returns a string containing the type of the property
-    virtual QString type() const Q_DECL_OVERRIDE;
+    virtual QString type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
     //! \param container If a property is being passed here, no new VProperty is being created but instead it is tried
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
-    virtual VProperty* clone(bool include_children = true, VProperty* container = NULL) const Q_DECL_OVERRIDE;
+    virtual VProperty* clone(bool include_children = true, VProperty* container = NULL) const override;
 
     //! Sets the value of the property
-    virtual void setValue(const QVariant& value) Q_DECL_OVERRIDE;
+    virtual void setValue(const QVariant& value) override;
 
     //! Returns the value of the property as a QVariant
-    virtual QVariant getValue() const Q_DECL_OVERRIDE;
+    virtual QVariant getValue() const override;
 
 private:
     Q_DISABLE_COPY(QVector3DProperty)

--- a/src/libs/vpropertyexplorer/plugins/direction_property.h
+++ b/src/libs/vpropertyexplorer/plugins/direction_property.h
@@ -50,10 +50,10 @@ public:
     explicit               DirectionProperty(const QString &name);
 
     //! Destructor
-    virtual               ~DirectionProperty() Q_DECL_OVERRIDE {}
+    virtual               ~DirectionProperty() override {}
 
     //! Get the data how it should be displayed
-    virtual QVariant       data (int column = DPC_Name, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant       data (int column = DPC_Name, int role = Qt::DisplayRole) const override;
 
     //! Returns an editor widget, or NULL if it doesn't supply one
     //! \param parent The widget to which the editor will be added as a child
@@ -61,10 +61,10 @@ public:
     //! \delegate A pointer to the QAbstractItemDelegate requesting the editor. This can be used to connect signals and
     //! slots.
     virtual QWidget       *createEditor(QWidget *parent, const QStyleOptionViewItem &options,
-                                  const QAbstractItemDelegate *delegate) Q_DECL_OVERRIDE;
+                                  const QAbstractItemDelegate *delegate) override;
 
     //! Gets the data from the widget
-    virtual QVariant       getEditorData(const QWidget *editor) const Q_DECL_OVERRIDE;
+    virtual QVariant       getEditorData(const QWidget *editor) const override;
 
     //! Sets the directions
     virtual void           setDirections(const QMap<QString, QString> &directions);
@@ -73,10 +73,10 @@ public:
     virtual QMap<QString, QString> getDirections() const;
 
     //! Sets the value of the property
-    virtual void           setValue(const QVariant &value) Q_DECL_OVERRIDE;
+    virtual void           setValue(const QVariant &value) override;
 
     //! Returns a string containing the type of the property
-    virtual QString        type() const Q_DECL_OVERRIDE;
+    virtual QString        type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
@@ -84,7 +84,7 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty *clone(bool include_children = true,
-                                               VProperty *container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty *container = nullptr) const override;
 
     static int             indexOfDirection(const QMap<QString, QString> &directions, const QString &direction);
 

--- a/src/libs/vpropertyexplorer/plugins/expandingtextedit.h
+++ b/src/libs/vpropertyexplorer/plugins/expandingtextedit.h
@@ -39,8 +39,8 @@ public:
                  ExpandingTextEdit(const QString &contents, QWidget *parent = nullptr);
 
 protected:
-    virtual void focusInEvent(QFocusEvent *event) Q_DECL_OVERRIDE;
-    virtual void focusOutEvent(QFocusEvent *event) Q_DECL_OVERRIDE;
+    virtual void focusInEvent(QFocusEvent *event) override;
+    virtual void focusOutEvent(QFocusEvent *event) override;
 
 private:
     Q_DISABLE_COPY(ExpandingTextEdit)

--- a/src/libs/vpropertyexplorer/plugins/lineweight_property.h
+++ b/src/libs/vpropertyexplorer/plugins/lineweight_property.h
@@ -53,10 +53,10 @@ public:
     explicit               LineWeightProperty(const QString &name);
 
     //! Destructor
-    virtual               ~LineWeightProperty() Q_DECL_OVERRIDE {}
+    virtual               ~LineWeightProperty() override {}
 
     //! Get the data how it should be displayed
-    virtual QVariant       data (int column = DPC_Name, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant       data (int column = DPC_Name, int role = Qt::DisplayRole) const override;
 
     //! Returns an editor widget, or NULL if it doesn't supply one
     //! \param parent The widget to which the editor will be added as a child
@@ -64,10 +64,10 @@ public:
     //! \delegate A pointer to the QAbstractItemDelegate requesting the editor. This can be used to connect signals and
     //! slots.
     virtual QWidget       *createEditor(QWidget *parent, const QStyleOptionViewItem &options,
-                                  const QAbstractItemDelegate *delegate) Q_DECL_OVERRIDE;
+                                  const QAbstractItemDelegate *delegate) override;
 
     //! Gets the data from the widget
-    virtual QVariant       getEditorData(const QWidget *editor) const Q_DECL_OVERRIDE;
+    virtual QVariant       getEditorData(const QWidget *editor) const override;
 
     //! Sets the line styles
     virtual void           setLineWeights(const QMap<QString, QString> &weights);
@@ -76,10 +76,10 @@ public:
     virtual QMap<QString, QString> getLineWeights() const;
 
     //! Sets the value of the property
-    virtual void           setValue(const QVariant &value) Q_DECL_OVERRIDE;
+    virtual void           setValue(const QVariant &value) override;
 
     //! Returns a string containing the type of the property
-    virtual QString        type() const Q_DECL_OVERRIDE;
+    virtual QString        type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
@@ -87,7 +87,7 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty *clone(bool include_children = true,
-                                               VProperty *container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty *container = nullptr) const override;
 
     static int             indexOfLineWeight(const QMap<QString, QString> &lineWeights, const QString &weight);
 

--- a/src/libs/vpropertyexplorer/plugins/plaintext_property.h
+++ b/src/libs/vpropertyexplorer/plugins/plaintext_property.h
@@ -55,26 +55,26 @@ public:
     explicit            PlainTextProperty(const QString &name);
 
     virtual QWidget    *createEditor(QWidget *parent, const QStyleOptionViewItem &options,
-                                  const QAbstractItemDelegate *delegate) Q_DECL_OVERRIDE;
+                                  const QAbstractItemDelegate *delegate) override;
 
 
-    virtual QVariant     getEditorData(const QWidget *editor) const Q_DECL_OVERRIDE;
+    virtual QVariant     getEditorData(const QWidget *editor) const override;
 
     void                 setReadOnly(bool readOnly);
     void                 setOsSeparator(bool separator);
     void                 setClearButtonEnable(bool value);
 
 
-    virtual void        setSetting(const QString &key, const QVariant &value) Q_DECL_OVERRIDE;
-    virtual QVariant    getSetting(const QString &key) const Q_DECL_OVERRIDE;
-    virtual QStringList getSettingKeys() const Q_DECL_OVERRIDE;
+    virtual void        setSetting(const QString &key, const QVariant &value) override;
+    virtual QVariant    getSetting(const QString &key) const override;
+    virtual QStringList getSettingKeys() const override;
 
-    virtual QString     type() const Q_DECL_OVERRIDE;
+    virtual QString     type() const override;
 
     Q_REQUIRED_RESULT virtual VProperty *clone(bool include_children = true,
-                                               VProperty *container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty *container = nullptr) const override;
 
-    virtual void        updateParent(const QVariant &value) Q_DECL_OVERRIDE;
+    virtual void        updateParent(const QVariant &value) override;
 
     int                 getTypeForParent() const;
     void                setTypeForParent(int value);
@@ -84,7 +84,7 @@ protected:
     int                 m_typeForParent;
     bool                m_osSeparator;
 
-    virtual bool        eventFilter(QObject *object, QEvent *event) Q_DECL_OVERRIDE;
+    virtual bool        eventFilter(QObject *object, QEvent *event) override;
 
 private:
     Q_DISABLE_COPY(PlainTextProperty)

--- a/src/libs/vpropertyexplorer/plugins/vboolproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vboolproperty.h
@@ -44,29 +44,29 @@ public:
     explicit VBoolProperty(const QString& name);
 
     //! Destructor
-    virtual ~VBoolProperty()  Q_DECL_OVERRIDE {}
+    virtual ~VBoolProperty()  override {}
 
     //! Get the data how it should be displayed
-    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const override;
 
     //! This is used by the model to set the data
     //! \param data The data to set
     //! \param role The role. Default is Qt::EditRole
     //! \return Returns true, if the data was changed, false if not.
-    virtual bool setData (const QVariant& data, int role = Qt::EditRole) Q_DECL_OVERRIDE;
+    virtual bool setData (const QVariant& data, int role = Qt::EditRole) override;
 
     //! Returns item flags
-    virtual Qt::ItemFlags flags(int column = DPC_Name) const Q_DECL_OVERRIDE;
+    virtual Qt::ItemFlags flags(int column = DPC_Name) const override;
 
     //! Returns a string containing the type of the property
-    virtual QString type() const Q_DECL_OVERRIDE;
+    virtual QString type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
     //! \param container If a property is being passed here, no new VProperty is being created but instead it is tried
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
-    virtual VProperty* clone(bool include_children = true, VProperty* container = NULL) const Q_DECL_OVERRIDE;
+    virtual VProperty* clone(bool include_children = true, VProperty* container = NULL) const override;
 
 protected:
     //! The (translatable) text displayed when the property is set to true (default: "True")

--- a/src/libs/vpropertyexplorer/plugins/vcolorproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vcolorproperty.h
@@ -43,7 +43,7 @@ public:
     explicit           VColorProperty(const QString &name);
 
     //! Get the data how it should be displayed
-    virtual QVariant   data (int column = DPC_Name, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant   data (int column = DPC_Name, int role = Qt::DisplayRole) const override;
 
     //! Returns an editor widget, or NULL if it doesn't supply one
     //! \param parent The widget to which the editor will be added as a child
@@ -51,23 +51,23 @@ public:
     //! \delegate A pointer to the QAbstractItemDelegate requesting the editor. This can be used to connect signals and
     //! slots.
     virtual QWidget   *createEditor(QWidget *parent, const QStyleOptionViewItem &options,
-                                  const QAbstractItemDelegate *delegate) Q_DECL_OVERRIDE;
+                                  const QAbstractItemDelegate *delegate) override;
 
     //! Sets the property's data to the editor (returns false, if the standard delegate should do that)
-    virtual bool       setEditorData(QWidget *editor) Q_DECL_OVERRIDE;
+    virtual bool       setEditorData(QWidget *editor) override;
 
     //! Gets the data from the widget
-    virtual QVariant   getEditorData(const QWidget *editor) const Q_DECL_OVERRIDE;
+    virtual QVariant   getEditorData(const QWidget *editor) const override;
 
     //! Returns a string containing the type of the property
-    virtual QString    type() const Q_DECL_OVERRIDE;
+    virtual QString    type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
     //! \param container If a property is being passed here, no new VProperty is being created but instead it is tried
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
-    virtual VProperty *clone(bool include_children = true, VProperty *container = NULL) const Q_DECL_OVERRIDE;
+    virtual VProperty *clone(bool include_children = true, VProperty *container = NULL) const override;
 
 private:
     Q_DISABLE_COPY(VColorProperty)

--- a/src/libs/vpropertyexplorer/plugins/vcolorpropertyeditor.h
+++ b/src/libs/vpropertyexplorer/plugins/vcolorpropertyeditor.h
@@ -46,7 +46,7 @@ public:
     explicit       VColorPropertyEditor(QWidget *parent);
 
     //! Destructor
-    virtual       ~VColorPropertyEditor() Q_DECL_OVERRIDE;
+    virtual       ~VColorPropertyEditor() override;
 
 
     //! Returns the color currently set
@@ -64,7 +64,7 @@ public:
     static QString GetColorString(const QColor &color);
 
     //! Needed for proper event handling
-    virtual bool   eventFilter(QObject *obj, QEvent *ev) Q_DECL_OVERRIDE;
+    virtual bool   eventFilter(QObject *obj, QEvent *ev) override;
 
 signals:
     //! This is emitted, when the user changes the color

--- a/src/libs/vpropertyexplorer/plugins/vemptyproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vemptyproperty.h
@@ -48,10 +48,10 @@ public:
     explicit VEmptyProperty(const QString& name);
 
     //! Destructor
-    virtual ~VEmptyProperty() Q_DECL_OVERRIDE;
+    virtual ~VEmptyProperty() override;
 
     //! Get the data how it should be displayed
-    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const override;
 
     //! Returns an editor widget, or NULL if it doesn't supply one
     //! \param parent The widget to which the editor will be added as a child
@@ -59,16 +59,16 @@ public:
     //! \delegate A pointer to the QAbstractItemDelegate requesting the editor. This can be used to connect signals and
     //! slots.
     virtual QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& options,
-                                  const QAbstractItemDelegate* delegate) Q_DECL_OVERRIDE;
+                                  const QAbstractItemDelegate* delegate) override;
 
     //! Gets the data from the widget
-    virtual QVariant getEditorData(const QWidget* editor) const Q_DECL_OVERRIDE;
+    virtual QVariant getEditorData(const QWidget* editor) const override;
 
     //! Returns item flags
-    virtual Qt::ItemFlags flags(int column = DPC_Name) const Q_DECL_OVERRIDE;
+    virtual Qt::ItemFlags flags(int column = DPC_Name) const override;
 
     //! Returns a string containing the type of the property
-    virtual QString type() const Q_DECL_OVERRIDE;
+    virtual QString type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
@@ -76,7 +76,7 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty* clone(bool include_children = true,
-                                               VProperty* container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty* container = nullptr) const override;
 
 protected:
     //! Protected constructor

--- a/src/libs/vpropertyexplorer/plugins/venumproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/venumproperty.h
@@ -44,10 +44,10 @@ public:
     explicit VEnumProperty(const QString& name);
 
     //! Destructor
-    virtual ~VEnumProperty() Q_DECL_OVERRIDE {}
+    virtual ~VEnumProperty() override {}
 
     //! Get the data how it should be displayed
-    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const override;
 
     //! Returns an editor widget, or NULL if it doesn't supply one
     //! \param parent The widget to which the editor will be added as a child
@@ -55,10 +55,10 @@ public:
     //! \delegate A pointer to the QAbstractItemDelegate requesting the editor. This can be used to connect signals and
     //! slots.
     virtual QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& options,
-                                  const QAbstractItemDelegate* delegate) Q_DECL_OVERRIDE;
+                                  const QAbstractItemDelegate* delegate) override;
 
     //! Gets the data from the widget
-    virtual QVariant getEditorData(const QWidget* editor) const Q_DECL_OVERRIDE;
+    virtual QVariant getEditorData(const QWidget* editor) const override;
 
     //! Sets the enumeration literals
     virtual void setLiterals(const QStringList &literals);
@@ -67,10 +67,10 @@ public:
     virtual QStringList getLiterals() const;
 
     //! Sets the value of the property
-    virtual void setValue(const QVariant& value) Q_DECL_OVERRIDE;
+    virtual void setValue(const QVariant& value) override;
 
     //! Returns a string containing the type of the property
-    virtual QString type() const Q_DECL_OVERRIDE;
+    virtual QString type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
@@ -78,18 +78,18 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty* clone(bool include_children = true,
-                                               VProperty* container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty* container = nullptr) const override;
 
     //! Sets the settings. Available settings:
     //!
     //! key: "literals" - value: "item1;;item2;;item3"
-    virtual void setSetting(const QString& key, const QVariant& value) Q_DECL_OVERRIDE;
+    virtual void setSetting(const QString& key, const QVariant& value) override;
 
     //! Get the settings. This function has to be implemented in a subclass in order to have an effect
-    virtual QVariant getSetting(const QString& key) const Q_DECL_OVERRIDE;
+    virtual QVariant getSetting(const QString& key) const override;
 
     //! Returns the list of keys of the property's settings
-    virtual QStringList getSettingKeys() const Q_DECL_OVERRIDE;
+    virtual QStringList getSettingKeys() const override;
 
 public slots:
     void currentIndexChanged(int index);

--- a/src/libs/vpropertyexplorer/plugins/vfileproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vfileproperty.h
@@ -44,7 +44,7 @@ public:
     explicit VFileProperty(const QString &name);
 
     //! The destructor
-    virtual ~VFileProperty() Q_DECL_OVERRIDE;
+    virtual ~VFileProperty() override;
 
     //! Sets the file filters. The file filters have to be like the ones passed a QFileOpenDialog.
     virtual void setFileFilters(const QString& filefilters);
@@ -59,7 +59,7 @@ public:
     virtual QString getFile() const;
 
     //! Get the data how it should be displayed
-    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const override;
 
     //! Returns an editor widget, or NULL if it doesn't supply one
     //! \param parent The widget to which the editor will be added as a child
@@ -67,27 +67,27 @@ public:
     //! \delegate A pointer to the QAbstractItemDelegate requesting the editor. This can be used to connect signals and
     //! slots.
     virtual QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& options,
-                                  const QAbstractItemDelegate* delegate) Q_DECL_OVERRIDE;
+                                  const QAbstractItemDelegate* delegate) override;
 
     //! Sets the property's data to the editor (returns false, if the standard delegate should do that)
-    virtual bool setEditorData(QWidget* editor) Q_DECL_OVERRIDE;
+    virtual bool setEditorData(QWidget* editor) override;
 
     //! Gets the data from the widget
-    virtual QVariant getEditorData(const QWidget* editor) const Q_DECL_OVERRIDE;
+    virtual QVariant getEditorData(const QWidget* editor) const override;
 
     //! Sets the settings. Available settings:
     //!
     //! key: "FileFilters" - value: File filters in the same format the QFileDialog expects it
-    virtual void setSetting(const QString& key, const QVariant& value) Q_DECL_OVERRIDE;
+    virtual void setSetting(const QString& key, const QVariant& value) override;
 
     //! Get the settings. This function has to be implemented in a subclass in order to have an effect
-    virtual QVariant getSetting(const QString& key) const Q_DECL_OVERRIDE;
+    virtual QVariant getSetting(const QString& key) const override;
 
     //! Returns the list of keys of the property's settings
-    virtual QStringList getSettingKeys() const Q_DECL_OVERRIDE;
+    virtual QStringList getSettingKeys() const override;
 
     //! Returns a string containing the type of the property
-    virtual QString type() const Q_DECL_OVERRIDE;
+    virtual QString type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
@@ -95,7 +95,7 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty* clone(bool include_children = true,
-                                               VProperty* container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty* container = nullptr) const override;
 
     //! Returns whether this is a file (false) or a directory (true)
     virtual bool isDirectory() const;

--- a/src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.h
+++ b/src/libs/vpropertyexplorer/plugins/vfilepropertyeditor.h
@@ -42,14 +42,14 @@ class VFileEditWidget : public QWidget
 
 public:
     explicit VFileEditWidget(QWidget* parent, bool is_directory = false);
-    virtual ~VFileEditWidget() Q_DECL_OVERRIDE;
+    virtual ~VFileEditWidget() override;
 
 
     //! This function returns the file currently set to this editor
     QString getFile() const;
 
     //! Needed for proper event handling
-    virtual bool eventFilter(QObject* obj, QEvent* ev) Q_DECL_OVERRIDE;
+    virtual bool eventFilter(QObject* obj, QEvent* ev) override;
 
     //! Returns the directory/file setting
     //! \return True, if a directory dialog is being shown, false if a file dialog
@@ -86,10 +86,10 @@ private slots:
     void onToolButtonClicked();
 
 protected:
-    virtual void dragEnterEvent(QDragEnterEvent* event) Q_DECL_OVERRIDE;
-    virtual void dragMoveEvent(QDragMoveEvent* event) Q_DECL_OVERRIDE;
-    virtual void dragLeaveEvent(QDragLeaveEvent* event) Q_DECL_OVERRIDE;
-    virtual void dropEvent(QDropEvent* event) Q_DECL_OVERRIDE;
+    virtual void dragEnterEvent(QDragEnterEvent* event) override;
+    virtual void dragMoveEvent(QDragMoveEvent* event) override;
+    virtual void dragLeaveEvent(QDragLeaveEvent* event) override;
+    virtual void dropEvent(QDropEvent* event) override;
 
     //! This function checks the mime data, if it is compatible with the filters
     virtual bool checkMimeData(const QMimeData* data, QString& file) const;

--- a/src/libs/vpropertyexplorer/plugins/vlabelproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vlabelproperty.h
@@ -83,22 +83,22 @@ public:
     //! \delegate A pointer to the QAbstractItemDelegate requesting the editor. This can be used to connect signals and
     //! slots.
     virtual QWidget     *createEditor(QWidget *parent, const QStyleOptionViewItem &options,
-                                  const QAbstractItemDelegate *delegate) Q_DECL_OVERRIDE;
+                                  const QAbstractItemDelegate *delegate) override;
 
     //! Gets the data from the widget
-    virtual QVariant     getEditorData(const QWidget *editor) const Q_DECL_OVERRIDE;
+    virtual QVariant     getEditorData(const QWidget *editor) const override;
 
     //! Sets the settings.
-    virtual void         setSetting(const QString &key, const QVariant &value) Q_DECL_OVERRIDE;
+    virtual void         setSetting(const QString &key, const QVariant &value) override;
 
     //! Get the settings. This function has to be implemented in a subclass in order to have an effect
-    virtual QVariant     getSetting(const QString &key) const Q_DECL_OVERRIDE;
+    virtual QVariant     getSetting(const QString &key) const override;
 
     //! Returns the list of keys of the property's settings
-    virtual QStringList  getSettingKeys() const Q_DECL_OVERRIDE;
+    virtual QStringList  getSettingKeys() const override;
 
     //! Returns a string containing the type of the property
-    virtual QString      type() const Q_DECL_OVERRIDE;
+    virtual QString      type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
@@ -106,9 +106,9 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty *clone(bool include_children = true,
-                                               VProperty *container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty *container = nullptr) const override;
 
-    virtual void        updateParent(const QVariant &value) Q_DECL_OVERRIDE;
+    virtual void        updateParent(const QVariant &value) override;
 
     int                 getTypeForParent() const;
     void                setTypeForParent(int value);

--- a/src/libs/vpropertyexplorer/plugins/vlinecolorproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vlinecolorproperty.h
@@ -76,10 +76,10 @@ public:
     explicit               VLineColorProperty(const QString &name);
 
     //! Destructor
-    virtual               ~VLineColorProperty() Q_DECL_OVERRIDE {}
+    virtual               ~VLineColorProperty() override {}
 
     //! Get the data how it should be displayed
-    virtual QVariant       data (int column = DPC_Name, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant       data (int column = DPC_Name, int role = Qt::DisplayRole) const override;
 
     //! Returns an editor widget, or NULL if it doesn't supply one
     //! \param parent The widget to which the editor will be added as a child
@@ -87,10 +87,10 @@ public:
     //! \delegate A pointer to the QAbstractItemDelegate requesting the editor. This can be used to connect signals and
     //! slots.
     virtual QWidget       *createEditor(QWidget *parent, const QStyleOptionViewItem &options,
-                                  const QAbstractItemDelegate *delegate) Q_DECL_OVERRIDE;
+                                  const QAbstractItemDelegate *delegate) override;
 
     //! Gets the data from the widget
-    virtual QVariant       getEditorData(const QWidget *editor) const Q_DECL_OVERRIDE;
+    virtual QVariant       getEditorData(const QWidget *editor) const override;
 
     //! Sets the colors
     virtual void           setColors(const QMap<QString, QString> &colors);
@@ -99,10 +99,10 @@ public:
     virtual QMap<QString, QString> getColors() const;
 
     //! Sets the value of the property
-    virtual void           setValue(const QVariant &value) Q_DECL_OVERRIDE;
+    virtual void           setValue(const QVariant &value) override;
 
     //! Returns a string containing the type of the property
-    virtual QString        type() const Q_DECL_OVERRIDE;
+    virtual QString        type() const override;
 
 
     //! Clones this property
@@ -111,7 +111,7 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty *clone(bool include_children = true,
-                                               VProperty *container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty *container = nullptr) const override;
 
     static int             indexOfColor(const QMap<QString, QString> &colors, const QString &color);
 

--- a/src/libs/vpropertyexplorer/plugins/vlinetypeproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vlinetypeproperty.h
@@ -81,10 +81,10 @@ public:
     explicit               LineTypeProperty(const QString &name);
 
     //! Destructor
-    virtual               ~LineTypeProperty() Q_DECL_OVERRIDE {}
+    virtual               ~LineTypeProperty() override {}
 
     //! Get the data how it should be displayed
-    virtual QVariant       data (int column = DPC_Name, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant       data (int column = DPC_Name, int role = Qt::DisplayRole) const override;
 
     //! Returns an editor widget, or NULL if it doesn't supply one
     //! \param parent The widget to which the editor will be added as a child
@@ -92,10 +92,10 @@ public:
     //! \delegate A pointer to the QAbstractItemDelegate requesting the editor. This can be used to connect signals and
     //! slots.
     virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &options,
-                                  const QAbstractItemDelegate *delegate) Q_DECL_OVERRIDE;
+                                  const QAbstractItemDelegate *delegate) override;
 
     //! Gets the data from the widget
-    virtual QVariant       getEditorData(const QWidget *editor) const Q_DECL_OVERRIDE;
+    virtual QVariant       getEditorData(const QWidget *editor) const override;
 
     //! Sets the line styles
     virtual void           setLineTypes(const QMap<QString, QString> &styles);
@@ -104,10 +104,10 @@ public:
     virtual QMap<QString, QString> getLineTypes() const;
 
     //! Sets the value of the property
-    virtual void           setValue(const QVariant &value) Q_DECL_OVERRIDE;
+    virtual void           setValue(const QVariant &value) override;
 
     //! Returns a string containing the type of the property
-    virtual QString        type() const Q_DECL_OVERRIDE;
+    virtual QString        type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
@@ -115,7 +115,7 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty *clone(bool include_children = true,
-                                               VProperty *container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty *container = nullptr) const override;
 
     static int             indexOfLineType(const QMap<QString, QString> &styles, const QString &style);
 

--- a/src/libs/vpropertyexplorer/plugins/vnumberproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vnumberproperty.h
@@ -53,25 +53,25 @@ public:
     //! \delegate A pointer to the QAbstractItemDelegate requesting the editor. This can be used to connect signals and
     //! slots.
     virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &options,
-                                  const QAbstractItemDelegate *delegate) Q_DECL_OVERRIDE;
+                                  const QAbstractItemDelegate *delegate) override;
 
     //! Gets the data from the widget
-    virtual QVariant getEditorData(const QWidget *editor) const Q_DECL_OVERRIDE;
+    virtual QVariant getEditorData(const QWidget *editor) const override;
 
     //! Sets the settings. Available settings:
     //!
     //! key: "Min" - value: Minimum number as integer
     //! key: "Max" - value: Maximum number as integer
-    virtual void setSetting(const QString &key, const QVariant &value) Q_DECL_OVERRIDE;
+    virtual void setSetting(const QString &key, const QVariant &value) override;
 
     //! Get the settings. This function has to be implemented in a subclass in order to have an effect
-    virtual QVariant getSetting(const QString &key) const Q_DECL_OVERRIDE;
+    virtual QVariant getSetting(const QString &key) const override;
 
     //! Returns the list of keys of the property's settings
-    virtual QStringList getSettingKeys() const Q_DECL_OVERRIDE;
+    virtual QStringList getSettingKeys() const override;
 
     //! Returns a string containing the type of the property
-    virtual QString type() const Q_DECL_OVERRIDE;
+    virtual QString type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
@@ -79,7 +79,7 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty *clone(bool include_children = true,
-                                               VProperty *container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty *container = nullptr) const override;
 public slots:
     void valueChanged(int i);
 protected:

--- a/src/libs/vpropertyexplorer/plugins/vobjectproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vobjectproperty.h
@@ -54,10 +54,10 @@ public:
     explicit               VObjectProperty(const QString& name);
 
     //! Destructor
-    virtual               ~VObjectProperty() Q_DECL_OVERRIDE {}
+    virtual               ~VObjectProperty() override {}
 
     //! Get the data how it should be displayed
-    virtual                QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual                QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const override;
 
     //! Returns an editor widget, or NULL if it doesn't supply one
     //! \param parent The widget to which the editor will be added as a child
@@ -65,10 +65,10 @@ public:
     //! \delegate A pointer to the QAbstractItemDelegate requesting the editor. This can be used to connect signals and
     //! slots.
     virtual QWidget*       createEditor(QWidget* parent, const QStyleOptionViewItem& options,
-                                               const QAbstractItemDelegate* delegate) Q_DECL_OVERRIDE;
+                                               const QAbstractItemDelegate* delegate) override;
 
     //! Gets the data from the widget
-    virtual QVariant       getEditorData(const QWidget* editor) const Q_DECL_OVERRIDE;
+    virtual QVariant       getEditorData(const QWidget* editor) const override;
 
     //! Sets the objects list
     void                   setObjectsList(const QMap<QString, quint32> &objects);
@@ -77,10 +77,10 @@ public:
     virtual QMap<QString, quint32> getObjects() const;
 
     //! Sets the value of the property
-    virtual void           setValue(const QVariant& value) Q_DECL_OVERRIDE;
+    virtual void           setValue(const QVariant& value) override;
 
     //! Returns a string containing the type of the property
-    virtual QString        type() const Q_DECL_OVERRIDE;
+    virtual QString        type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
@@ -88,7 +88,7 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty* clone(bool include_children = true,
-                                               VProperty* container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty* container = nullptr) const override;
 
     static int             indexOfObject(const QMap<QString, quint32> &objects, const QString &object);
 

--- a/src/libs/vpropertyexplorer/plugins/vpointfproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vpointfproperty.h
@@ -41,13 +41,13 @@ class VPointFProperty : public VProperty
 public:
     explicit VPointFProperty(const QString &name);
 
-    virtual ~VPointFProperty() Q_DECL_OVERRIDE {}
+    virtual ~VPointFProperty() override {}
 
     //! Get the data how it should be displayed
-    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const override;
 
     //! Returns item flags
-    Qt::ItemFlags flags(int column = DPC_Name) const Q_DECL_OVERRIDE;
+    Qt::ItemFlags flags(int column = DPC_Name) const override;
 
     //! Returns the QPointF
     virtual QPointF getPointF() const;
@@ -59,7 +59,7 @@ public:
     virtual void setPointF(qreal x, qreal y);
 
     //! Returns a string containing the type of the property
-    virtual QString type() const Q_DECL_OVERRIDE;
+    virtual QString type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
@@ -67,13 +67,13 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty *clone(bool include_children = true,
-                                               VProperty *container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty *container = nullptr) const override;
 
     //! Sets the value of the property
-    virtual void setValue(const QVariant &value) Q_DECL_OVERRIDE;
+    virtual void setValue(const QVariant &value) override;
 
     //! Returns the value of the property as a QVariant
-    virtual QVariant getValue() const Q_DECL_OVERRIDE;
+    virtual QVariant getValue() const override;
 
 private:
     Q_DISABLE_COPY(VPointFProperty)

--- a/src/libs/vpropertyexplorer/plugins/vshortcutproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vshortcutproperty.h
@@ -43,10 +43,10 @@ public:
     explicit VShortcutProperty(const QString &name);
 
     //! The destructor
-    virtual ~VShortcutProperty() Q_DECL_OVERRIDE;
+    virtual ~VShortcutProperty() override;
 
     //! Get the data how it should be displayed
-    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant data (int column = DPC_Name, int role = Qt::DisplayRole) const override;
 
     //! Returns an editor widget, or NULL if it doesn't supply one
     //! \param parent The widget to which the editor will be added as a child
@@ -54,16 +54,16 @@ public:
     //! \delegate A pointer to the QAbstractItemDelegate requesting the editor. This can be used to connect signals and
     //! slots.
     virtual QWidget* createEditor(QWidget* parent, const QStyleOptionViewItem& options,
-                                  const QAbstractItemDelegate* delegate) Q_DECL_OVERRIDE;
+                                  const QAbstractItemDelegate* delegate) override;
 
     //! Sets the property's data to the editor (returns false, if the standard delegate should do that)
-    virtual bool setEditorData(QWidget* editor) Q_DECL_OVERRIDE;
+    virtual bool setEditorData(QWidget* editor) override;
 
     //! Gets the data from the widget
-    virtual QVariant getEditorData(const QWidget* editor) const Q_DECL_OVERRIDE;
+    virtual QVariant getEditorData(const QWidget* editor) const override;
 
     //! Returns a string containing the type of the property
-    virtual QString type() const Q_DECL_OVERRIDE;
+    virtual QString type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
@@ -71,10 +71,10 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty* clone(bool include_children = true,
-                                               VProperty* container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty* container = nullptr) const override;
 
     //! Sets the value of the property
-    virtual void setValue(const QVariant& value) Q_DECL_OVERRIDE;
+    virtual void setValue(const QVariant& value) override;
 
 private:
     Q_DISABLE_COPY(VShortcutProperty)

--- a/src/libs/vpropertyexplorer/plugins/vshortcutpropertyeditor.h
+++ b/src/libs/vpropertyexplorer/plugins/vshortcutpropertyeditor.h
@@ -42,10 +42,10 @@ class VShortcutEditWidget : public QWidget
 
 public:
     explicit VShortcutEditWidget(QWidget* parent);
-    virtual ~VShortcutEditWidget() Q_DECL_OVERRIDE;
+    virtual ~VShortcutEditWidget() override;
 
     //! Needed for proper event handling
-    virtual bool eventFilter(QObject* obj, QEvent* event) Q_DECL_OVERRIDE;
+    virtual bool eventFilter(QObject* obj, QEvent* event) override;
 
     //! Returns the currently set shortcut
     QString getShortcutAsString() const;

--- a/src/libs/vpropertyexplorer/plugins/vstringproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vstringproperty.h
@@ -52,26 +52,26 @@ public:
     //! \delegate A pointer to the QAbstractItemDelegate requesting the editor. This can be used to connect signals and
     //! slots.
     virtual QWidget    *createEditor(QWidget *parent, const QStyleOptionViewItem &options,
-                                  const QAbstractItemDelegate *delegate) Q_DECL_OVERRIDE;
+                                  const QAbstractItemDelegate *delegate) override;
 
     //! Gets the data from the widget
-    virtual QVariant    getEditorData(const QWidget *editor) const Q_DECL_OVERRIDE;
+    virtual QVariant    getEditorData(const QWidget *editor) const override;
 
     void                setReadOnly(bool readOnly);
     void                setOsSeparator(bool separator);
     void                setClearButtonEnable(bool value);
 
     //! Sets the settings.
-    virtual void        setSetting(const QString &key, const QVariant &value) Q_DECL_OVERRIDE;
+    virtual void        setSetting(const QString &key, const QVariant &value) override;
 
     //! Get the settings. This function has to be implemented in a subclass in order to have an effect
-    virtual QVariant    getSetting(const QString &key) const Q_DECL_OVERRIDE;
+    virtual QVariant    getSetting(const QString &key) const override;
 
     //! Returns the list of keys of the property's settings
-    virtual QStringList getSettingKeys() const Q_DECL_OVERRIDE;
+    virtual QStringList getSettingKeys() const override;
 
     //! Returns a string containing the type of the property
-    virtual QString     type() const Q_DECL_OVERRIDE;
+    virtual QString     type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
@@ -79,9 +79,9 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty *clone(bool include_children = true,
-                                               VProperty *container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty *container = nullptr) const override;
 
-    virtual void        updateParent(const QVariant &value) Q_DECL_OVERRIDE;
+    virtual void        updateParent(const QVariant &value) override;
 
     int                 getTypeForParent() const;
     void                setTypeForParent(int value);
@@ -92,7 +92,7 @@ protected:
     bool                clearButton;
     bool                m_osSeparator;
 
-    virtual bool        eventFilter(QObject *object, QEvent *event) Q_DECL_OVERRIDE;
+    virtual bool        eventFilter(QObject *object, QEvent *event) override;
 
 private:
     Q_DISABLE_COPY(VStringProperty)

--- a/src/libs/vpropertyexplorer/plugins/vwidgetproperty.h
+++ b/src/libs/vpropertyexplorer/plugins/vwidgetproperty.h
@@ -46,7 +46,7 @@ public:
     explicit VWidgetProperty(const QString &name, QWidget* widget = nullptr);
 
     //! The destructor
-    virtual ~VWidgetProperty() Q_DECL_OVERRIDE;
+    virtual ~VWidgetProperty() override;
 
     //! Returns the widget held by this property
     QWidget* getWidget() const;
@@ -55,7 +55,7 @@ public:
     void setWidget(QWidget* widget);
 
     //! Returns a string containing the type of the property
-    virtual QString type() const Q_DECL_OVERRIDE;
+    virtual QString type() const override;
 
     //! Clones this property
     //! \param include_children Indicates whether to also clone the children
@@ -63,7 +63,7 @@ public:
     //! to fill all the data into container. This can also be used when subclassing this function.
     //! \return Returns the newly created property (or container, if it was not NULL)
     Q_REQUIRED_RESULT virtual VProperty* clone(bool include_children = true,
-                                               VProperty* container = nullptr) const Q_DECL_OVERRIDE;
+                                               VProperty* container = nullptr) const override;
 };
 
 }

--- a/src/libs/vpropertyexplorer/vfileproperty_p.h
+++ b/src/libs/vpropertyexplorer/vfileproperty_p.h
@@ -46,7 +46,7 @@ public:
     VFilePropertyPrivate()
         : VPropertyPrivate(), FileFilters(), Directory(false) {}
 
-    virtual ~VFilePropertyPrivate() Q_DECL_OVERRIDE;
+    virtual ~VFilePropertyPrivate() override;
 };
 
 VFilePropertyPrivate::~VFilePropertyPrivate()

--- a/src/libs/vpropertyexplorer/vproperty.h
+++ b/src/libs/vpropertyexplorer/vproperty.h
@@ -48,7 +48,7 @@ class UserChangeEvent : public QEvent
 {
 public:
     UserChangeEvent() : QEvent(static_cast<QEvent::Type>(MyCustomEventType)) {}
-    virtual ~UserChangeEvent() Q_DECL_OVERRIDE;
+    virtual ~UserChangeEvent() override;
 };
 
 class VPropertyPrivate;
@@ -67,7 +67,7 @@ public:
     explicit VProperty(const QString &name, QVariant::Type type = QVariant::String);
 
     //! Destructor
-    virtual ~VProperty() Q_DECL_OVERRIDE;
+    virtual ~VProperty() override;
 
     //! Returns a string containing the type of the property
     virtual QString type() const;

--- a/src/libs/vpropertyexplorer/vpropertydelegate.h
+++ b/src/libs/vpropertyexplorer/vpropertydelegate.h
@@ -37,28 +37,28 @@ class VPropertyDelegate : public QStyledItemDelegate
     Q_OBJECT
 public:
     explicit VPropertyDelegate(QObject *parent = nullptr);
-    virtual ~VPropertyDelegate() Q_DECL_OVERRIDE;
+    virtual ~VPropertyDelegate() override;
 
     //! Creates the editor widget
     virtual QWidget* createEditor (QWidget* parent, const QStyleOptionViewItem& option,
-                                   const QModelIndex& index) const Q_DECL_OVERRIDE;
+                                   const QModelIndex& index) const override;
 
     //! Sets the index data to the editor
-    virtual void setEditorData (QWidget * editor, const QModelIndex & index) const Q_DECL_OVERRIDE;
+    virtual void setEditorData (QWidget * editor, const QModelIndex & index) const override;
 
     //! Updates the index data
     virtual void setModelData (QWidget * editor, QAbstractItemModel * model,
-                               const QModelIndex & index) const Q_DECL_OVERRIDE;
+                               const QModelIndex & index) const override;
 
     //! Returns the size hint
-    virtual QSize sizeHint (const QStyleOptionViewItem& option, const QModelIndex& index) const Q_DECL_OVERRIDE;
+    virtual QSize sizeHint (const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 
     //! Sets the row height. Set this to 0 and the standard will be taken
     void setRowHeight(int height = 0, bool add_to_standard = false);
 
     //! Renders the delegate using the given painter and style option for the item specified by index.
     virtual void paint (QPainter* painter, const QStyleOptionViewItem& option,
-                        const QModelIndex& index ) const Q_DECL_OVERRIDE;
+                        const QModelIndex& index ) const override;
 
 protected:
     int RowHeight;

--- a/src/libs/vpropertyexplorer/vpropertyfactorymanager.h
+++ b/src/libs/vpropertyexplorer/vpropertyfactorymanager.h
@@ -42,7 +42,7 @@ public:
     explicit VPropertyFactoryManager(QObject* parent = nullptr);
 
     //! Destructor
-    virtual ~VPropertyFactoryManager() Q_DECL_OVERRIDE;
+    virtual ~VPropertyFactoryManager() override;
 
     //! Register a factory to the factory manager
     //! Note that the manager takes ownership of the factory, so don't delete it.

--- a/src/libs/vpropertyexplorer/vpropertyformview.h
+++ b/src/libs/vpropertyexplorer/vpropertyformview.h
@@ -50,12 +50,12 @@ public:
     explicit VPropertyFormView(VPropertySet *property_set, QWidget *parent = nullptr);
 
     //! Destructor
-    virtual ~VPropertyFormView() Q_DECL_OVERRIDE;
+    virtual ~VPropertyFormView() override;
 
 
 public slots:
     //! Rebuilds the whole form
-    virtual void build() Q_DECL_OVERRIDE;
+    virtual void build() override;
 
     //! Set the source model. Leads to the rebuild of the form
     //! \param model The model to use
@@ -87,7 +87,7 @@ private slots:
     void dataSubmitted(VProperty *property);
 
 protected:
-    virtual void showEvent(QShowEvent *event) Q_DECL_OVERRIDE;
+    virtual void showEvent(QShowEvent *event) override;
 
     //! Rebuilds the widegt only if it is visible
     void updatePropertyList();

--- a/src/libs/vpropertyexplorer/vpropertyformview_p.h
+++ b/src/libs/vpropertyexplorer/vpropertyformview_p.h
@@ -62,7 +62,7 @@ public:
           IgnoreDataChangedSignal(false)
     {}
 
-    virtual ~VPropertyFormViewPrivate() Q_DECL_OVERRIDE {}
+    virtual ~VPropertyFormViewPrivate() override {}
 
 private:
     Q_DISABLE_COPY(VPropertyFormViewPrivate)

--- a/src/libs/vpropertyexplorer/vpropertymodel.h
+++ b/src/libs/vpropertyexplorer/vpropertymodel.h
@@ -64,7 +64,7 @@ class VPropertyModel : public QAbstractItemModel
     Q_OBJECT
 public:
     explicit VPropertyModel(QObject * parent = nullptr);
-    virtual ~VPropertyModel() Q_DECL_OVERRIDE;
+    virtual ~VPropertyModel() override;
 
     //! Adds the property to the model and attaches it to the parentid
     //! \param emitsignals If this is set to false, this function will not call beginInsertRows() and endInsertRows(),
@@ -80,29 +80,29 @@ public:
     virtual VProperty* getProperty(const QString& id);
 
     //! Returns the item flags for the given index
-    virtual Qt::ItemFlags flags (const QModelIndex& index) const Q_DECL_OVERRIDE;
+    virtual Qt::ItemFlags flags (const QModelIndex& index) const override;
 
     //! Sets the role data for the item at index to value
-    virtual bool setData (const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) Q_DECL_OVERRIDE;
+    virtual bool setData (const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
 
     //! Returns the model index at row/column
-    virtual QModelIndex index (int row, int column, const QModelIndex & parent = QModelIndex() ) const Q_DECL_OVERRIDE;
+    virtual QModelIndex index (int row, int column, const QModelIndex & parent = QModelIndex() ) const override;
 
     //! Returns the parent of one model index
-    virtual QModelIndex parent (const QModelIndex& index) const Q_DECL_OVERRIDE;
+    virtual QModelIndex parent (const QModelIndex& index) const override;
 
     //! Returns the data of an model index
-    virtual QVariant data (const QModelIndex& index, int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+    virtual QVariant data (const QModelIndex& index, int role = Qt::DisplayRole) const override;
 
     //! Returns the data for the given role and section in the header with the specified orientation.
     virtual QVariant headerData (int section, Qt::Orientation orientation,
-                                 int role = Qt::DisplayRole) const Q_DECL_OVERRIDE;
+                                 int role = Qt::DisplayRole) const override;
 
     //! Returns the number of rows
-    virtual int rowCount ( const QModelIndex & parent = QModelIndex() ) const Q_DECL_OVERRIDE;
+    virtual int rowCount ( const QModelIndex & parent = QModelIndex() ) const override;
 
     //! Returns the number of columns
-    virtual int columnCount ( const QModelIndex & parent = QModelIndex() ) const Q_DECL_OVERRIDE;
+    virtual int columnCount ( const QModelIndex & parent = QModelIndex() ) const override;
 
     //! Gets a property by its ModelIndex
     //! \param index The modelIndex of the property.

--- a/src/libs/vpropertyexplorer/vpropertytreeview.h
+++ b/src/libs/vpropertyexplorer/vpropertytreeview.h
@@ -47,7 +47,7 @@ public:
     explicit VPropertyTreeView(VPropertyModel* model, QWidget *parent = nullptr);
 
     //! Destructor
-    virtual ~VPropertyTreeView() Q_DECL_OVERRIDE;
+    virtual ~VPropertyTreeView() override;
 
     //! Sets the height for each row. Set this to 0 in order to let the standard delegate decide
     void setRowHeight(int height = 0, bool add_to_standard = false);

--- a/src/libs/vpropertyexplorer/vstandardpropertyfactory.h
+++ b/src/libs/vpropertyexplorer/vstandardpropertyfactory.h
@@ -46,7 +46,7 @@ public:
     //! Creates a new property of a certain type and assigns a name and description (otionally)
     //! \param type The type of the property as string
     //! \return Returns the created property or NULL if it couldn't be be created
-    Q_REQUIRED_RESULT virtual VProperty* createProperty(const QString& type, const QString &name) Q_DECL_OVERRIDE;
+    Q_REQUIRED_RESULT virtual VProperty* createProperty(const QString& type, const QString &name) override;
 };
 
 }

--- a/src/libs/vpropertyexplorer/vwidgetproperty_p.h
+++ b/src/libs/vpropertyexplorer/vwidgetproperty_p.h
@@ -50,7 +50,7 @@ public:
         : VPropertyPrivate(), Widget(nullptr) {}
 
     //! Destructor
-    virtual ~VWidgetPropertyPrivate() Q_DECL_OVERRIDE
+    virtual ~VWidgetPropertyPrivate() override
     {
         if (Widget)
         {

--- a/src/libs/vtools/dialogs/support/dialogundo.h
+++ b/src/libs/vtools/dialogs/support/dialogundo.h
@@ -72,9 +72,9 @@ class DialogUndo : public QDialog
 public:
     explicit DialogUndo(QWidget *parent = nullptr);
     UndoButton Result() const;
-    virtual ~DialogUndo() Q_DECL_OVERRIDE;
+    virtual ~DialogUndo() override;
 protected:
-    virtual void closeEvent ( QCloseEvent *event ) Q_DECL_OVERRIDE;
+    virtual void closeEvent ( QCloseEvent *event ) override;
 private slots:
     void Cancel();
 private:

--- a/src/libs/vtools/dialogs/support/edit_formula_dialog.h
+++ b/src/libs/vtools/dialogs/support/edit_formula_dialog.h
@@ -88,7 +88,7 @@ class EditFormulaDialog : public DialogTool
 public:
                  EditFormulaDialog(const VContainer *data, const quint32 &toolId,
                                    const quint16 &source, QWidget *parent = nullptr);
-    virtual     ~EditFormulaDialog() Q_DECL_OVERRIDE;
+    virtual     ~EditFormulaDialog() override;
 
     QString      GetFormula() const;
     void         SetFormula(const QString &value);
@@ -97,9 +97,9 @@ public:
     void         setPostfix(const QString &value);
 
 public slots:
-    virtual void DialogAccepted() Q_DECL_OVERRIDE;
-    virtual void DialogRejected() Q_DECL_OVERRIDE;
-    virtual void EvalFormula() Q_DECL_OVERRIDE;
+    virtual void DialogAccepted() override;
+    virtual void DialogRejected() override;
+    virtual void EvalFormula() override;
     void         valueChanged(int row);
     void         tabChanged(int row);
     void         insertVariable(const QString &rotation);
@@ -114,10 +114,10 @@ public slots:
     void         functions();
 
 protected:
-    virtual void CheckState() Q_DECL_FINAL;
-    virtual void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
-    virtual void showEvent( QShowEvent *event ) Q_DECL_OVERRIDE;
-    virtual void resizeEvent(QResizeEvent *event) Q_DECL_OVERRIDE;
+    virtual void CheckState() final;
+    virtual void closeEvent(QCloseEvent *event) override;
+    virtual void showEvent( QShowEvent *event ) override;
+    virtual void resizeEvent(QResizeEvent *event) override;
 
 private slots:
     void         filterVariables(const QString &filter);

--- a/src/libs/vtools/dialogs/tools/addtogroup_dialog.h
+++ b/src/libs/vtools/dialogs/tools/addtogroup_dialog.h
@@ -57,10 +57,10 @@ public:
 
     QMap<quint32, quint32>    getGroupData() const;
 
-    virtual void              ShowDialog(bool click) Q_DECL_OVERRIDE;
+    virtual void              ShowDialog(bool click) override;
 
 public slots:
-    virtual void              SelectedObject(bool selected, quint32 object, quint32 tool) Q_DECL_OVERRIDE;
+    virtual void              SelectedObject(bool selected, quint32 object, quint32 tool) override;
 
 private:
                               Q_DISABLE_COPY(AddToGroupDialog)

--- a/src/libs/vtools/dialogs/tools/anchorpoint_dialog.h
+++ b/src/libs/vtools/dialogs/tools/anchorpoint_dialog.h
@@ -74,14 +74,14 @@ public:
     quint32 GetPointId() const;
     void    SetPointId(quint32 id);
 
-    virtual void SetPiecesList(const QVector<quint32> &list) Q_DECL_OVERRIDE;
+    virtual void SetPiecesList(const QVector<quint32> &list) override;
 
 public slots:
-    virtual void ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void ChosenObject(quint32 id, const SceneObject &type) override;
 
 protected:
-    virtual void CheckState() Q_DECL_FINAL;
-    virtual void ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void CheckState() final;
+    virtual void ShowVisualization() override;
 
 private:
     Q_DISABLE_COPY(AnchorPointDialog)

--- a/src/libs/vtools/dialogs/tools/dialogalongline.h
+++ b/src/libs/vtools/dialogs/tools/dialogalongline.h
@@ -74,7 +74,7 @@ class DialogAlongLine : public DialogTool
     Q_OBJECT
 public:
     DialogAlongLine(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogAlongLine() Q_DECL_OVERRIDE;
+    virtual ~DialogAlongLine() override;
 
     void                SetPointName(const QString &value);
 
@@ -96,9 +96,9 @@ public:
     quint32             GetSecondPointId() const;
     void                SetSecondPointId(const quint32 &value);
 
-    virtual void        Build(const Tool &type) Q_DECL_OVERRIDE;
+    virtual void        Build(const Tool &type) override;
 public slots:
-    virtual void        ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void        ChosenObject(quint32 id, const SceneObject &type) override;
     /**
      * @brief DeployFormulaTextEdit grow or shrink formula input
      */
@@ -112,12 +112,12 @@ public slots:
     void                FXLength();
 
 protected:
-    virtual void        ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void        ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void        SaveData() Q_DECL_OVERRIDE;
-    virtual void        closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void        SaveData() override;
+    virtual void        closeEvent(QCloseEvent *event) override;
 
 private:
     Q_DISABLE_COPY(DialogAlongLine)

--- a/src/libs/vtools/dialogs/tools/dialogarc.h
+++ b/src/libs/vtools/dialogs/tools/dialogarc.h
@@ -70,7 +70,7 @@ class DialogArc : public DialogTool
     Q_OBJECT
 public:
     DialogArc(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogArc() Q_DECL_OVERRIDE;
+    virtual ~DialogArc() override;
 
     VArc          getArc() const;
     void          setArc(const VArc &arc);
@@ -97,7 +97,7 @@ public:
     void          setLineColor(const QString &value);
 
 public slots:
-    virtual void  ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void  ChosenObject(quint32 id, const SceneObject &type) override;
     /**
      * @brief DeployFormulaTextEdit grow or shrink formula input
      */
@@ -114,13 +114,13 @@ public slots:
 
 protected:
     void          pointNameChanged();
-    virtual void  CheckState() Q_DECL_FINAL;
-    virtual void  ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void  CheckState() final;
+    virtual void  ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void  SaveData() Q_DECL_OVERRIDE;
-    virtual void  closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void  SaveData() override;
+    virtual void  closeEvent(QCloseEvent *event) override;
 
 private:
     Q_DISABLE_COPY(DialogArc)

--- a/src/libs/vtools/dialogs/tools/dialogarcwithlength.h
+++ b/src/libs/vtools/dialogs/tools/dialogarcwithlength.h
@@ -95,7 +95,7 @@ public:
     void          setLineColor(const QString &value);
 
 public slots:
-    virtual void  ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void  ChosenObject(quint32 id, const SceneObject &type) override;
     /**
      * @brief DeployFormulaTextEdit grow or shrink formula input
      */
@@ -113,13 +113,13 @@ public slots:
 
 protected:
     void          pointNameChanged();
-    virtual void  CheckState() Q_DECL_FINAL;
-    virtual void  ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void  CheckState() final;
+    virtual void  ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void  SaveData() Q_DECL_OVERRIDE;
-    virtual void  closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void  SaveData() override;
+    virtual void  closeEvent(QCloseEvent *event) override;
 
 private:
     Q_DISABLE_COPY(DialogArcWithLength)

--- a/src/libs/vtools/dialogs/tools/dialogbisector.h
+++ b/src/libs/vtools/dialogs/tools/dialogbisector.h
@@ -75,7 +75,7 @@ class DialogBisector : public DialogTool
 public:
 
     DialogBisector(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogBisector() Q_DECL_OVERRIDE;
+    virtual ~DialogBisector() override;
 
     void               SetPointName(const QString &value);
 
@@ -101,7 +101,7 @@ public:
     void               SetThirdPointId(const quint32 &value);
 
 public slots:
-    virtual void       ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void       ChosenObject(quint32 id, const SceneObject &type) override;
     /**
      * @brief DeployFormulaTextEdit grow or shrink formula input
      */
@@ -110,15 +110,15 @@ public slots:
      * @brief FormulaTextChanged when formula text changes for validation and calc
      */
     void               FormulaTextChanged();
-    virtual void       PointNameChanged() Q_DECL_OVERRIDE;
+    virtual void       PointNameChanged() override;
     void               FXLength();
 protected:
-    virtual void       ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void       ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void       SaveData() Q_DECL_OVERRIDE;
-    virtual void       closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void       SaveData() override;
+    virtual void       closeEvent(QCloseEvent *event) override;
 private:
     Q_DISABLE_COPY(DialogBisector)
 

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezier.h
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezier.h
@@ -91,15 +91,15 @@ public:
     void          setLineColor(const QString &value);
 
 public slots:
-    virtual void  ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    virtual void  PointNameChanged() Q_DECL_OVERRIDE;
+    virtual void  ChosenObject(quint32 id, const SceneObject &type) override;
+    virtual void  PointNameChanged() override;
 
 protected:
-    virtual void  ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void  ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void  SaveData() Q_DECL_OVERRIDE;
+    virtual void  SaveData() override;
 
 private:
     Q_DISABLE_COPY(DialogCubicBezier)

--- a/src/libs/vtools/dialogs/tools/dialogcubicbezierpath.h
+++ b/src/libs/vtools/dialogs/tools/dialogcubicbezierpath.h
@@ -91,12 +91,12 @@ public:
 
 
 public slots:
-    virtual void     ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    virtual void     ShowDialog(bool click) Q_DECL_OVERRIDE;
+    virtual void     ChosenObject(quint32 id, const SceneObject &type) override;
+    virtual void     ShowDialog(bool click) override;
 
 protected:
-    virtual void     ShowVisualization() Q_DECL_OVERRIDE;
-    virtual void     SaveData() Q_DECL_OVERRIDE;
+    virtual void     ShowVisualization() override;
+    virtual void     SaveData() override;
 
 private slots:
     void             PointChanged(int row);

--- a/src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.h
+++ b/src/libs/vtools/dialogs/tools/dialogcurveintersectaxis.h
@@ -72,7 +72,7 @@ class DialogCurveIntersectAxis : public DialogTool
 
 public:
     DialogCurveIntersectAxis(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogCurveIntersectAxis() Q_DECL_OVERRIDE;
+    virtual ~DialogCurveIntersectAxis() override;
 
     void         SetPointName(const QString &value);
 
@@ -97,22 +97,22 @@ public:
     quint32      getCurveId() const;
     void         setCurveId(const quint32 &value);
 
-    virtual void ShowDialog(bool click) Q_DECL_OVERRIDE;
+    virtual void ShowDialog(bool click) override;
     
 public slots:
-    virtual void ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void ChosenObject(quint32 id, const SceneObject &type) override;
     void         EvalAngle();
     void         AngleTextChanged();
     void         DeployAngleTextEdit();
     void         FXAngle();
 
 protected:
-    virtual void ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void SaveData() Q_DECL_OVERRIDE;
-    virtual void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void SaveData() override;
+    virtual void closeEvent(QCloseEvent *event) override;
 
 private:
     Q_DISABLE_COPY(DialogCurveIntersectAxis)

--- a/src/libs/vtools/dialogs/tools/dialogcutarc.h
+++ b/src/libs/vtools/dialogs/tools/dialogcutarc.h
@@ -72,7 +72,7 @@ class DialogCutArc : public DialogTool
     Q_OBJECT
 public:
                        DialogCutArc(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual           ~DialogCutArc() Q_DECL_OVERRIDE;
+    virtual           ~DialogCutArc() override;
 
     void               SetPointName(const QString &value);
 
@@ -89,7 +89,7 @@ public:
     void               setLineColor(const QString &value);
 
 public slots:
-    virtual void       ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void       ChosenObject(quint32 id, const SceneObject &type) override;
 
     /// @brief DeployFormulaTextEdit grow or shrink formula input.
     void               DeployFormulaTextEdit();
@@ -99,11 +99,11 @@ public slots:
     void               FXLength();
 
 protected:
-    virtual void       ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void       ShowVisualization() override;
 
     /// @brief SaveData Put dialog data in local variables
-    virtual void       SaveData() Q_DECL_OVERRIDE;
-    virtual void       closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void       SaveData() override;
+    virtual void       closeEvent(QCloseEvent *event) override;
 
 private:
     Q_DISABLE_COPY(DialogCutArc)

--- a/src/libs/vtools/dialogs/tools/dialogcutspline.h
+++ b/src/libs/vtools/dialogs/tools/dialogcutspline.h
@@ -72,7 +72,7 @@ class DialogCutSpline : public DialogTool
     Q_OBJECT
 public:
     DialogCutSpline(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogCutSpline() Q_DECL_OVERRIDE;
+    virtual ~DialogCutSpline() override;
 
     void                setPointName(const QString &value);
 
@@ -89,17 +89,17 @@ public:
     void                setLineColor(const QString &value);
 
 public slots:
-    virtual void        ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void        ChosenObject(quint32 id, const SceneObject &type) override;
 
     /// @brief DeployFormulaTextEdit grow or shrink formula input
     void                DeployFormulaTextEdit();
     void                FXLength();
 protected:
-    virtual void        ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void        ShowVisualization() override;
 
     /// @brief SaveData Put dialog data in local variables
-    virtual void        SaveData() Q_DECL_OVERRIDE;
-    virtual void        closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void        SaveData() override;
+    virtual void        closeEvent(QCloseEvent *event) override;
 private:
     Q_DISABLE_COPY(DialogCutSpline)
 

--- a/src/libs/vtools/dialogs/tools/dialogcutsplinepath.h
+++ b/src/libs/vtools/dialogs/tools/dialogcutsplinepath.h
@@ -73,7 +73,7 @@ class DialogCutSplinePath : public DialogTool
     Q_OBJECT
 public:
                  DialogCutSplinePath(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual     ~DialogCutSplinePath() Q_DECL_OVERRIDE;
+    virtual     ~DialogCutSplinePath() override;
 
     void         SetPointName(const QString &value);
 
@@ -90,17 +90,17 @@ public:
     void         setLineColor(const QString &value);
 
 public slots:
-    virtual void ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void ChosenObject(quint32 id, const SceneObject &type) override;
 
     /// @brief DeployFormulaTextEdit grow or shrink formula input.
     void         DeployFormulaTextEdit();
     void         FXLength();
 
 protected:
-    virtual void ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void ShowVisualization() override;
     /// @brief SaveData Put dialog data in local variables
-    virtual void SaveData() Q_DECL_OVERRIDE;
-    virtual void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void SaveData() override;
+    virtual void closeEvent(QCloseEvent *event) override;
 
 private:
     Q_DISABLE_COPY(DialogCutSplinePath)

--- a/src/libs/vtools/dialogs/tools/dialogellipticalarc.h
+++ b/src/libs/vtools/dialogs/tools/dialogellipticalarc.h
@@ -66,7 +66,7 @@ class DialogEllipticalArc : public DialogTool
     Q_OBJECT
 public:
     DialogEllipticalArc(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogEllipticalArc() Q_DECL_OVERRIDE;
+    virtual ~DialogEllipticalArc() override;
 
     VEllipticalArc getArc() const;
     void           setArc(const VEllipticalArc &arc);
@@ -100,7 +100,7 @@ public:
 
 
 public slots:
-    virtual void   ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void   ChosenObject(quint32 id, const SceneObject &type) override;
     /**
      * @brief DeployFormulaTextEdit grow or shrink formula input
      */
@@ -124,13 +124,13 @@ public slots:
 
 protected:
     void           pointNameChanged();
-    virtual void   CheckState() Q_DECL_FINAL;
-    virtual void   ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void   CheckState() final;
+    virtual void   ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void   SaveData() Q_DECL_OVERRIDE;
-    virtual void   closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void   SaveData() override;
+    virtual void   closeEvent(QCloseEvent *event) override;
 
 private:
     Q_DISABLE_COPY(DialogEllipticalArc)

--- a/src/libs/vtools/dialogs/tools/dialogendline.h
+++ b/src/libs/vtools/dialogs/tools/dialogendline.h
@@ -74,7 +74,7 @@ class DialogEndLine : public DialogTool
     Q_OBJECT
 public:
     DialogEndLine(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogEndLine() Q_DECL_OVERRIDE;
+    virtual ~DialogEndLine() override;
 
     void              SetPointName(const QString &value);
 
@@ -96,10 +96,10 @@ public:
     quint32           GetBasePointId() const;
     void              SetBasePointId(const quint32 &value);
 
-    virtual void      ShowDialog(bool click) Q_DECL_OVERRIDE;
+    virtual void      ShowDialog(bool click) override;
 
 public slots:
-    virtual void      ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void      ChosenObject(quint32 id, const SceneObject &type) override;
     /**
      * @brief DeployFormulaTextEdit grow or shrink formula input
      */
@@ -116,12 +116,12 @@ public slots:
     void             FXAngle();
     void             FXLength();
 protected:
-    virtual void     ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void     ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void     SaveData() Q_DECL_OVERRIDE;
-    virtual void     closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void     SaveData() override;
+    virtual void     closeEvent(QCloseEvent *event) override;
 private:
     Q_DISABLE_COPY(DialogEndLine)
 

--- a/src/libs/vtools/dialogs/tools/dialoggroup.h
+++ b/src/libs/vtools/dialogs/tools/dialoggroup.h
@@ -79,10 +79,10 @@ public:
 
     QMap<quint32, quint32> GetGroup() const;
 
-    virtual void ShowDialog(bool click) Q_DECL_OVERRIDE;
+    virtual void ShowDialog(bool click) override;
 
 public slots:
-    virtual void SelectedObject(bool selected, quint32 object, quint32 tool) Q_DECL_OVERRIDE;
+    virtual void SelectedObject(bool selected, quint32 object, quint32 tool) override;
 
 private slots:
     void NameChanged();

--- a/src/libs/vtools/dialogs/tools/dialogheight.h
+++ b/src/libs/vtools/dialogs/tools/dialogheight.h
@@ -74,7 +74,7 @@ class DialogHeight : public DialogTool
     Q_OBJECT
 public:
     DialogHeight(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogHeight() Q_DECL_OVERRIDE;
+    virtual ~DialogHeight() override;
 
     void             SetPointName(const QString &value);
 
@@ -97,15 +97,15 @@ public:
     void             SetP2LineId(const quint32 &value);
 
 public slots:
-    virtual void     ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    virtual void     PointNameChanged() Q_DECL_OVERRIDE;
+    virtual void     ChosenObject(quint32 id, const SceneObject &type) override;
+    virtual void     PointNameChanged() override;
 
 protected:
-    virtual void     ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void     ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void     SaveData() Q_DECL_OVERRIDE;
+    virtual void     SaveData() override;
 
 private:
     Q_DISABLE_COPY(DialogHeight)

--- a/src/libs/vtools/dialogs/tools/dialogline.h
+++ b/src/libs/vtools/dialogs/tools/dialogline.h
@@ -69,7 +69,7 @@ class DialogLine : public DialogTool
     Q_OBJECT
 public:
     DialogLine(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogLine() Q_DECL_OVERRIDE;
+    virtual ~DialogLine() override;
 
     quint32        getFirstPoint() const;
     void           setFirstPoint(const quint32 &value);
@@ -89,15 +89,15 @@ public:
     void           setLineColor(const QString &value);
 
 public slots:
-    virtual void   ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    virtual void   PointNameChanged() Q_DECL_OVERRIDE;
+    virtual void   ChosenObject(quint32 id, const SceneObject &type) override;
+    virtual void   PointNameChanged() override;
 
 protected:
-    virtual void   ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void   ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void   SaveData() Q_DECL_OVERRIDE;
+    virtual void   SaveData() override;
 
 private:
     Q_DISABLE_COPY(DialogLine)

--- a/src/libs/vtools/dialogs/tools/dialoglineintersect.h
+++ b/src/libs/vtools/dialogs/tools/dialoglineintersect.h
@@ -74,7 +74,7 @@ class DialogLineIntersect : public DialogTool
     Q_OBJECT
 public:
     DialogLineIntersect(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogLineIntersect() Q_DECL_OVERRIDE;
+    virtual ~DialogLineIntersect() override;
 
     quint32                 GetP1Line1() const;
     void                    SetP1Line1(const quint32 &value);
@@ -90,15 +90,15 @@ public:
 
     void                    SetPointName(const QString &value);
 public slots:
-    virtual void            ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void            ChosenObject(quint32 id, const SceneObject &type) override;
     void                    PointChanged();
-    virtual void            PointNameChanged() Q_DECL_OVERRIDE;
+    virtual void            PointNameChanged() override;
 protected:
-    virtual void            ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void            ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void            SaveData() Q_DECL_OVERRIDE;
+    virtual void            SaveData() override;
 private:
     Q_DISABLE_COPY(DialogLineIntersect)
 
@@ -108,7 +108,7 @@ private:
     /** @brief flagPoint keep state of point */
     bool                    flagPoint;
 
-    virtual void            CheckState() Q_DECL_FINAL;
+    virtual void            CheckState() final;
     bool                    CheckIntersecion();
 };
 

--- a/src/libs/vtools/dialogs/tools/dialoglineintersectaxis.h
+++ b/src/libs/vtools/dialogs/tools/dialoglineintersectaxis.h
@@ -72,7 +72,7 @@ class DialogLineIntersectAxis : public DialogTool
 
 public:
     DialogLineIntersectAxis(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogLineIntersectAxis() Q_DECL_OVERRIDE;
+    virtual ~DialogLineIntersectAxis() override;
 
     void         SetPointName(const QString &value);
 
@@ -97,24 +97,24 @@ public:
     quint32      GetSecondPointId() const;
     void         SetSecondPointId(const quint32 &value);
 
-    virtual void ShowDialog(bool click) Q_DECL_OVERRIDE;
+    virtual void ShowDialog(bool click) override;
 
 public slots:
-    virtual void ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void ChosenObject(quint32 id, const SceneObject &type) override;
     void         EvalAngle();
     void         AngleTextChanged();
     void         DeployAngleTextEdit();
-    virtual void PointNameChanged() Q_DECL_OVERRIDE;
+    virtual void PointNameChanged() override;
 
     void         FXAngle();
 
 protected:
-    virtual void ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void SaveData() Q_DECL_OVERRIDE;
-    virtual void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void SaveData() override;
+    virtual void closeEvent(QCloseEvent *event) override;
     
 private:
     Q_DISABLE_COPY(DialogLineIntersectAxis)

--- a/src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.h
+++ b/src/libs/vtools/dialogs/tools/dialogmirrorbyaxis.h
@@ -90,21 +90,21 @@ public:
     QVector<SourceItem>    getSourceObjects() const;
     void                   setSourceObjects(const QVector<SourceItem> &value);
 
-    virtual void           ShowDialog(bool click) Q_DECL_OVERRIDE;
+    virtual void           ShowDialog(bool click) override;
 
 public slots:
-    virtual void           ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    virtual void           SelectedObject(bool selected, quint32 id, quint32 tool) Q_DECL_OVERRIDE;
+    virtual void           ChosenObject(quint32 id, const SceneObject &type) override;
+    virtual void           SelectedObject(bool selected, quint32 id, quint32 tool) override;
 
 private slots:
     void                   suffixChanged();
 
 protected:
-    virtual void           CheckState() Q_DECL_FINAL;
-    virtual void           ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void           CheckState() final;
+    virtual void           ShowVisualization() override;
 
     /** @brief SaveData Put dialog data in local variables */
-    virtual void           SaveData() Q_DECL_OVERRIDE;
+    virtual void           SaveData() override;
 
 private slots:
     void                   pointChanged();

--- a/src/libs/vtools/dialogs/tools/dialogmirrorbyline.h
+++ b/src/libs/vtools/dialogs/tools/dialogmirrorbyline.h
@@ -90,21 +90,21 @@ public:
     QVector<SourceItem>    getSourceObjects() const;
     void                   setSourceObjects(const QVector<SourceItem> &value);
 
-    virtual void           ShowDialog(bool click) Q_DECL_OVERRIDE;
+    virtual void           ShowDialog(bool click) override;
 
 public slots:
-    virtual void           ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    virtual void           SelectedObject(bool selected, quint32 id, quint32 tool) Q_DECL_OVERRIDE;
+    virtual void           ChosenObject(quint32 id, const SceneObject &type) override;
+    virtual void           SelectedObject(bool selected, quint32 id, quint32 tool) override;
 
 private slots:
     void                   suffixChanged();
 
 protected:
-    virtual void           CheckState() Q_DECL_FINAL;
-    virtual void           ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void           CheckState() final;
+    virtual void           ShowVisualization() override;
 
     /** @brief SaveData Put dialog data in local variables */
-    virtual void           SaveData() Q_DECL_OVERRIDE;
+    virtual void           SaveData() override;
 
 private slots:
     void                   pointChanged();

--- a/src/libs/vtools/dialogs/tools/dialogmove.h
+++ b/src/libs/vtools/dialogs/tools/dialogmove.h
@@ -92,14 +92,14 @@ public:
     quint32          getOriginPointId() const;
     void             setOriginPointId(const quint32 &value);
 
-    virtual void     ShowDialog(bool click) Q_DECL_OVERRIDE;
+    virtual void     ShowDialog(bool click) override;
 
     QVector<SourceItem> getSourceObjects() const;
     void                setSourceObjects(const QVector<SourceItem> &value);
 
 public slots:
-    virtual void     ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    virtual void     SelectedObject(bool selected, quint32 id, quint32 tool) Q_DECL_OVERRIDE;
+    virtual void     ChosenObject(quint32 id, const SceneObject &type) override;
+    virtual void     SelectedObject(bool selected, quint32 id, quint32 tool) override;
 
 private slots:
     void             angleChanged();
@@ -114,12 +114,12 @@ private slots:
     void             originChanged(const QString &text);
 
 protected:
-    virtual void     CheckState() Q_DECL_FINAL;
-    virtual void     ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void     CheckState() final;
+    virtual void     ShowVisualization() override;
 
     /** @brief SaveData Put dialog data in local variables */
-    virtual void     SaveData() Q_DECL_OVERRIDE;
-    virtual void     closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void     SaveData() override;
+    virtual void     closeEvent(QCloseEvent *event) override;
 
 private:
     Q_DISABLE_COPY(DialogMove)

--- a/src/libs/vtools/dialogs/tools/dialognormal.h
+++ b/src/libs/vtools/dialogs/tools/dialognormal.h
@@ -74,7 +74,7 @@ class DialogNormal : public DialogTool
     Q_OBJECT
 public:
     DialogNormal(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogNormal() Q_DECL_OVERRIDE;
+    virtual ~DialogNormal() override;
 
     void             SetPointName(const QString &value);
 
@@ -100,7 +100,7 @@ public:
     void             SetSecondPointId(const quint32 &value);
 
 public slots:
-    virtual void     ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void     ChosenObject(quint32 id, const SceneObject &type) override;
     /**
      * @brief DeployFormulaTextEdit grow or shrink formula input
      */
@@ -109,16 +109,16 @@ public slots:
      * @brief FormulaTextChanged when formula text changes for validation and calc
      */
     void             FormulaTextChanged();
-    virtual void     PointNameChanged() Q_DECL_OVERRIDE;
+    virtual void     PointNameChanged() override;
     void             FXLength();
 
 protected:
-    virtual void     ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void     ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void     SaveData() Q_DECL_OVERRIDE;
-    virtual void     closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void     SaveData() override;
+    virtual void     closeEvent(QCloseEvent *event) override;
 
 private:
     Q_DISABLE_COPY(DialogNormal)

--- a/src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.h
+++ b/src/libs/vtools/dialogs/tools/dialogpointfromarcandtangent.h
@@ -88,14 +88,14 @@ public:
     void              setCirclesCrossPoint(const CrossCirclesPoint &p);
 
 public slots:
-    virtual void   ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void   ChosenObject(quint32 id, const SceneObject &type) override;
 
 protected:
-    virtual void   ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void   ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void   SaveData() Q_DECL_OVERRIDE;
+    virtual void   SaveData() override;
 
 private:
     Q_DISABLE_COPY(DialogPointFromArcAndTangent)

--- a/src/libs/vtools/dialogs/tools/dialogpointofcontact.h
+++ b/src/libs/vtools/dialogs/tools/dialogpointofcontact.h
@@ -75,7 +75,7 @@ class DialogPointOfContact : public DialogTool
     Q_OBJECT
 public:
     DialogPointOfContact(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogPointOfContact() Q_DECL_OVERRIDE;
+    virtual ~DialogPointOfContact() override;
 
     void           SetPointName(const QString &value);
 
@@ -91,7 +91,7 @@ public:
     quint32        GetSecondPoint() const;
     void           SetSecondPoint(const quint32 &value);
 public slots:
-    virtual void   ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void   ChosenObject(quint32 id, const SceneObject &type) override;
     /**
      * @brief DeployFormulaTextEdit grow or shrink formula input
      */
@@ -100,15 +100,15 @@ public slots:
      * @brief FormulaTextChanged when formula text changes for validation and calc
      */
     void           FormulaTextChanged();
-    virtual void   PointNameChanged() Q_DECL_OVERRIDE;
+    virtual void   PointNameChanged() override;
     void           FXRadius();
 protected:
-    virtual void   ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void   ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void   SaveData() Q_DECL_OVERRIDE;
-    virtual void   closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void   SaveData() override;
+    virtual void   closeEvent(QCloseEvent *event) override;
 private:
     Q_DISABLE_COPY(DialogPointOfContact)
 

--- a/src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.h
+++ b/src/libs/vtools/dialogs/tools/dialogpointofintersectionarcs.h
@@ -73,7 +73,7 @@ class DialogPointOfIntersectionArcs : public DialogTool
 
 public:
     DialogPointOfIntersectionArcs(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogPointOfIntersectionArcs() Q_DECL_OVERRIDE;
+    virtual ~DialogPointOfIntersectionArcs() override;
 
     void           SetPointName(const QString &value);
 
@@ -87,15 +87,15 @@ public:
     void              SetCrossArcPoint(const CrossCirclesPoint &p);
 
 public slots:
-    virtual void   ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void   ChosenObject(quint32 id, const SceneObject &type) override;
     virtual void   ArcChanged();
 
 protected:
-    virtual void   ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void   ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void   SaveData() Q_DECL_OVERRIDE;
+    virtual void   SaveData() override;
 
 private:
     Q_DISABLE_COPY(DialogPointOfIntersectionArcs)

--- a/src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.h
+++ b/src/libs/vtools/dialogs/tools/dialogpointofintersectioncurves.h
@@ -72,7 +72,7 @@ class DialogPointOfIntersectionCurves : public DialogTool
 
 public:
     explicit DialogPointOfIntersectionCurves(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogPointOfIntersectionCurves() Q_DECL_OVERRIDE;
+    virtual ~DialogPointOfIntersectionCurves() override;
 
     void    SetPointName(const QString &value);
 
@@ -89,16 +89,16 @@ public:
     void              SetHCrossPoint(const HCrossCurvesPoint &hP);
 
 public slots:
-    virtual void ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void ChosenObject(quint32 id, const SceneObject &type) override;
 
 protected:
-    virtual void ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void ShowVisualization() override;
 
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void SaveData() Q_DECL_OVERRIDE;
-    virtual void CheckState() Q_DECL_FINAL;
+    virtual void SaveData() override;
+    virtual void CheckState() final;
 
 private slots:
     void CurveChanged();

--- a/src/libs/vtools/dialogs/tools/dialogrotation.h
+++ b/src/libs/vtools/dialogs/tools/dialogrotation.h
@@ -89,11 +89,11 @@ public:
     void                setSourceObjects(const QVector<SourceItem> &value);
 
 
-    virtual void        ShowDialog(bool click) Q_DECL_OVERRIDE;
+    virtual void        ShowDialog(bool click) override;
 
 public slots:
-    virtual void        ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    virtual void        SelectedObject(bool selected, quint32 id, quint32 tool) Q_DECL_OVERRIDE;
+    virtual void        ChosenObject(quint32 id, const SceneObject &type) override;
+    virtual void        SelectedObject(bool selected, quint32 id, quint32 tool) override;
 
 private slots:
     void                angleChanged();
@@ -101,12 +101,12 @@ private slots:
     void                suffixChanged();
 
 protected:
-    virtual void        CheckState() Q_DECL_FINAL;
-    virtual void        ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void        CheckState() final;
+    virtual void        ShowVisualization() override;
 
     /** @brief SaveData Put dialog data in local variables */
-    virtual void        SaveData() Q_DECL_OVERRIDE;
-    virtual void        closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void        SaveData() override;
+    virtual void        closeEvent(QCloseEvent *event) override;
 
 private slots:
     void                pointChanged();

--- a/src/libs/vtools/dialogs/tools/dialogshoulderpoint.h
+++ b/src/libs/vtools/dialogs/tools/dialogshoulderpoint.h
@@ -74,7 +74,7 @@ class DialogShoulderPoint : public DialogTool
     Q_OBJECT
 public:
     DialogShoulderPoint(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogShoulderPoint() Q_DECL_OVERRIDE;
+    virtual ~DialogShoulderPoint() override;
 
     void           SetPointName(const QString &value);
 
@@ -100,7 +100,7 @@ public:
     void           SetP3(const quint32 &value);
 
 public slots:
-    virtual void   ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void   ChosenObject(quint32 id, const SceneObject &type) override;
     /**
      * @brief DeployFormulaTextEdit grow or shrink formula input
      */
@@ -109,16 +109,16 @@ public slots:
      * @brief FormulaTextChanged when formula text changes for validation and calc
      */
     void           FormulaTextChanged();
-    virtual void   PointNameChanged() Q_DECL_OVERRIDE;
+    virtual void   PointNameChanged() override;
     void           FXLength();
 
 protected:
-    virtual void   ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void   ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void   SaveData() Q_DECL_OVERRIDE;
-    virtual void   closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void   SaveData() override;
+    virtual void   closeEvent(QCloseEvent *event) override;
 
 private:
     Q_DISABLE_COPY(DialogShoulderPoint)

--- a/src/libs/vtools/dialogs/tools/dialogsinglepoint.h
+++ b/src/libs/vtools/dialogs/tools/dialogsinglepoint.h
@@ -74,7 +74,7 @@ class DialogSinglePoint : public DialogTool
     Q_OBJECT
 public:
     DialogSinglePoint(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogSinglePoint() Q_DECL_OVERRIDE;
+    virtual ~DialogSinglePoint() override;
 
     void           SetData(const QString &name, const QPointF &point);
     QPointF        GetPoint()const;
@@ -85,7 +85,7 @@ protected:
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void   SaveData() Q_DECL_OVERRIDE;
+    virtual void   SaveData() override;
 private:
     Q_DISABLE_COPY(DialogSinglePoint)
 

--- a/src/libs/vtools/dialogs/tools/dialogspline.h
+++ b/src/libs/vtools/dialogs/tools/dialogspline.h
@@ -78,7 +78,7 @@ class DialogSpline : public DialogTool
     Q_OBJECT
 public:
                   DialogSpline(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual      ~DialogSpline() Q_DECL_OVERRIDE;
+    virtual      ~DialogSpline() override;
 
     VSpline       GetSpline() const;
     void          SetSpline(const VSpline &spline);
@@ -93,18 +93,18 @@ public:
     void          setLineColor(const QString &value);
 
 public slots:
-    virtual void  ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    virtual void  PointNameChanged() Q_DECL_OVERRIDE;
-    virtual void  ShowDialog(bool click) Q_DECL_OVERRIDE;
+    virtual void  ChosenObject(quint32 id, const SceneObject &type) override;
+    virtual void  PointNameChanged() override;
+    virtual void  ShowDialog(bool click) override;
 
 protected:
-    virtual void  CheckState() Q_DECL_FINAL;
-    virtual void  ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void  CheckState() final;
+    virtual void  ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void  SaveData() Q_DECL_OVERRIDE;
-    virtual void  closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void  SaveData() override;
+    virtual void  closeEvent(QCloseEvent *event) override;
 
 private slots:
     void          DeployAngle1TextEdit();

--- a/src/libs/vtools/dialogs/tools/dialogsplinepath.h
+++ b/src/libs/vtools/dialogs/tools/dialogsplinepath.h
@@ -77,7 +77,7 @@ class DialogSplinePath : public DialogTool
     Q_OBJECT
 public:
                  DialogSplinePath(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual     ~DialogSplinePath() Q_DECL_OVERRIDE;
+    virtual     ~DialogSplinePath() override;
 
     VSplinePath  GetPath() const;
     void         SetPath(const VSplinePath &value);
@@ -92,15 +92,15 @@ public:
     void         setLineColor(const QString &value);
 
 public slots:
-    virtual void ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    virtual void ShowDialog(bool click) Q_DECL_OVERRIDE;
+    virtual void ChosenObject(quint32 id, const SceneObject &type) override;
+    virtual void ShowDialog(bool click) override;
     void         PathUpdated(const VSplinePath &path);
 
 protected:
-    virtual void ShowVisualization() Q_DECL_OVERRIDE;
-    virtual void SaveData() Q_DECL_OVERRIDE;
-    virtual void CheckState() Q_DECL_FINAL;
-    virtual void closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
+    virtual void ShowVisualization() override;
+    virtual void SaveData() override;
+    virtual void CheckState() final;
+    virtual void closeEvent(QCloseEvent *event) override;
 
 private slots:
     void         PointChanged(int row);

--- a/src/libs/vtools/dialogs/tools/dialogtool.h
+++ b/src/libs/vtools/dialogs/tools/dialogtool.h
@@ -105,7 +105,7 @@ class DialogTool : public QDialog
     Q_OBJECT
 public:
     DialogTool(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual          ~DialogTool() Q_DECL_OVERRIDE;
+    virtual          ~DialogTool() override;
 
     VAbstractTool*   GetAssociatedTool();
     void             SetAssociatedTool(VAbstractTool* tool);
@@ -233,9 +233,9 @@ protected:
     QPointer<Visualization> vis;
 
     QScreen         *m_screen;
-    virtual void     keyPressEvent(QKeyEvent *event) Q_DECL_OVERRIDE;
-    virtual void     closeEvent ( QCloseEvent * event ) Q_DECL_OVERRIDE;
-    virtual void     showEvent( QShowEvent *event ) Q_DECL_OVERRIDE;
+    virtual void     keyPressEvent(QKeyEvent *event) override;
+    virtual void     closeEvent ( QCloseEvent * event ) override;
+    virtual void     showEvent( QShowEvent *event ) override;
 
     void             fillComboBoxPiecesList(QComboBox *box, const QVector<quint32> &list);
     void             fillComboBoxPoints(QComboBox *box, FillComboBox rule = FillComboBox::Whole,
@@ -302,7 +302,7 @@ protected:
      */
     virtual void     SaveData() {}
     void             MoveCursorToEnd(QPlainTextEdit *plainTextEdit) const;
-    virtual bool     eventFilter(QObject *object, QEvent *event) Q_DECL_OVERRIDE;
+    virtual bool     eventFilter(QObject *object, QEvent *event) override;
     quint32          DNumber(const QString &baseName) const;
 
     static int       FindNotExcludedNodeDown(QListWidget *listWidget, int candidate);

--- a/src/libs/vtools/dialogs/tools/dialogtriangle.h
+++ b/src/libs/vtools/dialogs/tools/dialogtriangle.h
@@ -74,7 +74,7 @@ class DialogTriangle : public DialogTool
     Q_OBJECT
 public:
     DialogTriangle(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual ~DialogTriangle() Q_DECL_OVERRIDE;
+    virtual ~DialogTriangle() override;
 
     quint32        GetAxisP1Id() const;
     void           SetAxisP1Id(const quint32 &value);
@@ -90,14 +90,14 @@ public:
 
     void           SetPointName(const QString &value);
 public slots:
-    virtual void   ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    virtual void   PointNameChanged() Q_DECL_OVERRIDE;
+    virtual void   ChosenObject(quint32 id, const SceneObject &type) override;
+    virtual void   PointNameChanged() override;
 protected:
-    virtual void   ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void   ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void   SaveData() Q_DECL_OVERRIDE;
+    virtual void   SaveData() override;
 private:
     Q_DISABLE_COPY(DialogTriangle)
 

--- a/src/libs/vtools/dialogs/tools/dialogtruedarts.h
+++ b/src/libs/vtools/dialogs/tools/dialogtruedarts.h
@@ -95,17 +95,17 @@ public:
 
     void               SetChildrenId(const quint32 &ch1, const quint32 &ch2);
 public slots:
-    virtual void       ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
-    virtual void       PointNameChanged() Q_DECL_OVERRIDE;
+    virtual void       ChosenObject(quint32 id, const SceneObject &type) override;
+    virtual void       PointNameChanged() override;
     void               NameDartPoint1Changed();
     void               NameDartPoint2Changed();
 protected:
-    virtual void       ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void       ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void       SaveData() Q_DECL_OVERRIDE;
-    virtual void       CheckState() Q_DECL_FINAL;
+    virtual void       SaveData() override;
+    virtual void       CheckState() final;
 
 private:
     Q_DISABLE_COPY(DialogTrueDarts)

--- a/src/libs/vtools/dialogs/tools/editgroup_dialog.h
+++ b/src/libs/vtools/dialogs/tools/editgroup_dialog.h
@@ -86,10 +86,10 @@ public:
     QString                   getLineWeight() const;
     void                      setLineWeight(const QString &weight);
 
-    virtual void              ShowDialog(bool click) Q_DECL_OVERRIDE;
+    virtual void              ShowDialog(bool click) override;
 
 public slots:
-    virtual void              SelectedObject(bool selected, quint32 object, quint32 tool) Q_DECL_OVERRIDE;
+    virtual void              SelectedObject(bool selected, quint32 object, quint32 tool) override;
 
 private slots:
     void                      nameChanged();

--- a/src/libs/vtools/dialogs/tools/insert_nodes_dialog.h
+++ b/src/libs/vtools/dialogs/tools/insert_nodes_dialog.h
@@ -73,23 +73,23 @@ public:
     explicit              InsertNodesDialog(const VContainer *data, quint32 toolId, QWidget *parent = nullptr);
     virtual              ~InsertNodesDialog();
 
-    virtual void          SetPiecesList(const QVector<quint32> &list) Q_DECL_OVERRIDE;
+    virtual void          SetPiecesList(const QVector<quint32> &list) override;
 
     quint32               getPieceId() const;
 
     QVector<VPieceNode>   getNodes() const;
 
-    virtual void          ShowDialog(bool click) Q_DECL_OVERRIDE;
+    virtual void          ShowDialog(bool click) override;
 
 public slots:
-    virtual void          SelectedObject(bool selected, quint32 object, quint32 tool) Q_DECL_OVERRIDE;
+    virtual void          SelectedObject(bool selected, quint32 object, quint32 tool) override;
 
 private slots:
     void                  showContextMenu(const QPoint &pos);
 
 protected:
-    virtual void          checkState() Q_DECL_FINAL;
-    virtual bool          eventFilter(QObject *object, QEvent *event) Q_DECL_OVERRIDE;
+    virtual void          checkState() final;
+    virtual bool          eventFilter(QObject *object, QEvent *event) override;
 
 private:
                           Q_DISABLE_COPY(InsertNodesDialog)

--- a/src/libs/vtools/dialogs/tools/intersect_circles_dialog.h
+++ b/src/libs/vtools/dialogs/tools/intersect_circles_dialog.h
@@ -53,7 +53,7 @@ class IntersectCirclesDialog : public DialogTool
 
 public:
                       IntersectCirclesDialog(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual          ~IntersectCirclesDialog() Q_DECL_OVERRIDE;
+    virtual          ~IntersectCirclesDialog() override;
 
     void              SetPointName(const QString &value);
 
@@ -73,7 +73,7 @@ public:
     void              setCirclesCrossPoint(const CrossCirclesPoint &p);
 
 public slots:
-    virtual void      ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void      ChosenObject(quint32 id, const SceneObject &type) override;
     void              PointChanged();
 
     void              Circle1RadiusChanged();
@@ -86,13 +86,13 @@ public slots:
     void              EvalCircle2Radius();
 
 protected:
-    virtual void      ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void      ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void      SaveData() Q_DECL_OVERRIDE;
-    virtual void      closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
-    virtual void      CheckState() Q_DECL_FINAL;
+    virtual void      SaveData() override;
+    virtual void      closeEvent(QCloseEvent *event) override;
+    virtual void      CheckState() final;
 
 private:
                       Q_DISABLE_COPY(IntersectCirclesDialog)

--- a/src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.h
+++ b/src/libs/vtools/dialogs/tools/intersect_circletangent_dialog.h
@@ -71,7 +71,7 @@ public:
     void              setCirclesCrossPoint(const CrossCirclesPoint &p);
 
 public slots:
-    virtual void      ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void      ChosenObject(quint32 id, const SceneObject &type) override;
     void              PointChanged();
 
     void              DeployCircleRadiusTextEdit();
@@ -80,13 +80,13 @@ public slots:
     void              EvalCircleRadius();
 
 protected:
-    virtual void      ShowVisualization() Q_DECL_OVERRIDE;
+    virtual void      ShowVisualization() override;
     /**
      * @brief SaveData Put dialog data in local variables
      */
-    virtual void      SaveData() Q_DECL_OVERRIDE;
-    virtual void      closeEvent(QCloseEvent *event) Q_DECL_OVERRIDE;
-    virtual void      CheckState() Q_DECL_FINAL;
+    virtual void      SaveData() override;
+    virtual void      closeEvent(QCloseEvent *event) override;
+    virtual void      CheckState() final;
 
 private:
                       Q_DISABLE_COPY(IntersectCircleTangentDialog)

--- a/src/libs/vtools/dialogs/tools/point_intersectxy_dialog.h
+++ b/src/libs/vtools/dialogs/tools/point_intersectxy_dialog.h
@@ -55,7 +55,7 @@ class PointIntersectXYDialog : public DialogTool
 
 public:
                    PointIntersectXYDialog(const VContainer *data, const quint32 &toolId, QWidget *parent = nullptr);
-    virtual       ~PointIntersectXYDialog() Q_DECL_OVERRIDE;
+    virtual       ~PointIntersectXYDialog() override;
 
     void           setPointName(const QString &value);
 
@@ -75,12 +75,12 @@ public:
     void           setLineColor(const QString &value);
 
 public slots:
-    virtual void   ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void   ChosenObject(quint32 id, const SceneObject &type) override;
     void           pointChanged();
 
 protected:
-    virtual void   ShowVisualization() Q_DECL_OVERRIDE;
-    virtual void   SaveData() Q_DECL_OVERRIDE;
+    virtual void   ShowVisualization() override;
+    virtual void   SaveData() override;
 
 private:
                    Q_DISABLE_COPY(PointIntersectXYDialog)

--- a/src/libs/vtools/dialogs/tools/union_dialog.h
+++ b/src/libs/vtools/dialogs/tools/union_dialog.h
@@ -77,7 +77,7 @@ class UnionDialog : public DialogTool
 public:
                  UnionDialog(const VContainer *data, const quint32 &toolId,
                              QWidget *parent = nullptr);
-    virtual     ~UnionDialog() Q_DECL_OVERRIDE;
+    virtual     ~UnionDialog() override;
 
     quint32      getPiece1Id() const;
     quint32      getPiece2Id() const;
@@ -85,7 +85,7 @@ public:
     int          getPiece2Index() const;
 
 public slots:
-    virtual void ChosenObject(quint32 id, const SceneObject &type) Q_DECL_OVERRIDE;
+    virtual void ChosenObject(quint32 id, const SceneObject &type) override;
 
 private:
     Q_DISABLE_COPY(UnionDialog)

--- a/src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.h
+++ b/src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyaxis.h
@@ -62,7 +62,7 @@ class VToolMirrorByAxis : public VAbstractMirror
 
 public:
     virtual                  ~VToolMirrorByAxis() Q_DECL_EQ_DEFAULT;
-    virtual void              setDialog() Q_DECL_OVERRIDE;
+    virtual void              setDialog() override;
     static VToolMirrorByAxis *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene,
                                      VAbstractPattern *doc, VContainer *data);
 
@@ -74,7 +74,7 @@ public:
 
     static const QString ToolType;
 
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum                 {Type = UserType + static_cast<int>(Tool::MirrorByAxis)};
 
     AxisType             getAxisType() const;
@@ -84,17 +84,17 @@ public:
     quint32              getOriginPointId() const;
     void                 setOriginPointId(const quint32 &value);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual QString      makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void         SetVisualization() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual QString      makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolMirrorByAxis)

--- a/src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.h
+++ b/src/libs/vtools/tools/drawTools/operation/mirror/vtoolmirrorbyline.h
@@ -62,7 +62,7 @@ class VToolMirrorByLine : public VAbstractMirror
 
 public:
     virtual                  ~VToolMirrorByLine() Q_DECL_EQ_DEFAULT;
-    virtual void              setDialog() Q_DECL_OVERRIDE;
+    virtual void              setDialog() override;
     static VToolMirrorByLine *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene,
                                        VAbstractPattern *doc, VContainer *data);
     static VToolMirrorByLine *Create(const quint32 _id, quint32 firstLinePointId, quint32 secondLinePointId,
@@ -73,7 +73,7 @@ public:
 
     static const QString      ToolType;
 
-    virtual int               type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int               type() const override {return Type;}
     enum                      { Type = UserType + static_cast<int>(Tool::MirrorByLine)};
 
     QString                   firstLinePointName() const;
@@ -85,17 +85,17 @@ public:
     quint32                   getSecondLinePointId() const;
     void                      setSecondLinePointId(const quint32 &value);
 
-    virtual void              ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void              ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void              showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void              showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void              SetVisualization() Q_DECL_OVERRIDE;
-    virtual void              SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void              ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void              SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual QString           makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void              SetVisualization() override;
+    virtual void              SaveDialog(QDomElement &domElement) override;
+    virtual void              ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void              SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual QString           makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolMirrorByLine)

--- a/src/libs/vtools/tools/drawTools/operation/vabstractoperation.h
+++ b/src/libs/vtools/tools/drawTools/operation/vabstractoperation.h
@@ -105,28 +105,28 @@ public:
     static const QString TagSource;
     static const QString TagDestination;
 
-    virtual QString      getTagName() const Q_DECL_OVERRIDE;
+    virtual QString      getTagName() const override;
 
     QString              Suffix() const;
     void                 setSuffix(const QString &suffix);
 
-    virtual void         GroupVisibility(quint32 object, bool visible) Q_DECL_OVERRIDE;
-    virtual void         paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) Q_DECL_OVERRIDE;
+    virtual void         GroupVisibility(quint32 object, bool visible) override;
+    virtual void         paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
 
-    virtual bool         isPointNameVisible(quint32 id) const Q_DECL_OVERRIDE;
-    virtual void         setPointNameVisiblity(quint32 id, bool visible) Q_DECL_OVERRIDE;
+    virtual bool         isPointNameVisible(quint32 id) const override;
+    virtual void         setPointNameVisiblity(quint32 id, bool visible) override;
 
-    virtual void         setPointNamePosition(quint32 id, const QPointF &pos) Q_DECL_OVERRIDE;
+    virtual void         setPointNamePosition(quint32 id, const QPointF &pos) override;
 
     static void          ExtractData(const QDomElement &domElement, QVector<SourceItem> &source,
                                      QVector<DestinationItem> &destination);
 
 public slots:
-    virtual void         FullUpdateFromFile() Q_DECL_OVERRIDE;
+    virtual void         FullUpdateFromFile() override;
 
-    virtual void         AllowHover(bool enabled) Q_DECL_OVERRIDE;
-    virtual void         AllowSelecting(bool enabled) Q_DECL_OVERRIDE;
-    virtual void         EnableToolMove(bool move) Q_DECL_OVERRIDE;
+    virtual void         AllowHover(bool enabled) override;
+    virtual void         AllowSelecting(bool enabled) override;
+    virtual void         EnableToolMove(bool move) override;
 
     void                 AllowPointHover(bool enabled);
     void                 AllowPointSelecting(bool enabled);
@@ -146,12 +146,12 @@ public slots:
     void                 AllowElArcHover(bool enabled);
     void                 AllowElArcSelecting(bool enabled);
 
-    virtual void         ToolSelectionType(const SelectionType &type) Q_DECL_OVERRIDE;
-    virtual void         Disable(bool disable, const QString &draftBlockName) Q_DECL_OVERRIDE;
+    virtual void         ToolSelectionType(const SelectionType &type) override;
+    virtual void         Disable(bool disable, const QString &draftBlockName) override;
     void                 ObjectSelected(bool selected, quint32 objId);
     void                 deletePoint();
     void                 pointNamePositionChanged(const QPointF &pos, quint32 labelId);
-    virtual void         updatePointNameVisibility(quint32 id, bool visible) Q_DECL_OVERRIDE;
+    virtual void         updatePointNameVisibility(quint32 id, bool visible) override;
 
 
 protected:
@@ -165,12 +165,12 @@ protected:
                                             const QVector<DestinationItem> &destination,
                                             QGraphicsItem *parent = nullptr);
 
-    virtual void         AddToFile() Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
+    virtual void         AddToFile() override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
 
 
-    //virtual void         updatePointNameVisibility(quint32 id, bool visible) Q_DECL_OVERRIDE;
+    //virtual void         updatePointNameVisibility(quint32 id, bool visible) override;
     void                 updatePointNamePosition(quint32 id, const QPointF &pos);
 
     void                 SaveSourceDestination(QDomElement &tag);

--- a/src/libs/vtools/tools/drawTools/operation/vtoolmove.h
+++ b/src/libs/vtools/tools/drawTools/operation/vtoolmove.h
@@ -73,7 +73,7 @@ class VToolMove : public VAbstractOperation
     Q_OBJECT
 public:
     virtual               ~VToolMove() Q_DECL_EQ_DEFAULT;
-    virtual void           setDialog() Q_DECL_OVERRIDE;
+    virtual void           setDialog() override;
     static VToolMove      *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene,
                                   VAbstractPattern *doc, VContainer *data);
 
@@ -85,7 +85,7 @@ public:
 
     static const QString   ToolType;
 
-    virtual int            type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int            type() const override {return Type;}
     enum                   {Type = UserType + static_cast<int>(Tool::Move)};
 
     VFormula               GetFormulaAngle() const;
@@ -101,17 +101,17 @@ public:
     quint32                getOriginPointId() const;
     void                   setOriginPointId(const quint32 &value);
     
-    virtual void           ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void           ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void           showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void           showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void           SetVisualization() Q_DECL_OVERRIDE;
-    virtual void           SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void           ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void           SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual QString        makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void           SetVisualization() override;
+    virtual void           SaveDialog(QDomElement &domElement) override;
+    virtual void           ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void           SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual QString        makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolMove)

--- a/src/libs/vtools/tools/drawTools/operation/vtoolrotation.h
+++ b/src/libs/vtools/tools/drawTools/operation/vtoolrotation.h
@@ -73,7 +73,7 @@ class VToolRotation : public VAbstractOperation
     Q_OBJECT
 public:
     virtual               ~VToolRotation() Q_DECL_EQ_DEFAULT;
-    virtual void           setDialog() Q_DECL_OVERRIDE;
+    virtual void           setDialog() override;
     static VToolRotation  *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene,
                                   VAbstractPattern *doc, VContainer *data);
 
@@ -84,7 +84,7 @@ public:
 
     static const QString   ToolType;
 
-    virtual int            type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int            type() const override {return Type;}
     enum                   { Type = UserType + static_cast<int>(Tool::Rotation)};
 
     QString                getOriginPointName() const;
@@ -94,17 +94,17 @@ public:
     VFormula               GetFormulaAngle() const;
     void                   SetFormulaAngle(const VFormula &value);
 
-    virtual void           ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void           ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void           showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void           showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void           SetVisualization() Q_DECL_OVERRIDE;
-    virtual void           SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void           ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void           SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual QString        makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void           SetVisualization() override;
+    virtual void           SaveDialog(QDomElement &domElement) override;
+    virtual void           ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void           SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual QString        makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolRotation)

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolarc.h
@@ -69,7 +69,7 @@ class VToolArc :public VAbstractSpline
 {
     Q_OBJECT
 public:
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
 
     static VToolArc *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene, VAbstractPattern *doc,
                             VContainer *data);
@@ -79,9 +79,9 @@ public:
                             const Document &parse, const Source &typeCreation);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::Arc)};
-    virtual QString      getTagName() const Q_DECL_OVERRIDE;
+    virtual QString      getTagName() const override;
 
     QString              CenterPointName() const;
 
@@ -100,18 +100,18 @@ public:
     VArc                 getArc()const;
     void                 setArc(const VArc &arc);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
-    virtual QString      makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         SetVisualization() override;
+    virtual QString      makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolArc)

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolarcwithlength.h
@@ -65,7 +65,7 @@ class VToolArcWithLength : public VAbstractSpline
 {
     Q_OBJECT
 public:
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
 
     static VToolArcWithLength *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene,
                                       VAbstractPattern *doc, VContainer *data);
@@ -75,9 +75,9 @@ public:
                                       VContainer *data, const Document &parse, const Source &typeCreation);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::ArcWithLength)};
-    virtual QString      getTagName() const Q_DECL_OVERRIDE;
+    virtual QString      getTagName() const override;
 
     QString              CenterPointName() const;
 
@@ -93,18 +93,18 @@ public:
     VFormula             GetFormulaLength() const;
     void                 SetFormulaLength(const VFormula &value);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
-    virtual QString      makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         SetVisualization() override;
+    virtual QString      makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolArcWithLength)

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezier.h
@@ -71,7 +71,7 @@ class VToolCubicBezier : public VAbstractSpline
     Q_OBJECT
 public:
     virtual             ~VToolCubicBezier() Q_DECL_EQ_DEFAULT;
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
 
     static VToolCubicBezier *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene,
                                     VAbstractPattern *doc, VContainer *data);
@@ -80,7 +80,7 @@ public:
                                     const Source &typeCreation);
                                     
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::CubicBezier)};
 
     QString              FirstPointName() const;
@@ -91,18 +91,18 @@ public:
     VCubicBezier         getSpline()const;
     void                 setSpline(const VCubicBezier &spl);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
-    virtual void         refreshGeometry() Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         SetVisualization() override;
+    virtual void         refreshGeometry() override;
 
 private:
     Q_DISABLE_COPY(VToolCubicBezier)

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezierpath.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolcubicbezierpath.h
@@ -71,7 +71,7 @@ class VToolCubicBezierPath:public VAbstractSpline
     Q_OBJECT
 public:
     virtual             ~VToolCubicBezierPath() Q_DECL_EQ_DEFAULT;
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
 
     static VToolCubicBezierPath *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene,
                                         VAbstractPattern *doc, VContainer *data);
@@ -81,23 +81,23 @@ public:
 
     static const QString ToolType;
     static void          UpdatePathPoints(VAbstractPattern *doc, QDomElement &element, const VCubicBezierPath &path);
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::CubicBezierPath)};
 
     VCubicBezierPath     getSplinePath()const;
     void                 setSplinePath(const VCubicBezierPath &splPath);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
     
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
-    virtual void         refreshGeometry() Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         SetVisualization() override;
+    virtual void         refreshGeometry() override;
 
 private:
     Q_DISABLE_COPY(VToolCubicBezierPath)

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolellipticalarc.h
@@ -67,7 +67,7 @@ class VToolEllipticalArc : public VAbstractSpline
 {
     Q_OBJECT
 public:
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
     static VToolEllipticalArc *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene,
                                       VAbstractPattern *doc, VContainer *data);
     static VToolEllipticalArc *Create(const quint32 _id, const quint32 &center, QString &radius1, QString &radius2,
@@ -76,9 +76,9 @@ public:
                                       VAbstractPattern *doc, VContainer *data,
                             const Document &parse, const Source &typeCreation);
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::EllipticalArc)};
-    virtual QString      getTagName() const Q_DECL_OVERRIDE;
+    virtual QString      getTagName() const override;
 
     QString              CenterPointName() const;
 
@@ -100,18 +100,18 @@ public:
     VFormula             GetFormulaRotationAngle() const;
     void                 SetFormulaRotationAngle(const VFormula &value);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
-    virtual QString      makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         SetVisualization() override;
+    virtual QString      makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolEllipticalArc)

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolspline.h
@@ -72,7 +72,7 @@ class VToolSpline:public VAbstractSpline
     Q_OBJECT
 public:
     virtual      ~VToolSpline() = default;
-    virtual void  setDialog() Q_DECL_OVERRIDE;
+    virtual void  setDialog() override;
     static VToolSpline *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene, VAbstractPattern *doc,
                                VContainer *data);
     static VToolSpline *Create(const quint32 _id, VSpline *spline,
@@ -84,33 +84,33 @@ public:
                                VContainer *data, const Document &parse, const Source &typeCreation);
     static const QString ToolType;
     static const QString OldToolType;
-    virtual int   type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int   type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::Spline)};
 
     VSpline       getSpline()const;
     void          setSpline(const VSpline &spl);
 
-    virtual void  ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void  ShowVisualization(bool show) override;
 
 public slots:
     void          controlPointPositionChanged(const qint32 &splineIndex, const SplinePointPosition &position,
                                              const QPointF &pos);
-    virtual void  EnableToolMove(bool move) Q_DECL_OVERRIDE;
+    virtual void  EnableToolMove(bool move) override;
 
 protected slots:
-    virtual void  showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void  showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void  RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void  SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void  SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void  mousePressEvent(QGraphicsSceneMouseEvent * event) Q_DECL_OVERRIDE;
-    virtual void  mouseReleaseEvent ( QGraphicsSceneMouseEvent * event ) Q_DECL_OVERRIDE;
-    virtual void  mouseMoveEvent(QGraphicsSceneMouseEvent * event) Q_DECL_OVERRIDE;
-    virtual void  hoverEnterEvent ( QGraphicsSceneHoverEvent * event ) Q_DECL_OVERRIDE;
-    virtual void  hoverLeaveEvent ( QGraphicsSceneHoverEvent * event ) Q_DECL_OVERRIDE;
-    virtual void  SetVisualization() Q_DECL_OVERRIDE;
-    virtual void  refreshCtrlPoints() Q_DECL_OVERRIDE;
+    virtual void  RemoveReferens() override;
+    virtual void  SaveDialog(QDomElement &domElement) override;
+    virtual void  SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void  mousePressEvent(QGraphicsSceneMouseEvent * event) override;
+    virtual void  mouseReleaseEvent ( QGraphicsSceneMouseEvent * event ) override;
+    virtual void  mouseMoveEvent(QGraphicsSceneMouseEvent * event) override;
+    virtual void  hoverEnterEvent ( QGraphicsSceneHoverEvent * event ) override;
+    virtual void  hoverLeaveEvent ( QGraphicsSceneHoverEvent * event ) override;
+    virtual void  SetVisualization() override;
+    virtual void  refreshCtrlPoints() override;
 
 private:
     Q_DISABLE_COPY(VToolSpline)

--- a/src/libs/vtools/tools/drawTools/toolcurve/vtoolsplinepath.h
+++ b/src/libs/vtools/tools/drawTools/toolcurve/vtoolsplinepath.h
@@ -74,7 +74,7 @@ class VToolSplinePath:public VAbstractSpline
     Q_OBJECT
 public:
     virtual      ~VToolSplinePath() =default;
-    virtual void  setDialog() Q_DECL_OVERRIDE;
+    virtual void  setDialog() override;
     static VToolSplinePath *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene,
                                    VAbstractPattern *doc, VContainer *data);
     static VToolSplinePath *Create(const quint32 _id, VSplinePath *path,
@@ -88,13 +88,13 @@ public:
     static const QString ToolType;
     static const QString OldToolType;
     static void   UpdatePathPoints(VAbstractPattern *doc, QDomElement &element, const VSplinePath &path);
-    virtual int   type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int   type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::SplinePath)};
 
     VSplinePath   getSplinePath()const;
     void          setSplinePath(const VSplinePath &splPath);
 
-    virtual void  ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void  ShowVisualization(bool show) override;
 
 signals:
     // @brief refreshLine refresh control line.
@@ -108,22 +108,22 @@ public slots:
 
     void          controlPointPositionChanged(const qint32 &splineIndex, const SplinePointPosition &position,
                                              const QPointF &pos);
-    virtual void  EnableToolMove(bool move) Q_DECL_OVERRIDE;
+    virtual void  EnableToolMove(bool move) override;
 
 protected slots:
-    virtual void  showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void  showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void  RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void  SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void  SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void  mousePressEvent(QGraphicsSceneMouseEvent * event) Q_DECL_OVERRIDE;
-    virtual void  mouseReleaseEvent ( QGraphicsSceneMouseEvent * event ) Q_DECL_OVERRIDE;
-    virtual void  mouseMoveEvent(QGraphicsSceneMouseEvent * event) Q_DECL_OVERRIDE;
-    virtual void  hoverEnterEvent ( QGraphicsSceneHoverEvent * event ) Q_DECL_OVERRIDE;
-    virtual void  hoverLeaveEvent ( QGraphicsSceneHoverEvent * event ) Q_DECL_OVERRIDE;
-    virtual void  SetVisualization() Q_DECL_OVERRIDE;
-    virtual void  refreshCtrlPoints() Q_DECL_OVERRIDE;
+    virtual void  RemoveReferens() override;
+    virtual void  SaveDialog(QDomElement &domElement) override;
+    virtual void  SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void  mousePressEvent(QGraphicsSceneMouseEvent * event) override;
+    virtual void  mouseReleaseEvent ( QGraphicsSceneMouseEvent * event ) override;
+    virtual void  mouseMoveEvent(QGraphicsSceneMouseEvent * event) override;
+    virtual void  hoverEnterEvent ( QGraphicsSceneHoverEvent * event ) override;
+    virtual void  hoverLeaveEvent ( QGraphicsSceneHoverEvent * event ) override;
+    virtual void  SetVisualization() override;
+    virtual void  refreshCtrlPoints() override;
 
 private:
     Q_DISABLE_COPY(VToolSplinePath)

--- a/src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooldoublepoint.h
@@ -76,7 +76,7 @@ public:
                                        quint32 p1id, quint32 p2id, QGraphicsItem * parent = nullptr);
     virtual          ~VToolDoublePoint() Q_DECL_EQ_DEFAULT;
 
-    virtual int       type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int       type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::DoublePoint)};
 
     QString           nameP1() const;
@@ -85,26 +85,26 @@ public:
     QString           nameP2() const;
     void              setNameP2(const QString &name);
 
-    virtual void      GroupVisibility(quint32 object, bool visible) Q_DECL_OVERRIDE;
-    virtual void      setPointNamePosition(quint32 id, const QPointF &pos) Q_DECL_OVERRIDE;
-    virtual bool      isPointNameVisible(quint32 id) const Q_DECL_OVERRIDE;
-    virtual void      setPointNameVisiblity(quint32 id, bool visible) Q_DECL_OVERRIDE;
+    virtual void      GroupVisibility(quint32 object, bool visible) override;
+    virtual void      setPointNamePosition(quint32 id, const QPointF &pos) override;
+    virtual bool      isPointNameVisible(quint32 id) const override;
+    virtual void      setPointNameVisiblity(quint32 id, bool visible) override;
 
 public slots:
     void              changePointName1Position(const QPointF &pos);
     void              changePointName2Position(const QPointF &pos);
-    virtual void      Disable(bool disable, const QString &draftBlockName) Q_DECL_OVERRIDE;
-    virtual void      EnableToolMove(bool move) Q_DECL_OVERRIDE;
+    virtual void      Disable(bool disable, const QString &draftBlockName) override;
+    virtual void      EnableToolMove(bool move) override;
     void              point1Chosen();
     void              point2Chosen();
     void              point1Selected(bool selected);
     void              point2Selected(bool selected);
-    virtual void      FullUpdateFromFile() Q_DECL_OVERRIDE;
-    virtual void      AllowHover(bool enabled) Q_DECL_OVERRIDE;
-    virtual void      AllowSelecting(bool enabled) Q_DECL_OVERRIDE;
+    virtual void      FullUpdateFromFile() override;
+    virtual void      AllowHover(bool enabled) override;
+    virtual void      AllowSelecting(bool enabled) override;
     void              allowTextHover(bool enabled);
     void              allowTextSelectable(bool enabled);
-    virtual void      ToolSelectionType(const SelectionType &type) Q_DECL_OVERRIDE;
+    virtual void      ToolSelectionType(const SelectionType &type) override;
 
 protected:
     VSimplePoint     *firstPoint;
@@ -113,13 +113,13 @@ protected:
     quint32           p1id;
     quint32           p2id;
 
-    virtual void      updatePointNamePosition(quint32 id, const QPointF &pos) Q_DECL_OVERRIDE;
-    virtual QVariant  itemChange ( GraphicsItemChange change, const QVariant &value ) Q_DECL_OVERRIDE;
-    virtual void      keyReleaseEvent(QKeyEvent * event) Q_DECL_OVERRIDE;
-    virtual void      contextMenuEvent (QGraphicsSceneContextMenuEvent *event) Q_DECL_OVERRIDE;
-    virtual void      SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void      AddToFile() Q_DECL_OVERRIDE;
-    virtual void      updatePointNameVisibility(quint32 id, bool visible) Q_DECL_OVERRIDE;
+    virtual void      updatePointNamePosition(quint32 id, const QPointF &pos) override;
+    virtual QVariant  itemChange ( GraphicsItemChange change, const QVariant &value ) override;
+    virtual void      keyReleaseEvent(QKeyEvent * event) override;
+    virtual void      contextMenuEvent (QGraphicsSceneContextMenuEvent *event) override;
+    virtual void      SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void      AddToFile() override;
+    virtual void      updatePointNameVisibility(quint32 id, bool visible) override;
     QString           complexToolTip(quint32 itemId) const;
 
 private:

--- a/src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooltruedarts.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/tooldoublepoint/vtooltruedarts.h
@@ -73,7 +73,7 @@ class VToolTrueDarts : public VToolDoublePoint
 public:
     static void            FindPoint(const QPointF &baseLineP1, const QPointF &baseLineP2, const QPointF &dartP1,
                                      const QPointF &dartP2, const QPointF &dartP3, QPointF &p1, QPointF &p2);
-    virtual void           setDialog() Q_DECL_OVERRIDE;
+    virtual void           setDialog() override;
 
     static VToolTrueDarts *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene, VAbstractPattern *doc,
                                   VContainer *data);
@@ -92,10 +92,10 @@ public:
                                   const Document &parse, const Source &typeCreation);
 
     static const QString ToolType;
-    virtual int          type() const  Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const  override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::TrueDarts)};
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
     QString              BaseLineP1Name() const;
     QString              BaseLineP2Name() const;
@@ -119,14 +119,14 @@ public:
     void                 SetDartP3Id(const quint32 &value);
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
 
 private:
     Q_DISABLE_COPY(VToolTrueDarts)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circles_tool.h
@@ -53,7 +53,7 @@ class IntersectCirclesTool : public VToolSinglePoint
     Q_OBJECT
 
 public:
-    virtual void                 setDialog() Q_DECL_OVERRIDE;
+    virtual void                 setDialog() override;
 
     static IntersectCirclesTool *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene,
                                         VAbstractPattern *doc, VContainer *data);
@@ -70,7 +70,7 @@ public:
                                    const CrossCirclesPoint crossPoint);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum                 {Type = UserType + static_cast<int>(Tool::PointOfIntersectionCircles)};
 
     QString              FirstCircleCenterPointName() const;
@@ -91,17 +91,17 @@ public:
     CrossCirclesPoint    GetCrossCirclesPoint() const;
     void                 setCirclesCrossPoint(const CrossCirclesPoint &value);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
 
 private:
                          Q_DISABLE_COPY(IntersectCirclesTool)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/intersect_circletangent_tool.h
@@ -52,7 +52,7 @@ class IntersectCircleTangentTool : public VToolSinglePoint
 {
     Q_OBJECT
 public:
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
 
     static IntersectCircleTangentTool *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene,
                                                   VAbstractPattern *doc, VContainer *data);
@@ -66,7 +66,7 @@ public:
                                    const CrossCirclesPoint crossPoint);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum                {Type = UserType + static_cast<int>(Tool::PointFromCircleAndTangent) };
 
     QString              TangentPointName() const;
@@ -84,17 +84,17 @@ public:
     CrossCirclesPoint    GetCrossCirclesPoint() const;
     void                 setCirclesCrossPoint(const CrossCirclesPoint &value);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
 
 private:
     Q_DISABLE_COPY(IntersectCircleTangentTool)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/point_intersectxy_tool.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/point_intersectxy_tool.h
@@ -53,7 +53,7 @@ class PointIntersectXYTool : public DoubleLinePointTool
 {
     Q_OBJECT
 public:
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
 
     static PointIntersectXYTool *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene,
                                             VAbstractPattern *doc, VContainer *data);
@@ -65,23 +65,23 @@ public:
                                             const Document &parse, const Source &typeCreation);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum                 {Type = UserType + static_cast<int>(Tool::PointOfIntersection)};
 
     QString              firstPointName() const;
     QString              secondPointName() const;
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
 
 private:
                          Q_DISABLE_COPY(PointIntersectXYTool)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcut.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcut.h
@@ -72,7 +72,7 @@ public:
                            const QString &formula, const QString &lineColor, const quint32 &curveCutId,
                            QGraphicsItem * parent = nullptr);
 
-    virtual int   type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int   type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::Cut)};
 
     VFormula      GetFormula() const;
@@ -90,9 +90,9 @@ public:
     void          setDirection(const QString &value);
 
 public slots:
-    virtual void  Disable(bool disable, const QString &draftBlockName) Q_DECL_OVERRIDE;
-    virtual void  piecesMode(bool mode) Q_DECL_OVERRIDE;
-    virtual void  FullUpdateFromFile() Q_DECL_OVERRIDE;
+    virtual void  Disable(bool disable, const QString &draftBlockName) override;
+    virtual void  piecesMode(bool mode) override;
+    virtual void  FullUpdateFromFile() override;
 
 protected:
     QString       m_direction;
@@ -102,7 +102,7 @@ protected:
     bool          m_piecesMode;
 
     void          RefreshGeometry();
-    virtual void  RemoveReferens() Q_DECL_OVERRIDE;
+    virtual void  RemoveReferens() override;
 
     template <typename T>
     void          ShowToolVisualization(bool show);

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutarc.h
@@ -73,7 +73,7 @@ class VToolCutArc : public VToolCut
 {
     Q_OBJECT
 public:
-    virtual void        setDialog() Q_DECL_OVERRIDE;
+    virtual void        setDialog() override;
 
     static VToolCutArc *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene, VAbstractPattern *doc,
                                 VContainer *data);
@@ -83,19 +83,19 @@ public:
                                const Document &parse, const Source &typeCreation);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::CutArc)};
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
-    virtual QString      makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
+    virtual QString      makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolCutArc)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutspline.h
@@ -70,7 +70,7 @@ class VToolCutSpline : public VToolCut
 {
     Q_OBJECT
 public:
-    virtual void setDialog() Q_DECL_OVERRIDE;
+    virtual void setDialog() override;
 
     static VToolCutSpline *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene, VAbstractPattern *doc,
                                   VContainer *data);
@@ -83,19 +83,19 @@ public:
 
     static const QString ToolType;
     static const QString AttrSpline;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::CutSpline)};
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void          SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void          SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void          ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void          SetVisualization() Q_DECL_OVERRIDE;
-    virtual QString       makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void          SaveDialog(QDomElement &domElement) override;
+    virtual void          SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void          ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void          SetVisualization() override;
+    virtual QString       makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolCutSpline)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toolcut/vtoolcutsplinepath.h
@@ -72,7 +72,7 @@ class VToolCutSplinePath : public VToolCut
 {
     Q_OBJECT
 public:
-    virtual void               setDialog() Q_DECL_OVERRIDE;
+    virtual void               setDialog() override;
 
     static VToolCutSplinePath *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene,
                                       VAbstractPattern *doc, VContainer *data);
@@ -83,9 +83,9 @@ public:
                                       const Source &typeCreation);
     static const QString ToolType;
     static const QString AttrSplinePath;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::CutSplinePath)};
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
     Q_REQUIRED_RESULT static VPointF *CutSplinePath(qreal length,
                                                     const QSharedPointer<VAbstractCubicBezierPath> &splPath,
@@ -93,14 +93,14 @@ public:
                                                     VSplinePath **splPath2);
 
 protected slots:
-    virtual void    showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void    showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void    SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void    SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void    ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void    SetVisualization() Q_DECL_OVERRIDE;
-    virtual QString makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void    SaveDialog(QDomElement &domElement) override;
+    virtual void    SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void    ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void    SetVisualization() override;
+    virtual QString makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolCutSplinePath)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/doubleline_point_tool.h
@@ -54,13 +54,13 @@ public:
                                           const QString &lineColor,
                                           const quint32 &firstPointId, const quint32 &secondPointId,
                                           QGraphicsItem * parent = nullptr);
-    virtual          ~DoubleLinePointTool() Q_DECL_OVERRIDE;
+    virtual          ~DoubleLinePointTool() override;
 
-    virtual int       type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int       type() const override {return Type;}
     enum             {Type = UserType + static_cast<int>(Tool::LinePoint)};
 
     virtual void      paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-                            QWidget *widget = nullptr) Q_DECL_OVERRIDE;
+                            QWidget *widget = nullptr) override;
 
     QString           point1Name() const;
     QString           point2Name() const;
@@ -75,8 +75,8 @@ public:
     void              setLineColor(const QString &value);
 
 public slots:
-    virtual void      Disable(bool disable, const QString &draftBlockName) Q_DECL_OVERRIDE;
-    virtual void      FullUpdateFromFile() Q_DECL_OVERRIDE;
+    virtual void      Disable(bool disable, const QString &draftBlockName) override;
+    virtual void      FullUpdateFromFile() override;
 
 protected:
     quint32           firstPointId;     /** @brief firstPointId id first line point. */
@@ -86,11 +86,11 @@ protected:
     QString           lineColor;        /** @brief lineColor color of a line. */
 
     virtual void      RefreshGeometry();
-    virtual void      RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void      SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void      hoverEnterEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    virtual void      hoverLeaveEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    virtual QString   makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void      RemoveReferens() override;
+    virtual void      SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void      hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
+    virtual void      hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
+    virtual QString   makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(DoubleLinePointTool)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolalongline.h
@@ -73,7 +73,7 @@ class VToolAlongLine : public VToolLinePoint
 {
     Q_OBJECT
 public:
-    virtual void           setDialog() Q_DECL_OVERRIDE;
+    virtual void           setDialog() override;
 
     static VToolAlongLine *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene,
                                   VAbstractPattern *doc, VContainer *data);
@@ -86,24 +86,24 @@ public:
                                   const Source &typeCreation);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::AlongLine)};
 
     QString              SecondPointName() const;
     quint32              GetSecondPointId() const;
     void                 SetSecondPointId(const quint32 &value);
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
-    virtual QString      makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
+    virtual QString      makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolAlongLine)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolbisector.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolbisector.h
@@ -77,7 +77,7 @@ public:
     static qreal   BisectorAngle(const QPointF &firstPoint, const QPointF &secondPoint, const QPointF &thirdPoint);
     static QPointF FindPoint(const QPointF &firstPoint, const QPointF &secondPoint, const QPointF &thirdPoint,
                              const qreal& length);
-    virtual void   setDialog() Q_DECL_OVERRIDE;
+    virtual void   setDialog() override;
 
     static VToolBisector *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene, VAbstractPattern *doc,
                                  VContainer *data);
@@ -89,7 +89,7 @@ public:
                                  const Document &parse, const Source &typeCreation);
 
     static const QString ToolType;
-    virtual int    type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int    type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::Bisector)};
 
     QString        FirstPointName() const;
@@ -101,17 +101,17 @@ public:
     quint32        GetThirdPointId() const;
     void           SetThirdPointId(const quint32 &value);
 
-    virtual void   ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void   ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void   showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void   showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void   RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void   SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void   SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void   ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void   SetVisualization() Q_DECL_OVERRIDE;
+    virtual void   RemoveReferens() override;
+    virtual void   SaveDialog(QDomElement &domElement) override;
+    virtual void   SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void   ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void   SetVisualization() override;
 private:
     Q_DISABLE_COPY(VToolBisector)
 

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolcurveintersectaxis.h
@@ -75,7 +75,7 @@ class VToolCurveIntersectAxis : public VToolLinePoint
 
 public:
     virtual             ~VToolCurveIntersectAxis() Q_DECL_EQ_DEFAULT;
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
 
     static VToolCurveIntersectAxis *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene,
                                            VAbstractPattern *doc, VContainer *data);
@@ -90,7 +90,7 @@ public:
                                    QPointF *intersectPoint);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::CurveIntersectAxis)};
 
     VFormula             GetFormulaAngle() const;
@@ -101,16 +101,16 @@ public:
     quint32              getCurveId() const;
     void                 setCurveId(const quint32 &value);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
 
 private:
     Q_DISABLE_COPY(VToolCurveIntersectAxis)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolendline.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolendline.h
@@ -75,7 +75,7 @@ class VToolEndLine : public VToolLinePoint
     Q_OBJECT
 public:
     virtual             ~VToolEndLine() Q_DECL_EQ_DEFAULT;
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
 
     static VToolEndLine *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene, VAbstractPattern *doc,
                                 VContainer *data);
@@ -88,21 +88,21 @@ public:
                                 const Source &typeCreation);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::EndLine)};
 
     VFormula             GetFormulaAngle() const;
     void                 SetFormulaAngle(const VFormula &value);
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
 
 private:
     Q_DISABLE_COPY(VToolEndLine)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolheight.h
@@ -75,7 +75,7 @@ class VToolHeight: public VToolLinePoint
 {
     Q_OBJECT
 public:
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
 
     static VToolHeight  *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene, VAbstractPattern *doc,
                                 VContainer *data);
@@ -88,7 +88,7 @@ public:
 
     static QPointF       FindPoint(const QLineF &line, const QPointF &point);
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::Height)};
 
     QString              FirstLinePointName() const;
@@ -100,17 +100,17 @@ public:
     quint32              GetP2LineId() const;
     void                 SetP2LineId(const quint32 &value);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
-    virtual QString      makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
+    virtual QString      makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolHeight)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollineintersectaxis.h
@@ -74,7 +74,7 @@ class VToolLineIntersectAxis : public VToolLinePoint
     Q_OBJECT
 public:
     virtual             ~VToolLineIntersectAxis() Q_DECL_EQ_DEFAULT;
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
 
     static VToolLineIntersectAxis *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene,
                                           VAbstractPattern *doc, VContainer *data);
@@ -89,7 +89,7 @@ public:
     static QPointF       FindPoint(const QLineF &axis, const QLineF &line);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::LineIntersectAxis)};
 
     QString              FirstLinePoint() const;
@@ -104,17 +104,17 @@ public:
     quint32              GetSecondPointId() const;
     void                 SetSecondPointId(const quint32 &value);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
-    virtual QString      makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
+    virtual QString      makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolLineIntersectAxis)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoollinepoint.h
@@ -76,13 +76,13 @@ public:
                                      const QString &lineType, const QString &lineWeight,
                                      const QString &lineColor, const QString &formula,
                                      const quint32 &basePointId, const qreal &angle, QGraphicsItem * parent = nullptr);
-    virtual          ~VToolLinePoint() Q_DECL_OVERRIDE;
+    virtual          ~VToolLinePoint() override;
 
-    virtual int       type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int       type() const override {return Type;}
     enum              {Type = UserType + static_cast<int>(Tool::LinePoint)};
 
     virtual void      paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-                            QWidget *widget = nullptr) Q_DECL_OVERRIDE;
+                            QWidget *widget = nullptr) override;
 
     VFormula          GetFormulaLength() const;
     void              SetFormulaLength(const VFormula &value);
@@ -99,8 +99,8 @@ public:
     void              setLineColor(const QString &value);
 
 public slots:
-    virtual void      Disable(bool disable, const QString &draftBlockName) Q_DECL_OVERRIDE;
-    virtual void      FullUpdateFromFile() Q_DECL_OVERRIDE;
+    virtual void      Disable(bool disable, const QString &draftBlockName) override;
+    virtual void      FullUpdateFromFile() override;
 
 protected:
     QString           formulaLength; /** @brief formula string with length formula. */
@@ -110,11 +110,11 @@ protected:
     QString           lineColor; /** @brief lineColor color of a line. */
 
     virtual void      RefreshGeometry();
-    virtual void      RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void      SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void      hoverEnterEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    virtual void      hoverLeaveEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    virtual QString   makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void      RemoveReferens() override;
+    virtual void      SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void      hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
+    virtual void      hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
+    virtual QString   makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolLinePoint)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolnormal.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolnormal.h
@@ -74,7 +74,7 @@ class VToolNormal : public VToolLinePoint
 {
     Q_OBJECT
 public:
-    virtual void        setDialog() Q_DECL_OVERRIDE;
+    virtual void        setDialog() override;
 
     static VToolNormal *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene, VAbstractPattern *doc,
                                VContainer *data);
@@ -89,7 +89,7 @@ public:
     static QPointF       FindPoint(const QPointF &firstPoint, const QPointF &secondPoint, const qreal &length,
                                    const qreal &angle = 0);
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::Normal)};
 
     QString              SecondPointName() const;
@@ -97,17 +97,17 @@ public:
     quint32              GetSecondPointId() const;
     void                 SetSecondPointId(const quint32 &value);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
 
 private:
     Q_DISABLE_COPY(VToolNormal)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/toollinepoint/vtoolshoulderpoint.h
@@ -75,7 +75,7 @@ class VToolShoulderPoint : public VToolLinePoint
 {
     Q_OBJECT
 public:
-    virtual void               setDialog() Q_DECL_OVERRIDE;
+    virtual void               setDialog() override;
     static QPointF             FindPoint(const QPointF &p1Line, const QPointF &p2Line, const QPointF &pShoulder,
                                          const qreal &length);
 
@@ -90,7 +90,7 @@ public:
                                       const Source &typeCreation);
 
     static const QString       ToolType;
-    virtual int                type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int                type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::ShoulderPoint) };
 
     QString                    SecondPointName() const;
@@ -102,19 +102,19 @@ public:
     quint32                    getPShoulder() const;
     void                       setPShoulder(const quint32 &value);
 
-    virtual void               ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void               ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void               showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void               showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 
 protected:
-    virtual void               RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void               SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void               SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void               ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void               SetVisualization() Q_DECL_OVERRIDE;
-    virtual QString            makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void               RemoveReferens() override;
+    virtual void               SaveDialog(QDomElement &domElement) override;
+    virtual void               SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void               ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void               SetVisualization() override;
+    virtual QString            makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolShoulderPoint)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolbasepoint.h
@@ -77,24 +77,24 @@ class VToolBasePoint : public VToolSinglePoint
     Q_OBJECT
 public:
     virtual               ~VToolBasePoint() =default;
-    virtual void           setDialog() Q_DECL_OVERRIDE;
+    virtual void           setDialog() override;
 
     static VToolBasePoint *Create(quint32 _id, const QString &activeDraftBlock, VPointF *point,
                                   VMainGraphicsScene *scene, VAbstractPattern *doc, VContainer *data,
                                   const Document &parse, const Source &typeCreation);
 
     static const QString   ToolType;
-    virtual int            type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int            type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::BasePoint)};
 
-    virtual void           ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void           ShowVisualization(bool show) override;
 
     QPointF                GetBasePointPos() const;
     void                   SetBasePointPos(const QPointF &pos);
 
 public slots:
-    virtual void           FullUpdateFromFile() Q_DECL_OVERRIDE;
-    virtual void           EnableToolMove(bool move) Q_DECL_OVERRIDE;
+    virtual void           FullUpdateFromFile() override;
+    virtual void           EnableToolMove(bool move) override;
 
 signals:
     /**
@@ -103,21 +103,21 @@ signals:
     void                   LiteUpdateTree();
 
 protected slots:
-    virtual void           showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void           showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void           AddToFile() Q_DECL_OVERRIDE;
-    virtual QVariant       itemChange ( GraphicsItemChange change, const QVariant &value ) Q_DECL_OVERRIDE;
-    virtual void           deleteTool(bool ask = true) Q_DECL_OVERRIDE;
-    virtual void           SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void           hoverEnterEvent ( QGraphicsSceneHoverEvent * event ) Q_DECL_OVERRIDE;
-    virtual void           hoverLeaveEvent ( QGraphicsSceneHoverEvent * event ) Q_DECL_OVERRIDE;
-    virtual void           mousePressEvent( QGraphicsSceneMouseEvent * event ) Q_DECL_OVERRIDE;
-    virtual void           mouseReleaseEvent ( QGraphicsSceneMouseEvent * event ) Q_DECL_OVERRIDE;
-    virtual void           SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void           ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void           SetVisualization() Q_DECL_OVERRIDE {}
-    virtual QString        makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void           AddToFile() override;
+    virtual QVariant       itemChange ( GraphicsItemChange change, const QVariant &value ) override;
+    virtual void           deleteTool(bool ask = true) override;
+    virtual void           SaveDialog(QDomElement &domElement) override;
+    virtual void           hoverEnterEvent ( QGraphicsSceneHoverEvent * event ) override;
+    virtual void           hoverLeaveEvent ( QGraphicsSceneHoverEvent * event ) override;
+    virtual void           mousePressEvent( QGraphicsSceneMouseEvent * event ) override;
+    virtual void           mouseReleaseEvent ( QGraphicsSceneMouseEvent * event ) override;
+    virtual void           SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void           ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void           SetVisualization() override {}
+    virtual QString        makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolBasePoint)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoollineintersect.h
@@ -73,7 +73,7 @@ class VToolLineIntersect:public VToolSinglePoint
 {
     Q_OBJECT
 public:
-    virtual void setDialog() Q_DECL_OVERRIDE;
+    virtual void setDialog() override;
 
     static VToolLineIntersect *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene *scene,
                                       VAbstractPattern *doc, VContainer *data);
@@ -84,7 +84,7 @@ public:
                                       VContainer *data, const Document &parse, const Source &typeCreation);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::LineIntersect)};
 
     QString              Line1P1Name() const;
@@ -104,18 +104,18 @@ public:
     quint32              GetP2Line2() const;
     void                 SetP2Line2(const quint32 &value);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
-    virtual QString      makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
+    virtual QString      makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolLineIntersect)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointfromarcandtangent.h
@@ -75,7 +75,7 @@ class VToolPointFromArcAndTangent : public VToolSinglePoint
 {
     Q_OBJECT
 public:
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
 
     static VToolPointFromArcAndTangent *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene,
                                                VAbstractPattern *doc, VContainer *data);
@@ -95,7 +95,7 @@ public:
     static QPointF       FindPoint(const QPointF &p, const VArc *arc, const CrossCirclesPoint pType);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::PointFromArcAndTangent) };
 
     QString              TangentPointName() const;
@@ -110,17 +110,17 @@ public:
     CrossCirclesPoint    GetCrossCirclesPoint() const;
     void                 setCirclesCrossPoint(const CrossCirclesPoint &value);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
 
 private:
     Q_DISABLE_COPY(VToolPointFromArcAndTangent)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofcontact.h
@@ -75,7 +75,7 @@ class VToolPointOfContact : public VToolSinglePoint
 {
     Q_OBJECT
 public:
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
 
     static QPointF       FindPoint(const qreal &radius, const QPointF &center, const QPointF &firstPoint,
                              const QPointF &secondPoint);
@@ -90,7 +90,7 @@ public:
                                        VContainer *data, const Document &parse, const Source &typeCreation);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::PointOfContact) };
 
     QString              ArcCenterPointName() const;
@@ -109,18 +109,18 @@ public:
     quint32              GetSecondPointId() const;
     void                 SetSecondPointId(const quint32 &value);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
-    virtual QString      makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
+    virtual QString      makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolPointOfContact)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectionarcs.h
@@ -76,7 +76,7 @@ class VToolPointOfIntersectionArcs : public VToolSinglePoint
     Q_OBJECT
 
 public:
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
 
     static VToolPointOfIntersectionArcs *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene,
                                                 VAbstractPattern *doc, VContainer *data);
@@ -89,7 +89,7 @@ public:
     static QPointF       FindPoint(const VArc *arc1, const VArc *arc2, const CrossCirclesPoint pType);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::PointOfIntersectionArcs) };
 
     QString              FirstArcName() const;
@@ -104,17 +104,17 @@ public:
     CrossCirclesPoint    GetCrossCirclesPoint() const;
     void                 setCirclesCrossPoint(const CrossCirclesPoint &value);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
 
 private:
     Q_DISABLE_COPY(VToolPointOfIntersectionArcs)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolpointofintersectioncurves.h
@@ -72,7 +72,7 @@ class VToolPointOfIntersectionCurves : public VToolSinglePoint
 {
     Q_OBJECT
 public:
-    virtual void         setDialog() Q_DECL_OVERRIDE;
+    virtual void         setDialog() override;
 
     static VToolPointOfIntersectionCurves *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene,
                                                   VAbstractPattern *doc, VContainer *data);
@@ -87,7 +87,7 @@ public:
                                     VCrossCurvesPoint vCrossPoint, HCrossCurvesPoint hCrossPoint);
 
     static const QString ToolType;
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::PointOfIntersectionCurves) };
 
     QString              FirstCurveName() const;
@@ -105,17 +105,17 @@ public:
     HCrossCurvesPoint    GetHCrossPoint() const;
     void                 SetHCrossPoint(const HCrossCurvesPoint &value);
 
-    virtual void         ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void         ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void         showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void         RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void         SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void         ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void         SetVisualization() Q_DECL_OVERRIDE;
+    virtual void         RemoveReferens() override;
+    virtual void         SaveDialog(QDomElement &domElement) override;
+    virtual void         SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void         ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void         SetVisualization() override;
 
 private:
     Q_DISABLE_COPY(VToolPointOfIntersectionCurves)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolsinglepoint.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtoolsinglepoint.h
@@ -78,7 +78,7 @@ public:
                                       const QColor &lineColor, QGraphicsItem * parent = nullptr);
     virtual         ~VToolSinglePoint() Q_DECL_EQ_DEFAULT;
 
-    virtual int      type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int      type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::SinglePoint)};
 
     QString          name() const;
@@ -86,34 +86,34 @@ public:
 
     void             SetEnabled(bool enabled);
 
-    virtual void     GroupVisibility(quint32 object, bool visible) Q_DECL_OVERRIDE;
-    virtual bool     isPointNameVisible(quint32 id) const Q_DECL_OVERRIDE;
-    virtual void     setPointNameVisiblity(quint32 id, bool visible) Q_DECL_OVERRIDE;
-    virtual void     setPointNamePosition(quint32 id, const QPointF &pos) Q_DECL_OVERRIDE;
+    virtual void     GroupVisibility(quint32 object, bool visible) override;
+    virtual bool     isPointNameVisible(quint32 id) const override;
+    virtual void     setPointNameVisiblity(quint32 id, bool visible) override;
+    virtual void     setPointNamePosition(quint32 id, const QPointF &pos) override;
 
 public slots:
     void             pointnameChangedPosition(const QPointF &pos);
-    virtual void     Disable(bool disable, const QString &draftBlockName) Q_DECL_OVERRIDE;
-    virtual void     EnableToolMove(bool move) Q_DECL_OVERRIDE;
+    virtual void     Disable(bool disable, const QString &draftBlockName) override;
+    virtual void     EnableToolMove(bool move) override;
     void             pointChosen();
     void             pointSelected(bool selected);
-    virtual void     FullUpdateFromFile() Q_DECL_OVERRIDE;
-    virtual void     AllowHover(bool enabled) Q_DECL_OVERRIDE;
-    virtual void     AllowSelecting(bool enabled) Q_DECL_OVERRIDE;
+    virtual void     FullUpdateFromFile() override;
+    virtual void     AllowHover(bool enabled) override;
+    virtual void     AllowSelecting(bool enabled) override;
     void             allowTextHover(bool enabled);
     void             allowTextSelectable(bool enabled);
-    virtual void     ToolSelectionType(const SelectionType &type) Q_DECL_OVERRIDE;
+    virtual void     ToolSelectionType(const SelectionType &type) override;
 
 protected:
-    virtual void     updatePointNameVisibility(quint32 id, bool visible) Q_DECL_OVERRIDE;
-    virtual void     updatePointNamePosition(quint32 id, const QPointF &pos) Q_DECL_OVERRIDE;
-    virtual void     mousePressEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void     mouseReleaseEvent ( QGraphicsSceneMouseEvent * event ) Q_DECL_OVERRIDE;
-    virtual void     hoverEnterEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    virtual QVariant itemChange ( GraphicsItemChange change, const QVariant &value ) Q_DECL_OVERRIDE;
-    virtual void     keyReleaseEvent(QKeyEvent * event) Q_DECL_OVERRIDE;
-    virtual void     contextMenuEvent (QGraphicsSceneContextMenuEvent * event ) Q_DECL_OVERRIDE;
-    virtual void     SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
+    virtual void     updatePointNameVisibility(quint32 id, bool visible) override;
+    virtual void     updatePointNamePosition(quint32 id, const QPointF &pos) override;
+    virtual void     mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+    virtual void     mouseReleaseEvent ( QGraphicsSceneMouseEvent * event ) override;
+    virtual void     hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
+    virtual QVariant itemChange ( GraphicsItemChange change, const QVariant &value ) override;
+    virtual void     keyReleaseEvent(QKeyEvent * event) override;
+    virtual void     contextMenuEvent (QGraphicsSceneContextMenuEvent * event ) override;
+    virtual void     SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
 
 private:
     Q_DISABLE_COPY(VToolSinglePoint)

--- a/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtooltriangle.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/toolsinglepoint/vtooltriangle.h
@@ -75,7 +75,7 @@ class VToolTriangle : public VToolSinglePoint
 {
     Q_OBJECT
 public:
-    virtual void          setDialog() Q_DECL_OVERRIDE;
+    virtual void          setDialog() override;
 
     static VToolTriangle *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene, VAbstractPattern *doc,
                                  VContainer *data);
@@ -88,7 +88,7 @@ public:
                                     const QPointF &secondPoint);
 
     static const QString  ToolType;
-    virtual int           type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int           type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::Triangle)};
 
     QString               AxisP1Name() const;
@@ -108,17 +108,17 @@ public:
     quint32               GetSecondPointId() const;
     void                  SetSecondPointId(const quint32 &value);
 
-    virtual void          ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void          ShowVisualization(bool show) override;
 
 protected slots:
-    virtual void          showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void          showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
-    virtual void          RemoveReferens() Q_DECL_OVERRIDE;
-    virtual void          SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void          SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void          ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void          SetVisualization() Q_DECL_OVERRIDE;
+    virtual void          RemoveReferens() override;
+    virtual void          SaveDialog(QDomElement &domElement) override;
+    virtual void          SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void          ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void          SetVisualization() override;
 private:
     Q_DISABLE_COPY(VToolTriangle)
     /** @brief axisP1Id id first axis point. */

--- a/src/libs/vtools/tools/drawTools/toolpoint/vabstractpoint.h
+++ b/src/libs/vtools/tools/drawTools/toolpoint/vabstractpoint.h
@@ -79,13 +79,13 @@ public:
                      VAbstractPoint(VAbstractPattern *doc, VContainer *data, quint32 id);
     virtual         ~VAbstractPoint() Q_DECL_EQ_DEFAULT;
 
-    virtual QString  getTagName() const Q_DECL_OVERRIDE;
+    virtual QString  getTagName() const override;
 
     template <typename T>
     void             ShowToolVisualization(bool show);
 
 public slots:
-    virtual void     ShowTool(quint32 id, bool enable) Q_DECL_OVERRIDE;
+    virtual void     ShowTool(quint32 id, bool enable) override;
     void             deletePoint();
 
 protected:

--- a/src/libs/vtools/tools/drawTools/vdrawtool.h
+++ b/src/libs/vtools/tools/drawTools/vdrawtool.h
@@ -140,8 +140,8 @@ protected:
 
     /** @brief SaveDialog save options into file after change in dialog. */
     virtual void     SaveDialog(QDomElement &domElement)=0;
-    virtual void     SaveDialogChange() Q_DECL_FINAL;
-    virtual void     AddToFile() Q_DECL_OVERRIDE;
+    virtual void     SaveDialogChange() final;
+    virtual void     AddToFile() override;
     void             SaveOption(QSharedPointer<VGObject> &obj);
     virtual void     SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj);
     virtual QString  makeToolTip() const;

--- a/src/libs/vtools/tools/drawTools/vtoolline.h
+++ b/src/libs/vtools/tools/drawTools/vtoolline.h
@@ -75,7 +75,7 @@ class VToolLine: public VDrawTool, public QGraphicsLineItem
 {
     Q_OBJECT
 public:
-    virtual void      setDialog() Q_DECL_OVERRIDE;
+    virtual void      setDialog() override;
 
     static VToolLine *Create(QSharedPointer<DialogTool> dialog, VMainGraphicsScene  *scene, VAbstractPattern *doc,
                              VContainer *data);
@@ -85,12 +85,12 @@ public:
                              VAbstractPattern *doc, VContainer *data, const Document &parse,
                              const Source &typeCreation);
 
-    virtual int       type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int       type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::Line)};
-    virtual QString   getTagName() const Q_DECL_OVERRIDE;
+    virtual QString   getTagName() const override;
 
     virtual void      paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-                            QWidget *widget = nullptr) Q_DECL_OVERRIDE;
+                            QWidget *widget = nullptr) override;
 
     QString           FirstPointName() const;
     QString           SecondPointName() const;
@@ -104,36 +104,36 @@ public:
     QString           getLineColor() const;
     void              setLineColor(const QString &value);
 
-    virtual void      ShowVisualization(bool show) Q_DECL_OVERRIDE;
+    virtual void      ShowVisualization(bool show) override;
 
-    virtual void      setLineType(const QString &value) Q_DECL_OVERRIDE;
-    void              setLineWeight(const QString &value) Q_DECL_OVERRIDE;
+    virtual void      setLineType(const QString &value) override;
+    void              setLineWeight(const QString &value) override;
     
-    virtual void      GroupVisibility(quint32 object, bool visible) Q_DECL_OVERRIDE;
+    virtual void      GroupVisibility(quint32 object, bool visible) override;
 
 public slots:
-    virtual void      FullUpdateFromFile() Q_DECL_OVERRIDE;
-    virtual void      ShowTool(quint32 id, bool enable) Q_DECL_OVERRIDE;
-    virtual void      Disable(bool disable, const QString &draftBlockName) Q_DECL_OVERRIDE;
-    virtual void      AllowHover(bool enabled) Q_DECL_OVERRIDE;
-    virtual void      AllowSelecting(bool enabled) Q_DECL_OVERRIDE;
+    virtual void      FullUpdateFromFile() override;
+    virtual void      ShowTool(quint32 id, bool enable) override;
+    virtual void      Disable(bool disable, const QString &draftBlockName) override;
+    virtual void      AllowHover(bool enabled) override;
+    virtual void      AllowSelecting(bool enabled) override;
 
 protected slots:
-    virtual void      showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) Q_DECL_OVERRIDE;
+    virtual void      showContextMenu(QGraphicsSceneContextMenuEvent *event, quint32 id=NULL_ID) override;
 
 protected:
     virtual void      contextMenuEvent(QGraphicsSceneContextMenuEvent * event ) override;
-    virtual void      AddToFile() Q_DECL_OVERRIDE;
-    virtual void      hoverEnterEvent(QGraphicsSceneHoverEvent * event ) Q_DECL_OVERRIDE;
-    virtual void      hoverLeaveEvent(QGraphicsSceneHoverEvent * event ) Q_DECL_OVERRIDE;
-    virtual void      RemoveReferens() Q_DECL_OVERRIDE;
-    virtual QVariant  itemChange(GraphicsItemChange change, const QVariant &value ) Q_DECL_OVERRIDE;
-    virtual void      keyReleaseEvent(QKeyEvent * event) Q_DECL_OVERRIDE;
-    virtual void      SaveDialog(QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void      SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) Q_DECL_OVERRIDE;
-    virtual void      ReadToolAttributes(const QDomElement &domElement) Q_DECL_OVERRIDE;
-    virtual void      SetVisualization() Q_DECL_OVERRIDE;
-    virtual QString   makeToolTip() const Q_DECL_OVERRIDE;
+    virtual void      AddToFile() override;
+    virtual void      hoverEnterEvent(QGraphicsSceneHoverEvent * event ) override;
+    virtual void      hoverLeaveEvent(QGraphicsSceneHoverEvent * event ) override;
+    virtual void      RemoveReferens() override;
+    virtual QVariant  itemChange(GraphicsItemChange change, const QVariant &value ) override;
+    virtual void      keyReleaseEvent(QKeyEvent * event) override;
+    virtual void      SaveDialog(QDomElement &domElement) override;
+    virtual void      SaveOptions(QDomElement &tag, QSharedPointer<VGObject> &obj) override;
+    virtual void      ReadToolAttributes(const QDomElement &domElement) override;
+    virtual void      SetVisualization() override;
+    virtual QString   makeToolTip() const override;
 
 private:
     Q_DISABLE_COPY(VToolLine)

--- a/src/libs/vtools/tools/nodeDetails/vnodearc.h
+++ b/src/libs/vtools/tools/nodeDetails/vnodearc.h
@@ -74,15 +74,15 @@ public:
                         const Source &typeCreation, const QString &blockName = QString(), const quint32 &idTool = 0);
 
     static const QString ToolType;
-    virtual QString getTagName() const Q_DECL_OVERRIDE;
+    virtual QString getTagName() const override;
 public slots:
-    virtual void FullUpdateFromFile() Q_DECL_OVERRIDE {}
-    virtual void AllowHover(bool enabled) Q_DECL_OVERRIDE;
-    virtual void AllowSelecting(bool enabled) Q_DECL_OVERRIDE;
+    virtual void FullUpdateFromFile() override {}
+    virtual void AllowHover(bool enabled) override;
+    virtual void AllowSelecting(bool enabled) override;
 protected:
-    virtual void AddToFile() Q_DECL_OVERRIDE;
-    virtual void ShowNode() Q_DECL_OVERRIDE {}
-    virtual void HideNode() Q_DECL_OVERRIDE {}
+    virtual void AddToFile() override;
+    virtual void ShowNode() override {}
+    virtual void HideNode() override {}
 private:
     Q_DISABLE_COPY(VNodeArc)
 

--- a/src/libs/vtools/tools/nodeDetails/vnodeellipticalarc.h
+++ b/src/libs/vtools/tools/nodeDetails/vnodeellipticalarc.h
@@ -72,15 +72,15 @@ public:
                         const quint32 &idTool = NULL_ID);
 
     static const QString ToolType;
-    virtual QString getTagName() const Q_DECL_OVERRIDE;
+    virtual QString getTagName() const override;
 public slots:
-    virtual void FullUpdateFromFile() Q_DECL_OVERRIDE {}
-    virtual void AllowHover(bool enabled) Q_DECL_OVERRIDE;
-    virtual void AllowSelecting(bool enabled) Q_DECL_OVERRIDE;
+    virtual void FullUpdateFromFile() override {}
+    virtual void AllowHover(bool enabled) override;
+    virtual void AllowSelecting(bool enabled) override;
 protected:
-    virtual void AddToFile() Q_DECL_OVERRIDE;
-    virtual void ShowNode() Q_DECL_OVERRIDE {}
-    virtual void HideNode() Q_DECL_OVERRIDE {}
+    virtual void AddToFile() override;
+    virtual void ShowNode() override {}
+    virtual void HideNode() override {}
 private:
     Q_DISABLE_COPY(VNodeEllipticalArc)
 

--- a/src/libs/vtools/tools/nodeDetails/vnodepoint.h
+++ b/src/libs/vtools/tools/nodeDetails/vnodepoint.h
@@ -78,12 +78,12 @@ public:
                            const QString &blockName = QString(), const quint32 &idTool = 0);
 
     static const QString ToolType;
-    virtual int     type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int     type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Tool::NodePoint)};
-    virtual QString getTagName() const Q_DECL_OVERRIDE;
+    virtual QString getTagName() const override;
 
-    virtual void    setPointNamePosition(quint32 id, const QPointF &pos) Q_DECL_OVERRIDE;
-    virtual void    setPointNameVisiblity(quint32 id, bool visible) Q_DECL_OVERRIDE;
+    virtual void    setPointNamePosition(quint32 id, const QPointF &pos) override;
+    virtual void    setPointNameVisiblity(quint32 id, bool visible) override;
 
 signals:
     void            nodeAngleChanged(quint32 id, PieceNodeAngle type);
@@ -92,23 +92,23 @@ signals:
     void            nodeDeleted(quint32 id);
 
 public slots:
-    virtual void    FullUpdateFromFile() Q_DECL_OVERRIDE;
+    virtual void    FullUpdateFromFile() override;
     void            nameChangedPosition(const QPointF &pos);
     void            pointChosen();
     void            EnableToolMove(bool move);
-    virtual void    AllowHover(bool enabled) Q_DECL_OVERRIDE;
-    virtual void    AllowSelecting(bool enabled) Q_DECL_OVERRIDE;
+    virtual void    AllowHover(bool enabled) override;
+    virtual void    AllowSelecting(bool enabled) override;
     void            allowTextHover(bool enabled);
     void            allowTextSelectable(bool enabled);
 
 protected:
-    virtual void    AddToFile() Q_DECL_OVERRIDE;
-    virtual void    mousePressEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void    mouseReleaseEvent ( QGraphicsSceneMouseEvent * event ) Q_DECL_OVERRIDE;
+    virtual void    AddToFile() override;
+    virtual void    mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+    virtual void    mouseReleaseEvent ( QGraphicsSceneMouseEvent * event ) override;
     virtual void    hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
-    virtual void    ShowNode() Q_DECL_OVERRIDE;
-    virtual void    HideNode() Q_DECL_OVERRIDE;
-    virtual void    contextMenuEvent(QGraphicsSceneContextMenuEvent *event) Q_DECL_OVERRIDE;
+    virtual void    ShowNode() override;
+    virtual void    HideNode() override;
+    virtual void    contextMenuEvent(QGraphicsSceneContextMenuEvent *event) override;
 
 private:
     Q_DISABLE_COPY(VNodePoint)

--- a/src/libs/vtools/tools/nodeDetails/vnodespline.h
+++ b/src/libs/vtools/tools/nodeDetails/vnodespline.h
@@ -76,15 +76,15 @@ public:
                                const quint32 &idTool = 0);
 
     static const QString ToolType;
-    virtual QString getTagName() const Q_DECL_OVERRIDE;
+    virtual QString getTagName() const override;
 public slots:
-    virtual void FullUpdateFromFile () Q_DECL_OVERRIDE {}
-    virtual void AllowHover(bool enabled) Q_DECL_OVERRIDE;
-    virtual void AllowSelecting(bool enabled) Q_DECL_OVERRIDE;
+    virtual void FullUpdateFromFile () override {}
+    virtual void AllowHover(bool enabled) override;
+    virtual void AllowSelecting(bool enabled) override;
 protected:
-    virtual void AddToFile () Q_DECL_OVERRIDE;
-    virtual void ShowNode() Q_DECL_OVERRIDE {}
-    virtual void HideNode() Q_DECL_OVERRIDE {}
+    virtual void AddToFile () override;
+    virtual void ShowNode() override {}
+    virtual void HideNode() override {}
 private:
     Q_DISABLE_COPY(VNodeSpline)
 

--- a/src/libs/vtools/tools/nodeDetails/vnodesplinepath.h
+++ b/src/libs/vtools/tools/nodeDetails/vnodesplinepath.h
@@ -75,15 +75,15 @@ public:
                         const Source &typeCreation, const QString &blockName = QString(), const quint32 &idTool = 0);
 
     static const QString ToolType;
-    virtual QString getTagName() const Q_DECL_OVERRIDE;
+    virtual QString getTagName() const override;
 public slots:
-    virtual void FullUpdateFromFile() Q_DECL_OVERRIDE {}
-    virtual void AllowHover(bool enabled) Q_DECL_OVERRIDE;
-    virtual void AllowSelecting(bool enabled) Q_DECL_OVERRIDE;
+    virtual void FullUpdateFromFile() override {}
+    virtual void AllowHover(bool enabled) override;
+    virtual void AllowSelecting(bool enabled) override;
 protected:
-    virtual void AddToFile() Q_DECL_OVERRIDE;
-    virtual void ShowNode() Q_DECL_OVERRIDE {}
-    virtual void HideNode() Q_DECL_OVERRIDE {}
+    virtual void AddToFile() override;
+    virtual void ShowNode() override {}
+    virtual void HideNode() override {}
 private:
     Q_DISABLE_COPY(VNodeSplinePath)
 

--- a/src/libs/vtools/tools/union_tool.h
+++ b/src/libs/vtools/tools/union_tool.h
@@ -121,23 +121,23 @@ public:
     static const QString NodeTypeContour;
     static const QString NodeTypeModeling;
 
-    virtual QString getTagName() const Q_DECL_OVERRIDE;
-    virtual void ShowVisualization(bool show) Q_DECL_OVERRIDE;
-    virtual void incrementReferens() Q_DECL_OVERRIDE;
-    virtual void decrementReferens() Q_DECL_OVERRIDE;
-    virtual void GroupVisibility(quint32 object, bool visible) Q_DECL_OVERRIDE;
+    virtual QString getTagName() const override;
+    virtual void ShowVisualization(bool show) override;
+    virtual void incrementReferens() override;
+    virtual void decrementReferens() override;
+    virtual void GroupVisibility(quint32 object, bool visible) override;
 
 public slots:
     /**
      * @brief FullUpdateFromFile update tool data form file.
      */
-    virtual void FullUpdateFromFile () Q_DECL_OVERRIDE {}
-    virtual void AllowHover(bool) Q_DECL_OVERRIDE {}
-    virtual void AllowSelecting(bool) Q_DECL_OVERRIDE {}
+    virtual void FullUpdateFromFile () override {}
+    virtual void AllowHover(bool) override {}
+    virtual void AllowSelecting(bool) override {}
 
 protected:
-    virtual void AddToFile() Q_DECL_OVERRIDE;
-    virtual void SetVisualization() Q_DECL_OVERRIDE {}
+    virtual void AddToFile() override;
+    virtual void SetVisualization() override {}
 
 private:
     Q_DISABLE_COPY(UnionTool)

--- a/src/libs/vtools/tools/vabstracttool.h
+++ b/src/libs/vtools/tools/vabstracttool.h
@@ -81,7 +81,7 @@ class VAbstractTool: public VDataTool
     Q_OBJECT
 public:
     VAbstractTool(VAbstractPattern *doc, VContainer *data, quint32 id, QObject *parent = nullptr);
-    virtual                      ~VAbstractTool() Q_DECL_OVERRIDE;
+    virtual                      ~VAbstractTool() override;
     quint32                       getId() const;
 
     static bool                   m_suppressContextMenu;

--- a/src/libs/vtools/undocommands/add_draftblock.h
+++ b/src/libs/vtools/undocommands/add_draftblock.h
@@ -68,9 +68,9 @@ class AddDraftBlock : public VUndoCommand
 public:
                   AddDraftBlock(const QDomElement &xml, VAbstractPattern *doc, const
                                 QString &draftBlockName, QUndoCommand *parent = nullptr);
-    virtual      ~AddDraftBlock() Q_DECL_OVERRIDE;
-    virtual void  undo() Q_DECL_OVERRIDE;
-    virtual void  redo() Q_DECL_OVERRIDE;
+    virtual      ~AddDraftBlock() override;
+    virtual void  undo() override;
+    virtual void  redo() override;
 
 private:
     Q_DISABLE_COPY(AddDraftBlock)

--- a/src/libs/vtools/undocommands/add_groupitem.h
+++ b/src/libs/vtools/undocommands/add_groupitem.h
@@ -41,8 +41,8 @@ public:
                   AddGroupItem(const QDomElement &xml, VAbstractPattern *doc, quint32 nodeId,
                                       QUndoCommand *parent = nullptr);
     virtual      ~AddGroupItem();
-    virtual void  undo() Q_DECL_OVERRIDE;
-    virtual void  redo() Q_DECL_OVERRIDE;
+    virtual void  undo() override;
+    virtual void  redo() override;
 
 signals:
     void          updateGroups();

--- a/src/libs/vtools/undocommands/adddetnode.h
+++ b/src/libs/vtools/undocommands/adddetnode.h
@@ -66,9 +66,9 @@ class AddDetNode : public VUndoCommand
     Q_OBJECT
 public:
     AddDetNode(const QDomElement &xml, VAbstractPattern *doc, const QString &blockName, QUndoCommand *parent = nullptr);
-    virtual ~AddDetNode() Q_DECL_OVERRIDE;
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
+    virtual ~AddDetNode() override;
+    virtual void undo() override;
+    virtual void redo() override;
 private:
     Q_DISABLE_COPY(AddDetNode)
 

--- a/src/libs/vtools/undocommands/addgroup.h
+++ b/src/libs/vtools/undocommands/addgroup.h
@@ -67,8 +67,8 @@ class AddGroup : public VUndoCommand
 public:
     AddGroup(const QDomElement &xml, VAbstractPattern *doc, QUndoCommand *parent = nullptr);
     virtual ~AddGroup();
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
+    virtual void undo() override;
+    virtual void redo() override;
 signals:
     void updateGroups();
 private:

--- a/src/libs/vtools/undocommands/addimage.h
+++ b/src/libs/vtools/undocommands/addimage.h
@@ -43,8 +43,8 @@ class AddImage : public VUndoCommand
 public:
     AddImage(const QDomElement &xml, VAbstractPattern *doc, QUndoCommand *parent = nullptr);
     virtual  ~AddImage();
-    virtual   void  undo() Q_DECL_OVERRIDE; // cppcheck-suppress unusedFunction
-    virtual   void  redo() Q_DECL_OVERRIDE; // cppcheck-suppress unusedFunction
+    virtual   void  undo() override; // cppcheck-suppress unusedFunction
+    virtual   void  redo() override; // cppcheck-suppress unusedFunction
 
 private:
     Q_DISABLE_COPY(AddImage)

--- a/src/libs/vtools/undocommands/addpiece.h
+++ b/src/libs/vtools/undocommands/addpiece.h
@@ -71,8 +71,8 @@ public:
                   AddPiece(const QDomElement &xml, VAbstractPattern *doc, const VPiece &piece,
                            const QString &blockName = QString(), QUndoCommand *parent = nullptr);
     virtual      ~AddPiece();
-    virtual void  undo() Q_DECL_OVERRIDE; // cppcheck-suppress unusedFunction
-    virtual void  redo() Q_DECL_OVERRIDE; // cppcheck-suppress unusedFunction
+    virtual void  undo() override; // cppcheck-suppress unusedFunction
+    virtual void  redo() override; // cppcheck-suppress unusedFunction
 
 private:
     Q_DISABLE_COPY(AddPiece)

--- a/src/libs/vtools/undocommands/addtocalc.h
+++ b/src/libs/vtools/undocommands/addtocalc.h
@@ -67,10 +67,10 @@ class AddToCalc : public VUndoCommand
 public:
     AddToCalc(const QDomElement &xml, VAbstractPattern *doc, QUndoCommand *parent = nullptr);
     virtual ~AddToCalc() =default;
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
+    virtual void undo() override;
+    virtual void redo() override;
 protected:
-    virtual void RedoFullParsing() Q_DECL_OVERRIDE;
+    virtual void RedoFullParsing() override;
 private:
     Q_DISABLE_COPY(AddToCalc)
     const QString     activeBlockName;

--- a/src/libs/vtools/undocommands/delete_draftblock.h
+++ b/src/libs/vtools/undocommands/delete_draftblock.h
@@ -68,9 +68,9 @@ class DeleteDraftBlock : public VUndoCommand
 public:
                   DeleteDraftBlock(VAbstractPattern *doc, const QString &draftBlockName,
                                    QUndoCommand *parent = nullptr);
-    virtual      ~DeleteDraftBlock() Q_DECL_OVERRIDE;
-    virtual void  undo() Q_DECL_OVERRIDE;
-    virtual void  redo() Q_DECL_OVERRIDE;
+    virtual      ~DeleteDraftBlock() override;
+    virtual void  undo() override;
+    virtual void  redo() override;
 
 private:
     Q_DISABLE_COPY(DeleteDraftBlock)

--- a/src/libs/vtools/undocommands/deletepiece.h
+++ b/src/libs/vtools/undocommands/deletepiece.h
@@ -66,8 +66,8 @@ public:
     DeletePiece(VAbstractPattern *doc, quint32 id, const VPiece &piece, QUndoCommand *parent = nullptr);
     virtual ~DeletePiece();
 
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
+    virtual void undo() override;
+    virtual void redo() override;
 private:
     Q_DISABLE_COPY(DeletePiece)
 

--- a/src/libs/vtools/undocommands/delgroup.h
+++ b/src/libs/vtools/undocommands/delgroup.h
@@ -66,8 +66,8 @@ class DelGroup : public VUndoCommand
 public:
     DelGroup(VAbstractPattern *doc, quint32 id, QUndoCommand *parent = nullptr);
     virtual ~DelGroup();
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
+    virtual void undo() override;
+    virtual void redo() override;
 signals:
     void updateGroups();
 private:

--- a/src/libs/vtools/undocommands/deltool.h
+++ b/src/libs/vtools/undocommands/deltool.h
@@ -66,9 +66,9 @@ class DelTool : public VUndoCommand
     Q_OBJECT
 public:
     DelTool(VAbstractPattern *doc, quint32 id, QUndoCommand *parent = nullptr);
-    virtual ~DelTool() Q_DECL_OVERRIDE;
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
+    virtual ~DelTool() override;
+    virtual void undo() override;
+    virtual void redo() override;
 private:
     Q_DISABLE_COPY(DelTool)
     QDomNode      parentNode;

--- a/src/libs/vtools/undocommands/label/moveabstractlabel.h
+++ b/src/libs/vtools/undocommands/label/moveabstractlabel.h
@@ -70,8 +70,8 @@ public:
     virtual        ~MoveAbstractLabel()=default;
 
 
-    virtual void    undo() Q_DECL_OVERRIDE;
-    virtual void    redo() Q_DECL_OVERRIDE;
+    virtual void    undo() override;
+    virtual void    redo() override;
 
     quint32         GetPointId() const;
     QPointF         GetNewPos() const;

--- a/src/libs/vtools/undocommands/label/movedoublelabel.h
+++ b/src/libs/vtools/undocommands/label/movedoublelabel.h
@@ -70,14 +70,14 @@ public:
                                     quint32 toolId, quint32 pointId, QUndoCommand *parent = nullptr);
     virtual        ~MoveDoubleLabel()=default;
 
-    virtual bool    mergeWith(const QUndoCommand *command) Q_DECL_OVERRIDE;
-    virtual int     id() const Q_DECL_OVERRIDE;
+    virtual bool    mergeWith(const QUndoCommand *command) override;
+    virtual int     id() const override;
 
     quint32         GetToolId() const;
     MoveDoublePoint GetPointType() const;
 
 protected:
-    virtual void    Do(const QPointF &pos) Q_DECL_OVERRIDE;
+    virtual void    Do(const QPointF &pos) override;
 
 private:
     Q_DISABLE_COPY(MoveDoubleLabel)

--- a/src/libs/vtools/undocommands/label/movelabel.h
+++ b/src/libs/vtools/undocommands/label/movelabel.h
@@ -67,11 +67,11 @@ public:
                               QUndoCommand *parent = nullptr);
     virtual        ~MoveLabel()=default;
 
-    virtual bool    mergeWith(const QUndoCommand *command) Q_DECL_OVERRIDE;
-    virtual int     id() const Q_DECL_OVERRIDE;
+    virtual bool    mergeWith(const QUndoCommand *command) override;
+    virtual int     id() const override;
 
 protected:
-    virtual void    Do(const QPointF &pos) Q_DECL_OVERRIDE;
+    virtual void    Do(const QPointF &pos) override;
     
 private:
     Q_DISABLE_COPY(MoveLabel)

--- a/src/libs/vtools/undocommands/label/moveoperationlabel.h
+++ b/src/libs/vtools/undocommands/label/moveoperationlabel.h
@@ -68,13 +68,13 @@ public:
                                        quint32 idPoint, QUndoCommand *parent = nullptr);
     virtual        ~MoveOperationLabel()=default;
 
-    virtual bool    mergeWith(const QUndoCommand *command) Q_DECL_OVERRIDE;
-    virtual int     id() const Q_DECL_OVERRIDE;
+    virtual bool    mergeWith(const QUndoCommand *command) override;
+    virtual int     id() const override;
 
     quint32         GetToolId() const;
 
 protected:
-    virtual void    Do(const QPointF &pos) Q_DECL_OVERRIDE;
+    virtual void    Do(const QPointF &pos) override;
 
 private:
     Q_DISABLE_COPY(MoveOperationLabel)

--- a/src/libs/vtools/undocommands/label/showoperationpointname.h
+++ b/src/libs/vtools/undocommands/label/showoperationpointname.h
@@ -37,8 +37,8 @@
                                             bool visible, QUndoCommand *parent = nullptr);
      virtual        ~ShowOperationPointName()=default;
 
-     virtual void    undo() Q_DECL_OVERRIDE;
-     virtual void    redo() Q_DECL_OVERRIDE;
+     virtual void    undo() override;
+     virtual void    redo() override;
 
  private:
      Q_DISABLE_COPY(ShowOperationPointName)

--- a/src/libs/vtools/undocommands/move_groupitem.h
+++ b/src/libs/vtools/undocommands/move_groupitem.h
@@ -41,8 +41,8 @@ public:
                    MoveGroupItem(const QDomElement &source, const QDomElement &dest, VAbstractPattern *doc, quint32 sourceId,
                                  quint32 destinationId, QUndoCommand *parent = nullptr);
     virtual       ~MoveGroupItem();
-    virtual void   undo() Q_DECL_OVERRIDE;
-    virtual void   redo() Q_DECL_OVERRIDE;
+    virtual void   undo() override;
+    virtual void   redo() override;
 
 signals:
     void           updateGroups();

--- a/src/libs/vtools/undocommands/movepiece.h
+++ b/src/libs/vtools/undocommands/movepiece.h
@@ -70,11 +70,11 @@ public:
                QUndoCommand *parent = nullptr);
     virtual ~MovePiece();
 
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
+    virtual void undo() override;
+    virtual void redo() override;
     // cppcheck-suppress unusedFunction
-    virtual bool mergeWith(const QUndoCommand *command) Q_DECL_OVERRIDE;
-    virtual int  id() const Q_DECL_OVERRIDE;
+    virtual bool mergeWith(const QUndoCommand *command) override;
+    virtual int  id() const override;
     quint32      getPieceId() const;
     double       getNewX() const;
     double       getNewY() const;

--- a/src/libs/vtools/undocommands/movespline.h
+++ b/src/libs/vtools/undocommands/movespline.h
@@ -69,11 +69,11 @@ class MoveSpline : public VUndoCommand
 public:
     MoveSpline(VAbstractPattern *doc, const VSpline *oldSpl, const VSpline &newSpl, const quint32 &id,
                QUndoCommand *parent = nullptr);
-    virtual ~MoveSpline() Q_DECL_OVERRIDE;
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
-    virtual bool mergeWith(const QUndoCommand *command) Q_DECL_OVERRIDE;
-    virtual int  id() const Q_DECL_OVERRIDE;
+    virtual ~MoveSpline() override;
+    virtual void undo() override;
+    virtual void redo() override;
+    virtual bool mergeWith(const QUndoCommand *command) override;
+    virtual int  id() const override;
     quint32      getSplineId() const;
     VSpline      getNewSpline() const;
 private:

--- a/src/libs/vtools/undocommands/movesplinepath.h
+++ b/src/libs/vtools/undocommands/movesplinepath.h
@@ -69,11 +69,11 @@ class MoveSplinePath : public VUndoCommand
 public:
     MoveSplinePath(VAbstractPattern *doc, const VSplinePath &oldSplPath, const VSplinePath &newSplPath,
                    const quint32 &id, QUndoCommand *parent = nullptr);
-    virtual ~MoveSplinePath() Q_DECL_OVERRIDE;
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
-    virtual bool mergeWith(const QUndoCommand *command) Q_DECL_OVERRIDE;
-    virtual int  id() const Q_DECL_OVERRIDE;
+    virtual ~MoveSplinePath() override;
+    virtual void undo() override;
+    virtual void redo() override;
+    virtual bool mergeWith(const QUndoCommand *command) override;
+    virtual int  id() const override;
     quint32      getSplinePathId() const;
     VSplinePath  getNewSplinePath() const;
 private:

--- a/src/libs/vtools/undocommands/movespoint.h
+++ b/src/libs/vtools/undocommands/movespoint.h
@@ -68,11 +68,11 @@ class MoveSPoint : public VUndoCommand
 public:
     MoveSPoint(VAbstractPattern *doc, const double &x, const double &y, const quint32 &id, QGraphicsScene *scene,
                QUndoCommand *parent = nullptr);
-    virtual ~MoveSPoint() Q_DECL_OVERRIDE;
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
-    virtual bool mergeWith(const QUndoCommand *command) Q_DECL_OVERRIDE;
-    virtual int  id() const Q_DECL_OVERRIDE;
+    virtual ~MoveSPoint() override;
+    virtual void undo() override;
+    virtual void redo() override;
+    virtual bool mergeWith(const QUndoCommand *command) override;
+    virtual int  id() const override;
     quint32      getSPointId() const;
     double       getNewX() const;
     double       getNewY() const;

--- a/src/libs/vtools/undocommands/remove_groupitem.h
+++ b/src/libs/vtools/undocommands/remove_groupitem.h
@@ -40,8 +40,8 @@ class RemoveGroupItem : public VUndoCommand
 public:
                   RemoveGroupItem(const QDomElement &xml, VAbstractPattern *doc, quint32 groupId, QUndoCommand *parent = nullptr);
     virtual      ~RemoveGroupItem();
-    virtual void  undo() Q_DECL_OVERRIDE;
-    virtual void  redo() Q_DECL_OVERRIDE;
+    virtual void  undo() override;
+    virtual void  redo() override;
 
 signals:
     void          updateGroups();

--- a/src/libs/vtools/undocommands/rename_draftblock.h
+++ b/src/libs/vtools/undocommands/rename_draftblock.h
@@ -66,12 +66,12 @@ class RenameDraftBlock :public VUndoCommand
     Q_OBJECT
 public:
     RenameDraftBlock(VAbstractPattern *doc, const QString &newBlockName, QComboBox *combo, QUndoCommand *parent = nullptr);
-    virtual     ~RenameDraftBlock() Q_DECL_OVERRIDE;
+    virtual     ~RenameDraftBlock() override;
 
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
-    virtual bool mergeWith(const QUndoCommand *command) Q_DECL_OVERRIDE;
-    virtual int  id() const Q_DECL_OVERRIDE;
+    virtual void undo() override;
+    virtual void redo() override;
+    virtual bool mergeWith(const QUndoCommand *command) override;
+    virtual int  id() const override;
     QString      getNewName() const;
     QString      getOldName() const;
 private:

--- a/src/libs/vtools/undocommands/savepieceoptions.h
+++ b/src/libs/vtools/undocommands/savepieceoptions.h
@@ -64,10 +64,10 @@ public:
 
     virtual      ~SavePieceOptions();
 
-    virtual void  undo() Q_DECL_OVERRIDE;
-    virtual void  redo() Q_DECL_OVERRIDE;
-    virtual bool  mergeWith(const QUndoCommand *command) Q_DECL_OVERRIDE;
-    virtual int   id() const Q_DECL_OVERRIDE;
+    virtual void  undo() override;
+    virtual void  redo() override;
+    virtual bool  mergeWith(const QUndoCommand *command) override;
+    virtual int   id() const override;
     quint32       pieceId() const;
     VPiece        getNewPiece() const;
 

--- a/src/libs/vtools/undocommands/savepiecepathoptions.h
+++ b/src/libs/vtools/undocommands/savepiecepathoptions.h
@@ -63,10 +63,10 @@ public:
                          VContainer *data, quint32 id, QUndoCommand *parent = nullptr);
     virtual ~SavePiecePathOptions();
 
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
-    virtual bool mergeWith(const QUndoCommand *command) Q_DECL_OVERRIDE;
-    virtual int  id() const Q_DECL_OVERRIDE;
+    virtual void undo() override;
+    virtual void redo() override;
+    virtual bool mergeWith(const QUndoCommand *command) override;
+    virtual int  id() const override;
     quint32      pathId() const;
     VPiecePath   newPath() const;
 

--- a/src/libs/vtools/undocommands/savetooloptions.h
+++ b/src/libs/vtools/undocommands/savetooloptions.h
@@ -67,11 +67,11 @@ class SaveToolOptions : public VUndoCommand
 public:
     SaveToolOptions(const QDomElement &oldXml, const QDomElement &newXml, VAbstractPattern *doc, const quint32 &id,
                     QUndoCommand *parent = nullptr);
-    virtual ~SaveToolOptions() Q_DECL_OVERRIDE;
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
-    virtual bool mergeWith(const QUndoCommand *command) Q_DECL_OVERRIDE;
-    virtual int  id() const Q_DECL_OVERRIDE;
+    virtual ~SaveToolOptions() override;
+    virtual void undo() override;
+    virtual void redo() override;
+    virtual bool mergeWith(const QUndoCommand *command) override;
+    virtual int  id() const override;
     QDomElement  getNewXml() const;
     quint32 getToolId() const;
 private:

--- a/src/libs/vtools/undocommands/set_piece_color.h
+++ b/src/libs/vtools/undocommands/set_piece_color.h
@@ -40,9 +40,9 @@ public:
                  SetPieceColor(quint32 id, QString color, VContainer *data,
                                VAbstractPattern *doc, QUndoCommand *parent = nullptr);
     virtual     ~SetPieceColor();
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
-    virtual int  id() const Q_DECL_OVERRIDE;
+    virtual void undo() override;
+    virtual void redo() override;
+    virtual int  id() const override;
     quint32      getpieceId() const;
     QString      getColor() const;
 

--- a/src/libs/vtools/undocommands/toggle_piecelock.h
+++ b/src/libs/vtools/undocommands/toggle_piecelock.h
@@ -39,9 +39,9 @@ class TogglePieceLock : public VUndoCommand
 public:
     TogglePieceLock(quint32 id, bool lock, VContainer *data, VAbstractPattern *doc, QUndoCommand *parent = nullptr);
     virtual     ~TogglePieceLock();
-    virtual void undo() Q_DECL_OVERRIDE;
-    virtual void redo() Q_DECL_OVERRIDE;
-    virtual int  id() const Q_DECL_OVERRIDE;
+    virtual void undo() override;
+    virtual void redo() override;
+    virtual int  id() const override;
     quint32      getpieceId() const;
     bool         getNewLock() const;
 

--- a/src/libs/vtools/undocommands/togglepieceinlayout.h
+++ b/src/libs/vtools/undocommands/togglepieceinlayout.h
@@ -68,9 +68,9 @@ public:
                   TogglePieceInLayout(quint32 id, bool state, VContainer *data,
                                       VAbstractPattern *doc, QUndoCommand *parent = nullptr);
     virtual      ~TogglePieceInLayout();
-    virtual void  undo() Q_DECL_OVERRIDE;
-    virtual void  redo() Q_DECL_OVERRIDE;
-    virtual int   id() const Q_DECL_OVERRIDE;
+    virtual void  undo() override;
+    virtual void  redo() override;
+    virtual int   id() const override;
     quint32       getPieceId() const;
     bool          getNewState() const;
 

--- a/src/libs/vtools/visualization/line/anchorpoint_visual.h
+++ b/src/libs/vtools/visualization/line/anchorpoint_visual.h
@@ -40,8 +40,8 @@ public:
     explicit               AnchorPointVisual(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual               ~AnchorPointVisual();
 
-    virtual void           RefreshGeometry() Q_DECL_OVERRIDE;
-    virtual int            type() const Q_DECL_OVERRIDE {return Type;}
+    virtual void           RefreshGeometry() override;
+    virtual int            type() const override {return Type;}
     enum                   {Type = UserType + static_cast<int>(Vis::ToolAnchorPoint)};
 
 private:

--- a/src/libs/vtools/visualization/line/intersect_circles_visual.h
+++ b/src/libs/vtools/visualization/line/intersect_circles_visual.h
@@ -53,15 +53,15 @@ public:
     explicit              IntersectCirclesVisual(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual              ~IntersectCirclesVisual() = default;
 
-    virtual void          RefreshGeometry() Q_DECL_OVERRIDE;
-    virtual void          VisualMode(const quint32 &id) Q_DECL_OVERRIDE;
+    virtual void          RefreshGeometry() override;
+    virtual void          VisualMode(const quint32 &id) override;
 
     void                  setObject2Id(const quint32 &value);
     void                  setC1Radius(const QString &value);
     void                  setC2Radius(const QString &value);
     void                  setCrossPoint(const CrossCirclesPoint &value);
 
-    virtual int           type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int           type() const override {return Type;}
     enum                  {Type = UserType + static_cast<int>(Vis::ToolPointOfIntersectionCircles)};
 
 private:

--- a/src/libs/vtools/visualization/line/intersect_circletangent_visual.h
+++ b/src/libs/vtools/visualization/line/intersect_circletangent_visual.h
@@ -51,13 +51,13 @@ public:
     explicit              IntersectCircleTangentVisual(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual              ~IntersectCircleTangentVisual() = default;
 
-    virtual void          RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void          RefreshGeometry() override;
 
     void                  setObject2Id(const quint32 &value);
     void                  setCRadius(const QString &value);
     void                  setCrossPoint(const CrossCirclesPoint &value);
 
-    virtual int           type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int           type() const override {return Type;}
     enum                  {Type = UserType + static_cast<int>(Vis::ToolPointFromCircleAndTangent)};
 
 private:

--- a/src/libs/vtools/visualization/line/operation/visoperation.h
+++ b/src/libs/vtools/visualization/line/operation/visoperation.h
@@ -66,9 +66,9 @@ public:
 
     void                      setObjects(QVector<quint32> objects);
 
-    virtual void              VisualMode(const quint32 &pointId = NULL_ID) Q_DECL_OVERRIDE;
+    virtual void              VisualMode(const quint32 &pointId = NULL_ID) override;
 
-    virtual int               type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int               type() const override {return Type;}
     enum                      {Type = UserType + static_cast<int>(Vis::ToolRotation)};
 protected:
     QVector<quint32>          objects;

--- a/src/libs/vtools/visualization/line/operation/vistoolmirrorbyaxis.h
+++ b/src/libs/vtools/visualization/line/operation/vistoolmirrorbyaxis.h
@@ -64,12 +64,12 @@ public:
     explicit        VisToolMirrorByAxis(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual        ~VisToolMirrorByAxis() = default;
 
-    virtual void    RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void    RefreshGeometry() override;
 
     void            setOriginPointId(quint32 value);
     void            setAxisType(AxisType value);
 
-    virtual int     type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int     type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolMirrorByAxis)};
 private:
     Q_DISABLE_COPY(VisToolMirrorByAxis)

--- a/src/libs/vtools/visualization/line/operation/vistoolmirrorbyline.h
+++ b/src/libs/vtools/visualization/line/operation/vistoolmirrorbyline.h
@@ -63,12 +63,12 @@ public:
     explicit VisToolMirrorByLine(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolMirrorByLine() = default;
 
-    virtual void   RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void   RefreshGeometry() override;
 
     void setFirstLinePointId(quint32 value);
     void setSecondLinePointId(quint32 value);
 
-    virtual int type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolMirrorByLine)};
 private:
     Q_DISABLE_COPY(VisToolMirrorByLine)

--- a/src/libs/vtools/visualization/line/operation/vistoolmove.h
+++ b/src/libs/vtools/visualization/line/operation/vistoolmove.h
@@ -73,7 +73,7 @@ public:
     explicit                 VisToolMove(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual                 ~VisToolMove();
 
-    virtual void             RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void             RefreshGeometry() override;
 
     QString                  Angle() const;
     void                     SetAngle(const QString &expression);
@@ -87,7 +87,7 @@ public:
 
     void                     setOriginPointId(quint32 value);
 
-    virtual int              type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int              type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolMove)};
 
 private:

--- a/src/libs/vtools/visualization/line/operation/vistoolrotation.h
+++ b/src/libs/vtools/visualization/line/operation/vistoolrotation.h
@@ -73,14 +73,14 @@ public:
     explicit VisToolRotation(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolRotation();
 
-    virtual void   RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void   RefreshGeometry() override;
 
     void SetOriginPointId(quint32 value);
 
     QString Angle() const;
     void    SetAngle(const QString &expression);
 
-    virtual int type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolRotation)};
 private:
     Q_DISABLE_COPY(VisToolRotation)

--- a/src/libs/vtools/visualization/line/point_intersectxy_visual.h
+++ b/src/libs/vtools/visualization/line/point_intersectxy_visual.h
@@ -52,11 +52,11 @@ public:
     explicit        PointIntersectXYVisual(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual        ~PointIntersectXYVisual() = default;
 
-    virtual void    RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void    RefreshGeometry() override;
 
     void            setPoint2Id(const quint32 &value);
     void            setPoint1Id(const quint32 &value);
-    virtual int     type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int     type() const override {return Type;}
     enum            {Type = UserType + static_cast<int>(Vis::ToolPointOfIntersection)};
 
 private:

--- a/src/libs/vtools/visualization/line/visline.h
+++ b/src/libs/vtools/visualization/line/visline.h
@@ -75,7 +75,7 @@ public:
     explicit VisLine(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisLine() = default;
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::Line)};
     static qreal CorrectAngle(const qreal &angle);
 protected:
@@ -83,8 +83,8 @@ protected:
     QPointF      Ray(const QPointF &firstPoint) const;
     QLineF       Axis(const QPointF &p, const qreal &angle) const;
     QLineF       Axis(const QPointF &p1, const QPointF &p2) const;
-    virtual void initPen() Q_DECL_OVERRIDE;
-    virtual void AddOnScene() Q_DECL_OVERRIDE;
+    virtual void initPen() override;
+    virtual void AddOnScene() override;
 
     void         DrawRay(VScaledLine *lineItem, const QPointF &p, const QPointF &pTangent,
                          const QColor &color, Qt::PenStyle style);

--- a/src/libs/vtools/visualization/line/vistoolalongline.h
+++ b/src/libs/vtools/visualization/line/vistoolalongline.h
@@ -69,10 +69,10 @@ public:
     explicit VisToolAlongLine(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolAlongLine() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
     void         setObject2Id(const quint32 &value);
     void         setLength(const QString &expression);
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolAlongLine)};
 private:
     Q_DISABLE_COPY(VisToolAlongLine)

--- a/src/libs/vtools/visualization/line/vistoolbisector.h
+++ b/src/libs/vtools/visualization/line/vistoolbisector.h
@@ -69,11 +69,11 @@ public:
     explicit VisToolBisector(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolBisector() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
     void         setObject2Id(const quint32 &value);
     void         setObject3Id(const quint32 &value);
     void         setLength(const QString &expression);
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolBisector)};
 private:
     Q_DISABLE_COPY(VisToolBisector)

--- a/src/libs/vtools/visualization/line/vistoolcurveintersectaxis.h
+++ b/src/libs/vtools/visualization/line/vistoolcurveintersectaxis.h
@@ -69,13 +69,13 @@ public:
     explicit VisToolCurveIntersectAxis(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolCurveIntersectAxis() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
 
     QString      Angle() const;
     void         SetAngle(const QString &expression);
     void         setAxisPointId(const quint32 &value);
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolLineIntersectAxis)};
 private:
     Q_DISABLE_COPY(VisToolCurveIntersectAxis)

--- a/src/libs/vtools/visualization/line/vistoolendline.h
+++ b/src/libs/vtools/visualization/line/vistoolendline.h
@@ -69,7 +69,7 @@ public:
     explicit VisToolEndLine(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolEndLine() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
 
     QString      Angle() const;
     void         SetAngle(const QString &expression);
@@ -77,7 +77,7 @@ public:
     QString      Length() const;
     void         setLength(const QString &expression);
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolEndLine)};
 private:
     Q_DISABLE_COPY(VisToolEndLine)

--- a/src/libs/vtools/visualization/line/vistoolheight.h
+++ b/src/libs/vtools/visualization/line/vistoolheight.h
@@ -70,11 +70,11 @@ public:
     explicit VisToolHeight(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolHeight() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
 
     void         setLineP1Id(const quint32 &value);
     void         setLineP2Id(const quint32 &value);
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolHeight)};
 private:
     Q_DISABLE_COPY(VisToolHeight)

--- a/src/libs/vtools/visualization/line/vistoolline.h
+++ b/src/libs/vtools/visualization/line/vistoolline.h
@@ -72,14 +72,14 @@ public:
     explicit VisToolLine(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolLine() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
     void         setPoint2Id(const quint32 &value);
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolLine)};
 protected:
     virtual void DrawLine(VScaledLine *lineItem, const QLineF &line, const QColor &color,
                           const qreal &lineWeight,
-                          Qt::PenStyle style = Qt::SolidLine) Q_DECL_OVERRIDE;
+                          Qt::PenStyle style = Qt::SolidLine) override;
 private:
     Q_DISABLE_COPY(VisToolLine)
     quint32      point2Id;

--- a/src/libs/vtools/visualization/line/vistoollineintersect.h
+++ b/src/libs/vtools/visualization/line/vistoollineintersect.h
@@ -69,12 +69,12 @@ public:
     explicit VisToolLineIntersect(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolLineIntersect() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
 
     void         setLine1P2Id(const quint32 &value);
     void         setLine2P1Id(const quint32 &value);
     void         setLine2P2Id(const quint32 &value);
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolLineIntersect)};
 private:
     Q_DISABLE_COPY(VisToolLineIntersect)

--- a/src/libs/vtools/visualization/line/vistoollineintersectaxis.h
+++ b/src/libs/vtools/visualization/line/vistoollineintersectaxis.h
@@ -70,14 +70,14 @@ public:
     explicit VisToolLineIntersectAxis(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolLineIntersectAxis() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
 
     QString      Angle() const;
     void         SetAngle(const QString &expression);
     void         setPoint2Id(const quint32 &value);
     void         setAxisPointId(const quint32 &value);
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolLineIntersectAxis)};
 private:
     Q_DISABLE_COPY(VisToolLineIntersectAxis)

--- a/src/libs/vtools/visualization/line/vistoolnormal.h
+++ b/src/libs/vtools/visualization/line/vistoolnormal.h
@@ -69,13 +69,13 @@ public:
     explicit VisToolNormal(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolNormal() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
 
     void         setObject2Id(const quint32 &value);
     void         setLength(const QString &expression);
     qreal        GetAngle() const;
     void         SetAngle(const qreal &value);
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolNormal)};
 
 private:

--- a/src/libs/vtools/visualization/line/vistoolpointfromarcandtangent.h
+++ b/src/libs/vtools/visualization/line/vistoolpointfromarcandtangent.h
@@ -73,12 +73,12 @@ public:
     explicit VisToolPointFromArcAndTangent(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolPointFromArcAndTangent() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
 
     void         setArcId(const quint32 &value);
     void         setCrossPoint(const CrossCirclesPoint &value);
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolPointFromArcAndTangent)};
 private:
     Q_DISABLE_COPY(VisToolPointFromArcAndTangent)

--- a/src/libs/vtools/visualization/line/vistoolpointofcontact.h
+++ b/src/libs/vtools/visualization/line/vistoolpointofcontact.h
@@ -69,11 +69,11 @@ public:
     explicit VisToolPointOfContact(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolPointOfContact() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
     void         setLineP2Id(const quint32 &value);
     void         setRadiusId(const quint32 &value);
     void         setRadius(const QString &expression);
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolPointOfContact)};
 private:
     Q_DISABLE_COPY(VisToolPointOfContact)

--- a/src/libs/vtools/visualization/line/vistoolpointofintersectionarcs.h
+++ b/src/libs/vtools/visualization/line/vistoolpointofintersectionarcs.h
@@ -70,14 +70,14 @@ public:
     explicit VisToolPointOfIntersectionArcs(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolPointOfIntersectionArcs() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
-    virtual void VisualMode(const quint32 &id) Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
+    virtual void VisualMode(const quint32 &id) override;
 
     void         setArc1Id(const quint32 &value);
     void         setArc2Id(const quint32 &value);
     void         setCrossPoint(const CrossCirclesPoint &value);
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolPointOfIntersectionArcs)};
 private:
     Q_DISABLE_COPY(VisToolPointOfIntersectionArcs)

--- a/src/libs/vtools/visualization/line/vistoolshoulderpoint.h
+++ b/src/libs/vtools/visualization/line/vistoolshoulderpoint.h
@@ -69,11 +69,11 @@ public:
     explicit VisToolShoulderPoint(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolShoulderPoint() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
     void         setLineP1Id(const quint32 &value);
     void         setLineP2Id(const quint32 &value);
     void         setLength(const QString &expression);
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolShoulderPoint)};
 private:
     Q_DISABLE_COPY(VisToolShoulderPoint)

--- a/src/libs/vtools/visualization/line/vistooltriangle.h
+++ b/src/libs/vtools/visualization/line/vistooltriangle.h
@@ -72,13 +72,13 @@ public:
     explicit VisToolTriangle(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolTriangle() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
 
     void         setObject2Id(const quint32 &value);
     void         setHypotenuseP1Id(const quint32 &value);
     void         setHypotenuseP2Id(const quint32 &value);
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolTriangle)};
 private:
     Q_DISABLE_COPY(VisToolTriangle)

--- a/src/libs/vtools/visualization/line/vistooltruedarts.h
+++ b/src/libs/vtools/visualization/line/vistooltruedarts.h
@@ -69,14 +69,14 @@ public:
     explicit VisToolTrueDarts(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolTrueDarts() = default;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
 
     void setObject2Id(const quint32 &value);
     void setD1PointId(const quint32 &value);
     void setD2PointId(const quint32 &value);
     void setD3PointId(const quint32 &value);
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolTrueDarts)};
 private:
     Q_DISABLE_COPY(VisToolTrueDarts)

--- a/src/libs/vtools/visualization/path/pattern_piece_visual.h
+++ b/src/libs/vtools/visualization/path/pattern_piece_visual.h
@@ -66,9 +66,9 @@ public:
                               PatternPieceVisual(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual                  ~PatternPieceVisual() Q_DECL_EQ_DEFAULT;
 
-    virtual void              RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void              RefreshGeometry() override;
     void                      SetPiece(const VPiece &piece);
-    virtual int               type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int               type() const override {return Type;}
     enum                      {Type = UserType + static_cast<int>(Vis::ToolPiece)};
 
 private:

--- a/src/libs/vtools/visualization/path/pieceanchorpoint_visual.h
+++ b/src/libs/vtools/visualization/path/pieceanchorpoint_visual.h
@@ -40,9 +40,9 @@ public:
                              PieceAnchorPointVisual(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual                 ~PieceAnchorPointVisual() Q_DECL_EQ_DEFAULT;
 
-    virtual void             RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void             RefreshGeometry() override;
     void                     setAnchors(const QVector<quint32> &anchors);
-    virtual int              type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int              type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::PieceAnchors)};
 
 private:

--- a/src/libs/vtools/visualization/path/vispath.h
+++ b/src/libs/vtools/visualization/path/vispath.h
@@ -72,11 +72,11 @@ public:
     explicit VisPath(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisPath() = default;
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::Path)};
 protected:
-    virtual void initPen() Q_DECL_OVERRIDE;
-    virtual void AddOnScene() Q_DECL_OVERRIDE;
+    virtual void initPen() override;
+    virtual void AddOnScene() override;
 
     VSimplePoint *GetPoint(QVector<VSimplePoint *> &points, quint32 i, const QColor &color);
 private:

--- a/src/libs/vtools/visualization/path/vistoolarc.h
+++ b/src/libs/vtools/visualization/path/vistoolarc.h
@@ -69,11 +69,11 @@ public:
     explicit VisToolArc(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolArc() Q_DECL_EQ_DEFAULT;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
     void         setRadius(const QString &expression);
     void         setF1(const QString &expression);
     void         setF2(const QString &expression);
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolArc)};
 private:
     Q_DISABLE_COPY(VisToolArc)

--- a/src/libs/vtools/visualization/path/vistoolarcwithlength.h
+++ b/src/libs/vtools/visualization/path/vistoolarcwithlength.h
@@ -69,11 +69,11 @@ public:
     explicit VisToolArcWithLength(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolArcWithLength() Q_DECL_EQ_DEFAULT;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
     void         setRadius(const QString &expression);
     void         setF1(const QString &expression);
     void         setLength(const QString &expression);
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolArcWithLength)};
 private:
     Q_DISABLE_COPY(VisToolArcWithLength)

--- a/src/libs/vtools/visualization/path/vistoolcubicbezier.h
+++ b/src/libs/vtools/visualization/path/vistoolcubicbezier.h
@@ -69,13 +69,13 @@ public:
     explicit VisToolCubicBezier(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolCubicBezier() Q_DECL_EQ_DEFAULT;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
 
     void         setObject2Id(const quint32 &value);
     void         setObject3Id(const quint32 &value);
     void         setObject4Id(const quint32 &value);
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolCubicBezier)};
 protected:
     Q_DISABLE_COPY(VisToolCubicBezier)

--- a/src/libs/vtools/visualization/path/vistoolcubicbezierpath.h
+++ b/src/libs/vtools/visualization/path/vistoolcubicbezierpath.h
@@ -71,12 +71,12 @@ public:
     explicit VisToolCubicBezierPath(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolCubicBezierPath();
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
 
     void              setPath(const VCubicBezierPath &value);
     VCubicBezierPath  getPath();
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolCubicBezierPath)};
 protected:
     Q_DISABLE_COPY(VisToolCubicBezierPath)

--- a/src/libs/vtools/visualization/path/vistoolcutarc.h
+++ b/src/libs/vtools/visualization/path/vistoolcutarc.h
@@ -69,10 +69,10 @@ public:
     explicit        VisToolCutArc(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual        ~VisToolCutArc() Q_DECL_EQ_DEFAULT;
 
-    virtual void    RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void    RefreshGeometry() override;
     void            setDirection(const QString &direction);
     void            setLength(const QString &expression);
-    virtual int     type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int     type() const override {return Type;}
     enum            {Type = UserType + static_cast<int>(Vis::ToolCutArc)};
 protected:
     Q_DISABLE_COPY(VisToolCutArc)

--- a/src/libs/vtools/visualization/path/vistoolcutspline.h
+++ b/src/libs/vtools/visualization/path/vistoolcutspline.h
@@ -69,10 +69,10 @@ public:
     explicit        VisToolCutSpline(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual        ~VisToolCutSpline() Q_DECL_EQ_DEFAULT;
 
-    virtual void    RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void    RefreshGeometry() override;
     void            setDirection(const QString &direction);
     void            setLength(const QString &expression);
-    virtual int     type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int     type() const override {return Type;}
     enum            {Type = UserType + static_cast<int>(Vis::ToolCutSpline)};
 
 protected:

--- a/src/libs/vtools/visualization/path/vistoolcutsplinepath.h
+++ b/src/libs/vtools/visualization/path/vistoolcutsplinepath.h
@@ -69,10 +69,10 @@ public:
     explicit VisToolCutSplinePath(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolCutSplinePath() Q_DECL_EQ_DEFAULT;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
     void         setDirection(const QString &direction);
     void         setLength(const QString &expression);
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolCutSpline)};
 protected:
     Q_DISABLE_COPY(VisToolCutSplinePath)

--- a/src/libs/vtools/visualization/path/vistoolellipticalarc.h
+++ b/src/libs/vtools/visualization/path/vistoolellipticalarc.h
@@ -45,14 +45,14 @@ public:
     explicit VisToolEllipticalArc(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolEllipticalArc() Q_DECL_EQ_DEFAULT;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
     void setRadius1(const QString &expression);
     void setRadius2(const QString &expression);
     void setF1(const QString &expression);
     void setF2(const QString &expression);
     void setRotationAngle(const QString &expression);
 
-    virtual int type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolEllipticalArc)};
 private:
     Q_DISABLE_COPY(VisToolEllipticalArc)

--- a/src/libs/vtools/visualization/path/vistoolpointofintersectioncurves.h
+++ b/src/libs/vtools/visualization/path/vistoolpointofintersectioncurves.h
@@ -70,14 +70,14 @@ public:
     explicit VisToolPointOfIntersectionCurves(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolPointOfIntersectionCurves() Q_DECL_EQ_DEFAULT;
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
-    virtual void VisualMode(const quint32 &id) Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
+    virtual void VisualMode(const quint32 &id) override;
 
     void setObject2Id(const quint32 &value);
     void setVCrossPoint(const VCrossCurvesPoint &value);
     void setHCrossPoint(const HCrossCurvesPoint &value);
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolPointOfIntersectionCurves)};
 private:
     Q_DISABLE_COPY(VisToolPointOfIntersectionCurves)

--- a/src/libs/vtools/visualization/path/vistoolspline.h
+++ b/src/libs/vtools/visualization/path/vistoolspline.h
@@ -73,7 +73,7 @@ public:
     explicit VisToolSpline(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolSpline();
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
 
     void         setObject4Id(const quint32 &value);
     void         SetAngle1(const qreal &value);
@@ -85,7 +85,7 @@ public:
     QPointF      GetP2() const;
     QPointF      GetP3() const;
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolSpline)};
 public slots:
     void MouseLeftPressed();

--- a/src/libs/vtools/visualization/path/vistoolsplinepath.h
+++ b/src/libs/vtools/visualization/path/vistoolsplinepath.h
@@ -74,12 +74,12 @@ public:
     explicit VisToolSplinePath(const VContainer *data, QGraphicsItem *parent = nullptr);
     virtual ~VisToolSplinePath();
 
-    virtual void RefreshGeometry() Q_DECL_OVERRIDE;
+    virtual void RefreshGeometry() override;
 
     void         setPath(const VSplinePath &value);
     VSplinePath  getPath();
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::ToolSplinePath)};
 signals:
     void PathChanged(const VSplinePath &path);

--- a/src/libs/vwidgets/group_tablewidgetitem.h
+++ b/src/libs/vwidgets/group_tablewidgetitem.h
@@ -37,7 +37,7 @@ class GroupTableWidgetItem : public QTableWidgetItem
 
 public:
     explicit     GroupTableWidgetItem(VAbstractPattern *doc);
-    virtual bool operator<(const QTableWidgetItem &other) const Q_DECL_OVERRIDE;
+    virtual bool operator<(const QTableWidgetItem &other) const override;
 
 private:
     VAbstractPattern *m_doc;

--- a/src/libs/vwidgets/nonscalingfill_pathitem.h
+++ b/src/libs/vwidgets/nonscalingfill_pathitem.h
@@ -66,9 +66,9 @@ public:
 
 protected:
     virtual void paint(QPainter * painter, const QStyleOptionGraphicsItem * option,
-                       QWidget * widget = nullptr) Q_DECL_OVERRIDE;
+                       QWidget * widget = nullptr) override;
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum         {Type = UserType + static_cast<int>(Vis::NoBrush)};
 
 private:

--- a/src/libs/vwidgets/piece_tablewidgetitem.h
+++ b/src/libs/vwidgets/piece_tablewidgetitem.h
@@ -34,7 +34,7 @@ class PieceTableWidgetItem : public QTableWidgetItem
 
 public:
     explicit     PieceTableWidgetItem(VContainer *data);
-    virtual bool operator<(const QTableWidgetItem &other) const Q_DECL_OVERRIDE;
+    virtual bool operator<(const QTableWidgetItem &other) const override;
 
 private:
     VContainer  *m_data;

--- a/src/libs/vwidgets/resize_handle.h
+++ b/src/libs/vwidgets/resize_handle.h
@@ -54,13 +54,13 @@ private:
         protected:
             void                paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr) override;
 
-            virtual QVariant    itemChange(GraphicsItemChange change, const QVariant &value) Q_DECL_OVERRIDE;
-            virtual void        hoverEnterEvent (QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-            virtual void        hoverLeaveEvent (QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-            virtual void        mousePressEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-            virtual void        mouseMoveEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-            virtual void        mouseReleaseEvent (QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-            virtual void        keyReleaseEvent (QKeyEvent *event) Q_DECL_OVERRIDE;
+            virtual QVariant    itemChange(GraphicsItemChange change, const QVariant &value) override;
+            virtual void        hoverEnterEvent (QGraphicsSceneHoverEvent *event) override;
+            virtual void        hoverLeaveEvent (QGraphicsSceneHoverEvent *event) override;
+            virtual void        mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+            virtual void        mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
+            virtual void        mouseReleaseEvent (QGraphicsSceneMouseEvent *event) override;
+            virtual void        keyReleaseEvent (QKeyEvent *event) override;
 
         private:
             QPointF            limitPosition(const QPointF &newPos);
@@ -77,7 +77,7 @@ public:
     explicit           ResizeHandlesItem(QGraphicsItem *parent = nullptr, qreal minDimension = 16, qreal maxDimension = 16000);
     virtual           ~ResizeHandlesItem() = default;
 
-    virtual int        type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int        type() const override {return Type;}
     enum               {Type = UserType + static_cast<int>(Vis::ResizeHandlesItem)};
 
     QRectF             boundingRect() const override;

--- a/src/libs/vwidgets/scalesceneitems.h
+++ b/src/libs/vwidgets/scalesceneitems.h
@@ -65,11 +65,11 @@ public:
                     VScaledLine(const QLineF &line, QGraphicsItem * parent = nullptr);
     virtual        ~VScaledLine() = default;
 
-    virtual int     type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int     type() const override {return Type;}
     enum            {Type = UserType + static_cast<int>(Vis::ScaledLine)};
 
     virtual void    paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-                          QWidget *widget = nullptr) Q_DECL_OVERRIDE;
+                          QWidget *widget = nullptr) override;
 
     qreal           getDefaultWidth() const;
     void            setDefaultWidth(const qreal &value);
@@ -87,11 +87,11 @@ public:
                     ArrowedLineItem(const QLineF &line, QGraphicsItem * parent = nullptr);
     virtual        ~ArrowedLineItem() = default;
 
-    virtual int     type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int     type() const override {return Type;}
     enum            {Type = UserType + static_cast<int>(Vis::ArrowedLineItem)};
 
     virtual void    paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-                          QWidget *widget = nullptr) Q_DECL_OVERRIDE;
+                          QWidget *widget = nullptr) override;
 
 private:
     Q_DISABLE_COPY(ArrowedLineItem)
@@ -105,11 +105,11 @@ public:
     explicit        VScaledEllipse(QGraphicsItem * parent = nullptr);
     virtual        ~VScaledEllipse() = default;
 
-    virtual int     type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int     type() const override {return Type;}
     enum            {Type = UserType + static_cast<int>(Vis::ScaledEllipse)};
 
     virtual void    paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-                          QWidget *widget = nullptr) Q_DECL_OVERRIDE;
+                          QWidget *widget = nullptr) override;
 private:
     Q_DISABLE_COPY(VScaledEllipse)
 };

--- a/src/libs/vwidgets/scene_rect.h
+++ b/src/libs/vwidgets/scene_rect.h
@@ -37,11 +37,11 @@ public:
     explicit      SceneRect(const QColor &lineColor, QGraphicsItem *parent = nullptr);
     virtual      ~SceneRect() = default;
     
-    virtual int   type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int   type() const override {return Type;}
     enum          {Type = UserType + static_cast<int>(Vis::ScenePoint)};
 
     virtual void  paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-                        QWidget *widget = nullptr) Q_DECL_OVERRIDE;
+                        QWidget *widget = nullptr) override;
     virtual void  refreshPointGeometry(const VPointF &point);
 
 protected:
@@ -50,8 +50,8 @@ protected:
     bool          m_isHovered;
     bool          m_showPointName;
 
-    virtual void  hoverEnterEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    virtual void  hoverLeaveEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
+    virtual void  hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
+    virtual void  hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
 
     void          setOnlyPoint(bool value);
     bool          isOnlyPoint() const;

--- a/src/libs/vwidgets/vcontrolpointspline.h
+++ b/src/libs/vwidgets/vcontrolpointspline.h
@@ -77,11 +77,11 @@ public:
                                             QGraphicsItem *parent = nullptr);
     virtual            ~VControlPointSpline() = default;
 
-    virtual int         type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int         type() const override {return Type;}
     enum                { Type = UserType + static_cast<int>(Vis::ControlPointSpline)};
 
     virtual void        paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-                              QWidget *widget = nullptr) Q_DECL_OVERRIDE;
+                              QWidget *widget = nullptr) override;
 signals:
     // @brief controlPointPositionChanged emit when control point change position.
     // @param splineIndex index spline in list.
@@ -102,12 +102,12 @@ public slots:
 protected:
     VScaledLine        *m_controlLine; /*!< @brief m_controlLine pointer to line control point. */
 
-    virtual void        hoverEnterEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    virtual void        hoverLeaveEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    QVariant            itemChange(GraphicsItemChange change, const QVariant &value) Q_DECL_OVERRIDE;
-    virtual void        mousePressEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void        mouseReleaseEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void        contextMenuEvent(QGraphicsSceneContextMenuEvent *event) Q_DECL_OVERRIDE;
+    virtual void        hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
+    virtual void        hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
+    QVariant            itemChange(GraphicsItemChange change, const QVariant &value) override;
+    virtual void        mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+    virtual void        mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
+    virtual void        contextMenuEvent(QGraphicsSceneContextMenuEvent *event) override;
 
 private:
     Q_DISABLE_COPY(VControlPointSpline)

--- a/src/libs/vwidgets/vcurvepathitem.h
+++ b/src/libs/vwidgets/vcurvepathitem.h
@@ -62,12 +62,12 @@ public:
     explicit             VCurvePathItem(QGraphicsItem *parent = nullptr);
     virtual             ~VCurvePathItem() = default;
 
-    virtual QPainterPath shape() const Q_DECL_OVERRIDE;
+    virtual QPainterPath shape() const override;
 
     virtual void         paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-                               QWidget *widget = nullptr) Q_DECL_OVERRIDE;
+                               QWidget *widget = nullptr) override;
 
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum                 {Type = UserType + static_cast<int>(Vis::CurvePathItem)};
 
     void                 SetDirectionArrows(const QVector<QPair<QLineF, QLineF>> &arrows);

--- a/src/libs/vwidgets/vgrainlineitem.h
+++ b/src/libs/vwidgets/vgrainlineitem.h
@@ -62,12 +62,12 @@ public:
     explicit             VGrainlineItem(QGraphicsItem* parent = nullptr);
     virtual             ~VGrainlineItem() Q_DECL_EQ_DEFAULT;
 
-    virtual QPainterPath shape() const Q_DECL_OVERRIDE;
+    virtual QPainterPath shape() const override;
 
-    virtual void         paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) Q_DECL_OVERRIDE;
+    virtual void         paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) override;
     void                 updateGeometry(const QPointF& pos, qreal rotation, qreal length, ArrowType type, qreal arrowLength);
 
-    virtual int          type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int          type() const override {return Type;}
     enum                 {Type = UserType + static_cast<int>(Vis::GrainlineItem)};
 
     bool                 isContained(const QPointF &pt, qreal dRot, qreal &dX, qreal &dY) const;
@@ -77,15 +77,15 @@ signals:
     void                 itemRotated(qreal dRot, const QPointF& ptNewPos);
 
 protected:
-    virtual void         mousePressEvent(QGraphicsSceneMouseEvent* pME) Q_DECL_OVERRIDE;
-    virtual void         mouseMoveEvent(QGraphicsSceneMouseEvent* pME) Q_DECL_OVERRIDE;
-    virtual void         mouseReleaseEvent(QGraphicsSceneMouseEvent* pME) Q_DECL_OVERRIDE;
-    virtual void         hoverEnterEvent(QGraphicsSceneHoverEvent* pME) Q_DECL_OVERRIDE;
-    virtual void         hoverLeaveEvent(QGraphicsSceneHoverEvent* pME) Q_DECL_OVERRIDE;
-    virtual void         updateItem() Q_DECL_OVERRIDE;
+    virtual void         mousePressEvent(QGraphicsSceneMouseEvent* pME) override;
+    virtual void         mouseMoveEvent(QGraphicsSceneMouseEvent* pME) override;
+    virtual void         mouseReleaseEvent(QGraphicsSceneMouseEvent* pME) override;
+    virtual void         hoverEnterEvent(QGraphicsSceneHoverEvent* pME) override;
+    virtual void         hoverLeaveEvent(QGraphicsSceneHoverEvent* pME) override;
+    virtual void         updateItem() override;
     void                 updateRectangle();
 
-    virtual double       GetAngle(const QPointF &pt) const Q_DECL_OVERRIDE;
+    virtual double       GetAngle(const QPointF &pt) const override;
 
     QPointF              rotate(const QPointF& pt, const QPointF& ptCenter, qreal dAng) const;
     QPointF              getInsideCorner(int i, qreal dDist) const;

--- a/src/libs/vwidgets/vgraphicssimpletextitem.h
+++ b/src/libs/vwidgets/vgraphicssimpletextitem.h
@@ -77,11 +77,11 @@ public:
     virtual         ~VGraphicsSimpleTextItem() =default;
 
     qint32           BaseFontSize()const;
-    virtual int      type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int      type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::GraphicsSimpleTextItem)};
 
     virtual void     paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-                           QWidget *widget = nullptr) Q_DECL_OVERRIDE;
+                           QWidget *widget = nullptr) override;
 
     void             setEnabled(bool enabled);
     void             textSelectionType(const SelectionType &type);
@@ -108,13 +108,13 @@ signals:
     void             pointSelected(bool selected);
 
 protected:
-    virtual QVariant itemChange (GraphicsItemChange change, const QVariant &value ) Q_DECL_OVERRIDE;
-    virtual void     hoverEnterEvent (QGraphicsSceneHoverEvent *event ) Q_DECL_OVERRIDE;
-    virtual void     hoverLeaveEvent (QGraphicsSceneHoverEvent *event ) Q_DECL_OVERRIDE;
-    virtual void     contextMenuEvent (QGraphicsSceneContextMenuEvent *event ) Q_DECL_OVERRIDE;
-    virtual void     mousePressEvent(QGraphicsSceneMouseEvent * event ) Q_DECL_OVERRIDE;
-    virtual void     mouseReleaseEvent (QGraphicsSceneMouseEvent * event ) Q_DECL_OVERRIDE;
-    virtual void     keyReleaseEvent (QKeyEvent * event ) Q_DECL_OVERRIDE;
+    virtual QVariant itemChange (GraphicsItemChange change, const QVariant &value ) override;
+    virtual void     hoverEnterEvent (QGraphicsSceneHoverEvent *event ) override;
+    virtual void     hoverLeaveEvent (QGraphicsSceneHoverEvent *event ) override;
+    virtual void     contextMenuEvent (QGraphicsSceneContextMenuEvent *event ) override;
+    virtual void     mousePressEvent(QGraphicsSceneMouseEvent * event ) override;
+    virtual void     mouseReleaseEvent (QGraphicsSceneMouseEvent * event ) override;
+    virtual void     keyReleaseEvent (QKeyEvent * event ) override;
 
 private:
     /** @brief fontSize label font size. */

--- a/src/libs/vwidgets/vlineedit.h
+++ b/src/libs/vwidgets/vlineedit.h
@@ -62,9 +62,9 @@ public:
     VLineEdit(const QString &contents, QWidget *parent = nullptr);
 
 protected:
-    virtual void focusInEvent(QFocusEvent *e) Q_DECL_OVERRIDE;
-    virtual void focusOutEvent(QFocusEvent *e) Q_DECL_OVERRIDE;
-    virtual void mousePressEvent(QMouseEvent *e) Q_DECL_OVERRIDE;
+    virtual void focusInEvent(QFocusEvent *e) override;
+    virtual void focusOutEvent(QFocusEvent *e) override;
+    virtual void mousePressEvent(QMouseEvent *e) override;
 private:
     Q_DISABLE_COPY(VLineEdit)
     bool m_selectOnMousePress;

--- a/src/libs/vwidgets/vmaingraphicsscene.h
+++ b/src/libs/vwidgets/vmaingraphicsscene.h
@@ -119,9 +119,9 @@ public slots:
     void          togglePieceHover(bool enabled);
 
 protected:
-    virtual void  mouseMoveEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void  mousePressEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void  mouseReleaseEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
+    virtual void  mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
+    virtual void  mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+    virtual void  mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
 
 signals:
     /**

--- a/src/libs/vwidgets/vmaingraphicsview.h
+++ b/src/libs/vwidgets/vmaingraphicsview.h
@@ -118,7 +118,7 @@ public slots:
     void                  animFinished();
 
 protected:
-    virtual bool          eventFilter(QObject* object, QEvent* event) Q_DECL_OVERRIDE;
+    virtual bool          eventFilter(QObject* object, QEvent* event) override;
 
 private:
     Q_DISABLE_COPY(GraphicsViewZoom)
@@ -199,10 +199,10 @@ public slots:
     void                  resetScrollAnimations();
 
 protected:
-    virtual void          mousePressEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void          mouseMoveEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void          mouseReleaseEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void          mouseDoubleClickEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
+    virtual void          mousePressEvent(QMouseEvent *event) override;
+    virtual void          mouseMoveEvent(QMouseEvent *event) override;
+    virtual void          mouseReleaseEvent(QMouseEvent *event) override;
+    virtual void          mouseDoubleClickEvent(QMouseEvent *event) override;
 
     QSharedPointer<QCursor> curMagnifier;
 

--- a/src/libs/vwidgets/vpieceitem.h
+++ b/src/libs/vwidgets/vpieceitem.h
@@ -74,7 +74,7 @@ public:
     explicit              VPieceItem(QGraphicsItem* pParent = nullptr);
     virtual              ~VPieceItem();
 
-    virtual QRectF        boundingRect() const Q_DECL_OVERRIDE;
+    virtual QRectF        boundingRect() const override;
 
     virtual void          updateItem() =0;
 
@@ -84,7 +84,7 @@ public:
     VPieceItem::MoveTypes getMoveType() const;
     void                  setMoveType(const VPieceItem::MoveTypes &moveType);
 
-    virtual int           type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int           type() const override {return Type;}
     enum                  {Type = UserType + static_cast<int>(Vis::PieceItem)};
 
 signals:

--- a/src/libs/vwidgets/vscenepoint.h
+++ b/src/libs/vwidgets/vscenepoint.h
@@ -66,11 +66,11 @@ class VScenePoint: public QGraphicsEllipseItem
 public:
     explicit                 VScenePoint(const QColor &lineColor, QGraphicsItem *parent = nullptr);
     virtual                 ~VScenePoint() = default;
-    virtual int              type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int              type() const override {return Type;}
                              enum { Type = UserType + static_cast<int>(Vis::ScenePoint)};
 
     virtual void             paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
-                                   QWidget *widget = nullptr) Q_DECL_OVERRIDE;
+                                   QWidget *widget = nullptr) override;
     virtual void             refreshPointGeometry(const VPointF &point);
 
     void                     refreshLeader();
@@ -84,8 +84,8 @@ protected:
     bool                     m_isHovered;
     bool                     m_showPointName;
 
-    virtual void             hoverEnterEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    virtual void             hoverLeaveEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
+    virtual void             hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
+    virtual void             hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
 
     void                     setOnlyPoint(bool value);
     bool                     isOnlyPoint() const;

--- a/src/libs/vwidgets/vsimplecurve.h
+++ b/src/libs/vwidgets/vsimplecurve.h
@@ -76,7 +76,7 @@ public:
     VSimpleCurve(quint32 id, const QSharedPointer<VAbstractCurve> &curve, QObject *parent = nullptr);
     virtual ~VSimpleCurve() Q_DECL_EQ_DEFAULT;
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::SimpleCurve)};
 
     void RefreshGeometry(const QSharedPointer<VAbstractCurve> &curve);
@@ -93,14 +93,14 @@ public slots:
     void CurveSelected(bool selected);
 
 protected:
-    virtual void     mousePressEvent( QGraphicsSceneMouseEvent * event ) Q_DECL_OVERRIDE;
-    virtual void     mouseReleaseEvent ( QGraphicsSceneMouseEvent * event ) Q_DECL_OVERRIDE;
-    virtual void     hoverEnterEvent ( QGraphicsSceneHoverEvent * event ) Q_DECL_OVERRIDE;
-    virtual void     hoverLeaveEvent ( QGraphicsSceneHoverEvent * event ) Q_DECL_OVERRIDE;
-    virtual QVariant itemChange ( GraphicsItemChange change, const QVariant &value ) Q_DECL_OVERRIDE;
-    virtual void     contextMenuEvent (QGraphicsSceneContextMenuEvent * event ) Q_DECL_OVERRIDE;
-    virtual void     keyReleaseEvent ( QKeyEvent * event ) Q_DECL_OVERRIDE;
-    virtual void     ScalePenWidth() Q_DECL_OVERRIDE;
+    virtual void     mousePressEvent( QGraphicsSceneMouseEvent * event ) override;
+    virtual void     mouseReleaseEvent ( QGraphicsSceneMouseEvent * event ) override;
+    virtual void     hoverEnterEvent ( QGraphicsSceneHoverEvent * event ) override;
+    virtual void     hoverLeaveEvent ( QGraphicsSceneHoverEvent * event ) override;
+    virtual QVariant itemChange ( GraphicsItemChange change, const QVariant &value ) override;
+    virtual void     contextMenuEvent (QGraphicsSceneContextMenuEvent * event ) override;
+    virtual void     keyReleaseEvent ( QKeyEvent * event ) override;
+    virtual void     ScalePenWidth() override;
 
 private:
     Q_DISABLE_COPY(VSimpleCurve)

--- a/src/libs/vwidgets/vsimplepoint.h
+++ b/src/libs/vwidgets/vsimplepoint.h
@@ -76,7 +76,7 @@ public:
     VSimplePoint(quint32 id, const QColor &currentColor, QObject *parent = nullptr);
     virtual ~VSimplePoint() = default;
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::SimplePoint)};
 
     using VScenePoint::setOnlyPoint;
@@ -91,7 +91,7 @@ public:
     void EnableToolMove(bool move);
     void allowTextHover(bool enabled);
     void allowTextSelectable(bool enabled);
-    virtual void ToolSelectionType(const SelectionType &type) Q_DECL_OVERRIDE;
+    virtual void ToolSelectionType(const SelectionType &type) override;
 
 signals:
     /**
@@ -109,13 +109,13 @@ public slots:
     void pointnameChangedPosition(const QPointF &pos);
 
 protected:
-    virtual void     mousePressEvent( QGraphicsSceneMouseEvent * event ) Q_DECL_OVERRIDE;
-    virtual void     mouseReleaseEvent ( QGraphicsSceneMouseEvent * event ) Q_DECL_OVERRIDE;
-    virtual void     hoverEnterEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    virtual void     hoverLeaveEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    virtual void     keyReleaseEvent ( QKeyEvent * event ) Q_DECL_OVERRIDE;
-    virtual QVariant itemChange ( GraphicsItemChange change, const QVariant &value ) Q_DECL_OVERRIDE;
-    virtual void     contextMenuEvent (QGraphicsSceneContextMenuEvent * event ) Q_DECL_OVERRIDE;
+    virtual void     mousePressEvent( QGraphicsSceneMouseEvent * event ) override;
+    virtual void     mouseReleaseEvent ( QGraphicsSceneMouseEvent * event ) override;
+    virtual void     hoverEnterEvent(QGraphicsSceneHoverEvent *event) override;
+    virtual void     hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
+    virtual void     keyReleaseEvent ( QKeyEvent * event ) override;
+    virtual QVariant itemChange ( GraphicsItemChange change, const QVariant &value ) override;
+    virtual void     contextMenuEvent (QGraphicsSceneContextMenuEvent * event ) override;
 
 private:
     Q_DISABLE_COPY(VSimplePoint)

--- a/src/libs/vwidgets/vtextgraphicsitem.h
+++ b/src/libs/vwidgets/vtextgraphicsitem.h
@@ -55,10 +55,10 @@ public:
     explicit VTextGraphicsItem(QGraphicsItem* pParent = nullptr);
     virtual ~VTextGraphicsItem() Q_DECL_EQ_DEFAULT;
 
-    virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) Q_DECL_OVERRIDE;
-    virtual void updateItem() Q_DECL_OVERRIDE;
+    virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) override;
+    virtual void updateItem() override;
 
-    virtual int  type() const Q_DECL_OVERRIDE {return Type;}
+    virtual int  type() const override {return Type;}
     enum { Type = UserType + static_cast<int>(Vis::TextGraphicsItem)};
 
     void setFont(const QFont &font);
@@ -70,11 +70,11 @@ public:
     int  getTextLines() const;
 
 protected:
-    virtual void mousePressEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void mouseMoveEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) Q_DECL_OVERRIDE;
-    virtual void hoverMoveEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
-    virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) Q_DECL_OVERRIDE;
+    virtual void mousePressEvent(QGraphicsSceneMouseEvent *event) override;
+    virtual void mouseMoveEvent(QGraphicsSceneMouseEvent *event) override;
+    virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) override;
+    virtual void hoverMoveEvent(QGraphicsSceneHoverEvent *event) override;
+    virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent *event) override;
 
     void UpdateBox();
     void correctLabel();

--- a/src/test/TranslationsTest/tst_buitinregexp.h
+++ b/src/test/TranslationsTest/tst_buitinregexp.h
@@ -67,8 +67,8 @@ public:
     virtual ~TST_BuitInRegExp() Q_DECL_EQ_DEFAULT;
 
 protected:
-    virtual void        PrepareData() Q_DECL_OVERRIDE;
-    virtual QStringList AllNames() Q_DECL_OVERRIDE;
+    virtual void        PrepareData() override;
+    virtual QStringList AllNames() override;
 
 private slots:
     void initTestCase();

--- a/src/test/TranslationsTest/tst_measurementregexp.h
+++ b/src/test/TranslationsTest/tst_measurementregexp.h
@@ -69,8 +69,8 @@ public:
     static const quint32 systemCounts;
 
 protected:
-    virtual void        PrepareData() Q_DECL_OVERRIDE;
-    virtual QStringList AllNames() Q_DECL_OVERRIDE;
+    virtual void        PrepareData() override;
+    virtual QStringList AllNames() override;
 
 private slots:
     void initTestCase();

--- a/src/test/TranslationsTest/tst_qmuparsererrormsg.h
+++ b/src/test/TranslationsTest/tst_qmuparsererrormsg.h
@@ -63,7 +63,7 @@ class TST_QmuParserErrorMsg : public AbstractTest
     Q_OBJECT
 public:
     explicit TST_QmuParserErrorMsg(const QString &locale, QObject *parent = nullptr);
-    virtual ~TST_QmuParserErrorMsg() Q_DECL_OVERRIDE;
+    virtual ~TST_QmuParserErrorMsg() override;
 
 private slots:
     void initTestCase();


### PR DESCRIPTION
The following complier MACRO's are deprecated:

<img width="657" height="342" alt="image" src="https://github.com/user-attachments/assets/ed5b582b-a67f-4c77-a551-ccd126921fcb" />

This PR replaces the MACRO's with the proper keywords.