### PR TITLE
fix: pattern piece grainlines

### DIFF
--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.cpp
@@ -1,14 +1,15 @@
+//---------------------------------------------------------------------------------------------------------------------
 //  @file   preferencespatternpage.cpp
 //  @author Douglas S Caskey
 //  @date   26 Oct, 2023
 //
-//  @brief
 //  @copyright
 //  This source code is part of the Seamly2D project, a pattern making
 //  program to create and model patterns of clothing.
-//  Copyright (C) 2017-2024 Seamly2D project
+//  Copyright (C) 2017 - 2025 Seamly, LLC
 //  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
 //
+//  @brief
 //  Seamly2D is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
 //  the Free Software Foundation, either version 3 of the License, or
@@ -21,34 +22,33 @@
 //
 //  You should have received a copy of the GNU General Public License
 //  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
-/************************************************************************
- **
- **  @file   preferencespatternpage.cpp
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   12 4, 2017
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2017 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- **************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   preferencespatternpage.cpp
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   12 4, 2017
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2017 Valentina project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina. If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #include "preferencespatternpage.h"
 #include "ui_preferencespatternpage.h"
@@ -352,12 +352,12 @@ void PreferencesPatternPage::initNotches()
 //---------------------------------------------------------------------------------------------------------------------
 void PreferencesPatternPage::initGrainlines()
 {
-    setMaxByUnits(ui->defaultGrainlineLength_DoubleSpinBox, 20.000);
-
     ui->showGrainlines_CheckBox->setChecked(qApp->Seamly2DSettings()->getDefaultGrainlineVisibilty());
 
     ui->defaultGrainlineLength_DoubleSpinBox->setValue(qApp->Seamly2DSettings()->getDefaultGrainlineLength());
     ui->defaultGrainlineLength_DoubleSpinBox->setSuffix(" " + UnitsToStr(StrToUnits(qApp->Seamly2DSettings()->getUnit()), true));
+    setMaxByUnits(ui->defaultGrainlineLength_DoubleSpinBox, 40.000);
+    grainlineLengthChanged();
 
     int index = ui->defaultGrainlineColor_ComboBox->findData(qApp->Seamly2DSettings()->getDefaultGrainlineColor());
     if (index != -1)
@@ -370,7 +370,38 @@ void PreferencesPatternPage::initGrainlines()
         ui->defaultGrainlineLineweight_ComboBox->setCurrentIndex(index);
     }
 
-    ui->defaultArrowLength_DoubleSpinBox->setValue(qApp->Seamly2DSettings()->getDefaultArrowLength());
+    ui->defaultArrowLength_DoubleSpinBox->setValue(qApp->Settings()->getDefaultArrowLength());
+    arrowLengthChanged();
+
+    connect(ui->defaultArrowLength_DoubleSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+            this, &PreferencesPatternPage::arrowLengthChanged);
+
+    connect(ui->defaultGrainlineLength_DoubleSpinBox, QOverload<double>::of(&QDoubleSpinBox::valueChanged),
+            this, &PreferencesPatternPage::grainlineLengthChanged);
+}
+
+void PreferencesPatternPage::arrowLengthChanged()
+{
+    QString units = qApp->Seamly2DSettings()->getUnit();
+    qreal arrowLength = ui->defaultArrowLength_DoubleSpinBox->value();
+    qreal arrowLengthCalc = FromPixel(arrowLength, StrToUnits(units));
+    ui->arrowlengthCalc_Label->setText(QString::number(arrowLengthCalc, 'f', 3) + units);
+}
+
+void PreferencesPatternPage::grainlineLengthChanged()
+{
+    QString units = qApp->Seamly2DSettings()->getUnit();
+    qreal arrowLength = ui->defaultArrowLength_DoubleSpinBox->value();
+    qreal arrowLengthCalc = FromPixel(arrowLength, StrToUnits(units));
+
+    if (ui->defaultGrainlineLength_DoubleSpinBox->value() < arrowLengthCalc * 2)
+    {
+        changeColor(ui->grainlineLength_Label, Qt::red);
+    }
+    else
+    {
+        changeColor(ui->grainlineLength_Label, Qt::black);
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -388,6 +419,14 @@ void PreferencesPatternPage::initComboBoxFormats(QComboBox *box, const QStringLi
     {
         box->setCurrentIndex(0);
     }
+}
+
+void PreferencesPatternPage::changeColor(QWidget *widget, const QColor &color)
+{
+    SCASSERT(widget != nullptr)
+    QPalette palette = widget->palette();
+    palette.setColor(QPalette::Active, widget->foregroundRole(), color);
+    widget->setPalette(palette);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.h
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.h
@@ -1,57 +1,54 @@
-/******************************************************************************
-*   @file   preferencespatternpage.h
-**  @author Douglas S Caskey
-**  @date   26 Oct, 2023
-**
-**  @brief
-**  @copyright
-**  This source code is part of the Seamly2D project, a pattern making
-**  program to create and model patterns of clothing.
-**  Copyright (C) 2017-2023 Seamly2D project
-**  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
-**
-**  Seamly2D is free software: you can redistribute it and/or modify
-**  it under the terms of the GNU General Public License as published by
-**  the Free Software Foundation, either version 3 of the License, or
-**  (at your option) any later version.
-**
-**  Seamly2D is distributed in the hope that it will be useful,
-**  but WITHOUT ANY WARRANTY; without even the implied warranty of
-**  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-**  GNU General Public License for more details.
-**
-**  You should have received a copy of the GNU General Public License
-**  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
-**
-*************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   preferencespatternpage.h
+//  @author Douglas S Caskey
+//  @date   26 Oct, 2023
+//
+//  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
+//  Copyright (C) 2017 - 2025 Seamly, LLC
+//  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
+//
+//  @brief
+//  Seamly2D is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Seamly2D is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
-/************************************************************************
- **
- **  @file   preferencespatternpage.h
- **  @author Roman Telezhynskyi <dismine(at)gmail.com>
- **  @date   12 4, 2017
- **
- **  @brief
- **  @copyright
- **  This source code is part of the Valentine project, a pattern making
- **  program, whose allow create and modeling patterns of clothing.
- **  Copyright (C) 2017 Seamly2D project
- **  <https://github.com/fashionfreedom/seamly2d> All Rights Reserved.
- **
- **  Seamly2D is free software: you can redistribute it and/or modify
- **  it under the terms of the GNU General Public License as published by
- **  the Free Software Foundation, either version 3 of the License, or
- **  (at your option) any later version.
- **
- **  Seamly2D is distributed in the hope that it will be useful,
- **  but WITHOUT ANY WARRANTY; without even the implied warranty of
- **  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- **  GNU General Public License for more details.
- **
- **  You should have received a copy of the GNU General Public License
- **  along with Seamly2D.  If not, see <http://www.gnu.org/licenses/>.
- **
- *************************************************************************/
+//---------------------------------------------------------------------------------------------------------------------
+//  @file   preferencespatternpage.h
+//  @author Roman Telezhynskyi <dismine(at)gmail.com>
+//  @date   12 4, 2017
+//
+//  @brief
+//  @copyright
+//  This source code is part of the Valentina project, a pattern making
+//  program, whose allow create and modeling patterns of clothing.
+//  Copyright (C) 2017 Seamly2D project
+//  <https://bitbucket.org/dismine/valentina> All Rights Reserved.
+//
+//  Valentina is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  Valentina is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with Valentina.  If not, see <http://www.gnu.org/licenses/>.
+//---------------------------------------------------------------------------------------------------------------------
 
 #ifndef PREFERENCESPATTERNPAGE_H
 #define PREFERENCESPATTERNPAGE_H
@@ -91,7 +88,11 @@ private:
     void          initializeLabelsTab();
     void          initNotches();
     void          initGrainlines();
+    void          arrowLengthChanged();
+    void          grainlineLengthChanged();
     void          initComboBoxFormats(QComboBox *box, const QStringList &items, const QString &currentFormat);
+    void          changeColor(QWidget *widget, const QColor &color);
+
 
     template <typename T>
     void          callDateTimeFormatEditor(const T &type, const QStringList &predefinedFormats,

--- a/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
+++ b/src/app/seamly2d/dialogs/configpages/preferencespatternpage.ui
@@ -117,6 +117,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="text">
@@ -138,6 +139,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="toolTip">
@@ -165,6 +167,7 @@
               <property name="font">
                <font>
                 <pointsize>9</pointsize>
+                <bold>true</bold>
                </font>
               </property>
               <property name="toolTip">
@@ -241,6 +244,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="text">
@@ -259,6 +263,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="toolTip">
@@ -288,6 +293,7 @@
          </property>
          <property name="font">
           <font>
+           <pointsize>9</pointsize>
            <bold>true</bold>
           </font>
          </property>
@@ -310,6 +316,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -343,6 +350,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="styleSheet">
@@ -381,6 +389,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -400,7 +409,10 @@
                  </size>
                 </property>
                 <property name="font">
-                 <font/>
+                 <font>
+                  <pointsize>9</pointsize>
+                  <bold>true</bold>
+                 </font>
                 </property>
                 <property name="styleSheet">
                  <string notr="true"/>
@@ -447,6 +459,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -480,6 +493,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="styleSheet">
@@ -545,6 +559,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -578,6 +593,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="styleSheet">
@@ -692,6 +708,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="toolTip">
@@ -699,6 +716,9 @@
             </property>
             <property name="text">
              <string>Show grainlines</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -729,6 +749,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>false</bold>
              </font>
             </property>
             <property name="text">
@@ -749,7 +770,7 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>200</width>
+              <width>150</width>
               <height>20</height>
              </size>
             </property>
@@ -762,6 +783,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>false</bold>
              </font>
             </property>
             <property name="styleSheet">
@@ -777,7 +799,7 @@
              <double>1.000000000000000</double>
             </property>
             <property name="maximum">
-             <double>20.000000000000000</double>
+             <double>40.000000000000000</double>
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
@@ -821,6 +843,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>false</bold>
              </font>
             </property>
             <property name="text">
@@ -841,13 +864,14 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>200</width>
+              <width>150</width>
               <height>20</height>
              </size>
             </property>
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>false</bold>
              </font>
             </property>
             <property name="styleSheet">
@@ -889,6 +913,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>false</bold>
              </font>
             </property>
             <property name="text">
@@ -909,7 +934,7 @@
             </property>
             <property name="minimumSize">
              <size>
-              <width>200</width>
+              <width>150</width>
               <height>20</height>
              </size>
             </property>
@@ -922,6 +947,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>false</bold>
              </font>
             </property>
             <property name="styleSheet">
@@ -931,6 +957,12 @@
           </item>
           <item>
            <widget class="QLabel" name="label_2">
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+              <bold>false</bold>
+             </font>
+            </property>
             <property name="text">
              <string>x 3</string>
             </property>
@@ -970,6 +1002,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>false</bold>
              </font>
             </property>
             <property name="text">
@@ -984,9 +1017,15 @@
            <widget class="QDoubleSpinBox" name="defaultArrowLength_DoubleSpinBox">
             <property name="minimumSize">
              <size>
-              <width>200</width>
+              <width>150</width>
               <height>20</height>
              </size>
+            </property>
+            <property name="font">
+             <font>
+              <pointsize>9</pointsize>
+              <bold>false</bold>
+             </font>
             </property>
             <property name="styleSheet">
              <string notr="true"/>
@@ -1001,13 +1040,26 @@
              <number>0</number>
             </property>
             <property name="minimum">
-             <double>25.000000000000000</double>
+             <double>18.000000000000000</double>
             </property>
             <property name="maximum">
              <double>200.000000000000000</double>
             </property>
             <property name="value">
-             <double>70.000000000000000</double>
+             <double>48.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="arrowlengthCalc_Label">
+            <property name="font">
+             <font>
+              <pointsize>10</pointsize>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string notr="true">calc</string>
             </property>
            </widget>
           </item>
@@ -1089,6 +1141,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="text">
@@ -1122,6 +1175,7 @@
             <property name="font">
              <font>
               <pointsize>9</pointsize>
+              <bold>true</bold>
              </font>
             </property>
             <property name="styleSheet">
@@ -1184,6 +1238,7 @@
        </property>
        <property name="font">
         <font>
+         <pointsize>9</pointsize>
          <bold>true</bold>
         </font>
        </property>
@@ -1214,6 +1269,7 @@
         <property name="font">
          <font>
           <pointsize>9</pointsize>
+          <bold>true</bold>
          </font>
         </property>
         <property name="currentIndex">
@@ -1245,6 +1301,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -1272,6 +1329,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="styleSheet">
@@ -1313,6 +1371,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -1340,6 +1399,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="styleSheet">
@@ -1381,6 +1441,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -1414,6 +1475,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="styleSheet">
@@ -1472,6 +1534,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -1499,6 +1562,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                </widget>
@@ -1531,6 +1595,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -1558,6 +1623,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                </widget>
@@ -1596,6 +1662,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -1629,6 +1696,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                </widget>
@@ -1678,6 +1746,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -1705,6 +1774,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                </widget>
@@ -1743,6 +1813,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -1770,6 +1841,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                </widget>
@@ -1808,6 +1880,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -1841,6 +1914,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                </widget>
@@ -1890,6 +1964,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -1917,6 +1992,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                </widget>
@@ -1955,6 +2031,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -1982,6 +2059,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                </widget>
@@ -2020,6 +2098,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                 <property name="text">
@@ -2053,6 +2132,7 @@
                 <property name="font">
                  <font>
                   <pointsize>9</pointsize>
+                  <bold>true</bold>
                  </font>
                 </property>
                </widget>
@@ -2753,14 +2833,14 @@
    <header location="global">color_combobox.h</header>
   </customwidget>
   <customwidget>
-   <class>LineTypeComboBox</class>
-   <extends>QComboBox</extends>
-   <header location="global">linetype_combobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>LineWeightComboBox</class>
    <extends>QComboBox</extends>
    <header location="global">lineweight_combobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>LineTypeComboBox</class>
+   <extends>QComboBox</extends>
+   <header location="global">linetype_combobox.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.cpp
@@ -4,6 +4,8 @@
 //  @date   17 Sep, 2023
 //
 //  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
 //  Copyright (C) 2017 - 2025 Seamly, LLC
 //  https://github.com/fashionfreedom/seamly2d
 //
@@ -113,6 +115,7 @@ PatternPieceDialog::PatternPieceDialog(const VContainer *data, const quint32 &to
     , ui(new Ui::PatternPieceDialog)
     , applyAllowed(false)// By default disabled
     , flagGrainlineAnchor(true)
+    , flagGrainlineArrow(true)
     , flagPieceLabelAnchor(true)
     , flagPatternLabelAnchor(true)
     , flagGrainlineFormula(true)
@@ -346,7 +349,7 @@ void PatternPieceDialog::SetPiece(const VPiece &piece)
     setPatternLabelAngle(m_oldGeom.getRotation());
 
     m_oldGrainline = piece.GetGrainlineGeometry();
-    ui->grainline_GroupBox->setChecked(m_oldGrainline.IsVisible());
+    ui->showGrainline_CheckBox->setChecked(m_oldGrainline.IsVisible());
     ui->anchorPoints_GroupBox->setEnabled(m_oldGrainline.IsVisible());
     ui->arrows_GroupBox->setEnabled(m_oldGrainline.IsVisible());
     changeCurrentData(ui->grainlineCenterAnchor_ComboBox, m_oldGrainline.centerAnchorPoint());
@@ -544,7 +547,7 @@ void PatternPieceDialog::CheckState()
     ok_Button->setEnabled(flagName
                     && flagFormula
                     && flagMainPath
-                    && (flagGrainlineFormula || flagGrainlineAnchor)
+                    && flagGrainlineArrow && (flagGrainlineFormula || flagGrainlineAnchor)
                     && flagPieceLabelAngle && (flagPieceLabelFormula || flagPieceLabelAnchor)
                     && flagPatternLabelAngle && (flagPatternLabelFormula || flagPatternLabelAnchor));
 
@@ -1112,7 +1115,7 @@ void PatternPieceDialog::enableSeamAllowance(bool enable)
     }
     else
     {
-        ui->builtIn_CheckBox->toggled(ui->builtIn_CheckBox->isChecked());
+        emit ui->builtIn_CheckBox->toggled(ui->builtIn_CheckBox->isChecked());
     }
 }
 
@@ -1787,8 +1790,9 @@ void PatternPieceDialog::updateGrainlineValues()
         labelValue->setText(formulaValueStr);
     }
 
-    flagGrainlineFormula = formulasOK[0] && formulasOK[1] && formulasOK[2];
-    if (!flagGrainlineFormula && !flagGrainlineAnchor)
+    flagGrainlineArrow = formulasOK[2];
+    flagGrainlineFormula = formulasOK[0] && formulasOK[1];
+    if (!flagGrainlineArrow || !(flagGrainlineFormula || flagGrainlineAnchor))
     {
         setErrorText(TabOrder::Grainline, tr("Grainline"));
     }
@@ -1972,10 +1976,12 @@ void PatternPieceDialog::updatePatternLabelValues()
 //---------------------------------------------------------------------------------------------------------------------
 void PatternPieceDialog::enabledGrainline()
 {
-    ui->anchorPoints_GroupBox->setEnabled(ui->grainline_GroupBox->isChecked());
-    ui->arrows_GroupBox->setEnabled(ui->grainline_GroupBox->isChecked());
+    bool showGrainline = ui->showGrainline_CheckBox->isChecked();
+    ui->grainlineGeometry_GroupBox->setEnabled(showGrainline);
+    ui->anchorPoints_GroupBox->setEnabled(showGrainline);
+    ui->arrows_GroupBox->setEnabled(showGrainline);
 
-    if (ui->grainline_GroupBox->isChecked() == true)
+    if (showGrainline)
     {
         updateGrainlineValues();
         grainlineAnchorChanged();
@@ -1983,6 +1989,7 @@ void PatternPieceDialog::enabledGrainline()
     else
     {
         flagGrainlineFormula = true;
+        flagGrainlineArrow = true;
         resetGrainlineWarning();
         CheckState();
     }
@@ -2206,7 +2213,7 @@ void PatternPieceDialog::editPatternLabelFormula()
 //---------------------------------------------------------------------------------------------------------------------
 void PatternPieceDialog::resetGrainlineWarning()
 {
-    if (flagGrainlineFormula || flagGrainlineAnchor)
+    if (flagGrainlineArrow && (flagGrainlineFormula || flagGrainlineAnchor))
     {
         clearErrorText(TabOrder::Grainline, tr("Grainline "));
     }
@@ -2361,7 +2368,11 @@ void PatternPieceDialog::grainlineAnchorChanged()
     QColor color = okColor;
     const quint32 topAnchorId = getCurrentObjectId(ui->grainlineTopAnchor_ComboBox);
     const quint32 bottomAnchorId = getCurrentObjectId(ui->grainlineBottomAnchor_ComboBox);
-    if (topAnchorId != NULL_ID && bottomAnchorId != NULL_ID && topAnchorId != bottomAnchorId)
+    bool enabled = topAnchorId != NULL_ID && bottomAnchorId != NULL_ID && topAnchorId != bottomAnchorId;
+
+    ui->grainlineGeometry_GroupBox->setEnabled(!enabled);
+
+    if (enabled)
     {
         flagGrainlineAnchor = true;
         color = okColor;
@@ -2373,7 +2384,7 @@ void PatternPieceDialog::grainlineAnchorChanged()
         flagGrainlineAnchor = false;
         topAnchorId == NULL_ID && bottomAnchorId == NULL_ID ? color = okColor : color = errorColor;
 
-        if (!flagGrainlineFormula && !flagGrainlineAnchor)
+        if (!flagGrainlineArrow || !(flagGrainlineFormula || flagGrainlineAnchor))
         {
             ui->menuTab_ListWidget->item(TabOrder::Grainline)->setText(QString(tr("Grainline")));
         }
@@ -2529,7 +2540,7 @@ VPiece PatternPieceDialog::CreatePiece() const
     piece.GetPatternInfo().setBottomRightAnchorPoint(getCurrentObjectId(ui->patternLabelBottomRightAnchor_ComboBox));
 
     piece.GetGrainlineGeometry() = m_oldGrainline;
-    piece.GetGrainlineGeometry().SetVisible(ui->grainline_GroupBox->isChecked());
+    piece.GetGrainlineGeometry().SetVisible(ui->showGrainline_CheckBox->isChecked());
     piece.GetGrainlineGeometry().setRotation(getFormulaFromUser(ui->rotationFormula_LineEdit));
     piece.GetGrainlineGeometry().setLength(getFormulaFromUser(ui->lengthFormula_LineEdit));
     piece.GetGrainlineGeometry().setArrowLength(getFormulaFromUser(ui->arrowlLengthFormula_LineEdit));
@@ -2981,8 +2992,8 @@ void PatternPieceDialog::initializeSeamAllowanceTab()
     m_timerWidthAfter = new QTimer(this);
     connect(m_timerWidthAfter, &QTimer::timeout, this, &PatternPieceDialog::evaluateAfterWidth);
 
-    connect(ui->seams_CheckBox, &QCheckBox::toggled, this, &PatternPieceDialog::enableSeamAllowance);
-    connect(ui->builtIn_CheckBox, &QCheckBox::toggled, this, &PatternPieceDialog::enableBuiltIn);
+    connect(ui->seams_CheckBox,   &QCheckBox::stateChanged, this, &PatternPieceDialog::enableSeamAllowance);
+    connect(ui->builtIn_CheckBox, &QCheckBox::stateChanged, this, &PatternPieceDialog::enableBuiltIn);
 
     // Initialize the default seam allowance, convert the value if app unit is different than pattern unit
     m_saWidth = UnitConvertor(qApp->Settings()->GetDefaultSeamAllowance(),
@@ -3148,7 +3159,7 @@ void PatternPieceDialog::initializeLabelsTab()
     {
         VLabelTemplate labelTemplate;
         QString filename = qApp->Settings()->getDefaultPieceTemplate();
-        if (QFileInfo(filename).exists())
+        if (QFileInfo::exists(filename))
         {
             labelTemplate.setXMLContent(VLabelTemplateConverter(filename).Convert());
             m_pieceLabelLines = labelTemplate.ReadLines();
@@ -3212,19 +3223,26 @@ void PatternPieceDialog::initializeLabelsTab()
 //---------------------------------------------------------------------------------------------------------------------
 void PatternPieceDialog::initializeGrainlineTab()
 {
-    ui->grainline_GroupBox->setChecked(qApp->Settings()->getDefaultGrainlineVisibilty());
-    ui->anchorPoints_GroupBox->setEnabled(qApp->Settings()->getDefaultGrainlineVisibilty());
-    ui->arrows_GroupBox->setEnabled(qApp->Settings()->getDefaultGrainlineVisibilty());
-
-    ui->lengthFormula_LineEdit->setPlainText(QString::number(qApp->Settings()->getDefaultGrainlineLength()));
+    bool enabled = qApp->Settings()->getDefaultGrainlineVisibilty();
+    ui->showGrainline_CheckBox->setChecked(enabled);
+    ui->grainlineGeometry_GroupBox->setEnabled(enabled);
+    ui->anchorPoints_GroupBox->setEnabled(enabled);
+    ui->arrows_GroupBox->setEnabled(enabled);
 
     qreal arrowLength = FromPixel(qApp->Settings()->getDefaultArrowLength(), *data->GetPatternUnit());
     ui->arrowlLengthFormula_LineEdit->setPlainText(QString::number(arrowLength));
 
-    connect(ui->grainline_GroupBox,     &QGroupBox::toggled,   this, &PatternPieceDialog::enabledGrainline);
-    connect(ui->rotation_PushButton,    &QPushButton::clicked, this, &PatternPieceDialog::editGrainlineFormula);
-    connect(ui->length_PushButton,      &QPushButton::clicked, this, &PatternPieceDialog::editGrainlineFormula);
-    connect(ui->arrowLength_PushButton, &QPushButton::clicked, this, &PatternPieceDialog::editGrainlineFormula);
+    qreal grainlineLength = qApp->Settings()->getDefaultGrainlineLength();
+    if (grainlineLength < arrowLength * 2)
+    {
+        grainlineLength = arrowLength * 2.1;
+    }
+    ui->lengthFormula_LineEdit->setPlainText(QString::number(grainlineLength));
+
+    connect(ui->showGrainline_CheckBox, &QCheckBox::stateChanged, this, &PatternPieceDialog::enabledGrainline);
+    connect(ui->rotation_PushButton,    &QPushButton::clicked,    this, &PatternPieceDialog::editGrainlineFormula);
+    connect(ui->length_PushButton,      &QPushButton::clicked,    this, &PatternPieceDialog::editGrainlineFormula);
+    connect(ui->arrowLength_PushButton, &QPushButton::clicked,    this, &PatternPieceDialog::editGrainlineFormula);
     connect(ui->lengthFormula_LineEdit, &QPlainTextEdit::textChanged,
             this, &PatternPieceDialog::updateGrainlineValues);
     connect(ui->rotationFormula_LineEdit, &QPlainTextEdit::textChanged,
@@ -3252,6 +3270,13 @@ void PatternPieceDialog::initializeGrainlineTab()
 //---------------------------------------------------------------------------------------------------------------------
 void PatternPieceDialog::initializeAnchorsTab()
 {
+    const quint32 topAnchorId = getCurrentObjectId(ui->grainlineTopAnchor_ComboBox);
+    const quint32 bottomAnchorId = getCurrentObjectId(ui->grainlineBottomAnchor_ComboBox);
+
+    if (topAnchorId != NULL_ID && bottomAnchorId != NULL_ID && topAnchorId != bottomAnchorId)
+    {
+        ui->grainlineGeometry_GroupBox->setEnabled(false);
+    }
     ui->anchorPoints_ListWidget->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui->anchorPoints_ListWidget, &QListWidget::customContextMenuRequested, this,
             &PatternPieceDialog::showAnchorsContextMenu);

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.h
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.h
@@ -4,6 +4,8 @@
 //  @date   17 Sep, 2023
 //
 //  @copyright
+//  This source code is part of the Seamly2D project, a pattern making
+//  program to create and model patterns of clothing.
 //  Copyright (C) 2017 - 2025 Seamly, LLC
 //  https://github.com/fashionfreedom/seamly2d
 //
@@ -186,6 +188,7 @@ private:
     bool                        flagPieceLabelAnchor;
     bool                        flagPatternLabelAnchor;
     bool                        flagGrainlineFormula;
+    bool                        flagGrainlineArrow;
     bool                        flagPieceLabelAngle;
     bool                        flagPieceLabelFormula;
     bool                        flagPatternLabelAngle;

--- a/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
+++ b/src/libs/vtools/dialogs/tools/piece/pattern_piece_dialog.ui
@@ -4107,7 +4107,17 @@ QListWidget::item:selected {
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_15">
          <item>
-          <widget class="QGroupBox" name="grainline_GroupBox">
+          <widget class="QCheckBox" name="showGrainline_CheckBox">
+           <property name="text">
+            <string>Show grainline</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="grainlineGeometry_GroupBox">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
              <horstretch>0</horstretch>
@@ -4121,10 +4131,10 @@ QListWidget::item:selected {
             </font>
            </property>
            <property name="title">
-            <string>Show grainline</string>
+            <string>Geometry</string>
            </property>
            <property name="checkable">
-            <bool>true</bool>
+            <bool>false</bool>
            </property>
            <property name="checked">
             <bool>false</bool>
@@ -4932,8 +4942,8 @@ QListWidget::item:selected {
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>362</width>
-              <height>558</height>
+              <width>264</width>
+              <height>486</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_8">


### PR DESCRIPTION
This PR fixes the grainline length & arrow prefs that prevent creating a new patten piece - #1393 & #1395.

Adds or fixes the following:

- Ignores the default grainline length pref if it is less than twice the arrow length. Ensures the grainlne length is at least 2.1 times the arrow length so the CheckState() routine in the Pattern Piece dialog doesnt fail and disable the OK button. The 2.1 factor allows for rounding error in converting px to units and mutilpying by 2, then comparing. Also leaves a gap between the 2 arrows. 

- Displays the grainline "Length" label in red if it less than twice the arrow length as an indication there will be an error in the length. 

- Default arrow length is now 48px ( .5 in / 1.27cm) for new installs, and converts the arrow length from pixels to the pattern units. 

- Displays a label with the converted value from px to units. 

<img width="646" height="282" alt="image" src="https://github.com/user-attachments/assets/f151da67-0079-4e38-a6cf-ecb730f9061c" />

closes issue #1393 
