### PR TITLE
bug: fix variables table refresh

### DIFF
--- a/src/app/seamly2d/dialogs/dialogvariables.cpp
+++ b/src/app/seamly2d/dialogs/dialogvariables.cpp
@@ -119,7 +119,6 @@ DialogVariables::DialogVariables(VContainer *data, VPattern *doc, QWidget *paren
     fillArcsRadiuses();
     fillCurveAngles();
 
-
     tableList.append(QSharedPointer<QTableWidget>(ui->variables_TableWidget));
     tableList.append(QSharedPointer<QTableWidget>(ui->lineLengths_TableWidget));
     tableList.append(QSharedPointer<QTableWidget>(ui->lineAngles_TableWidget));
@@ -129,14 +128,10 @@ DialogVariables::DialogVariables(VContainer *data, VPattern *doc, QWidget *paren
     tableList.append(QSharedPointer<QTableWidget>(ui->arcRadiuses_TableWidget));
 
     connect(this->doc, &VPattern::FullUpdateFromFile, this, &DialogVariables::FullUpdateFromFile);
-
-    connect(this->doc, &VPattern::patternClosed, [this]()
-    {
-        close();
-    });
+    connect(this->doc, &VPattern::patternClosed,      this, [this](){ close(); });
 
     ui->tabWidget->setCurrentIndex(0);
-    ui->name_LineEdit->setValidator( new QRegularExpressionValidator(QRegularExpression(
+    ui->name_LineEdit->setValidator(new QRegularExpressionValidator(QRegularExpression(
                                                                         QLatin1String("^$|")+NameRegExp()), this));
 
     connect(ui->variables_TableWidget, &QTableWidget::itemSelectionChanged, this,

--- a/src/app/seamly2d/dialogs/dialogvariables.cpp
+++ b/src/app/seamly2d/dialogs/dialogvariables.cpp
@@ -130,6 +130,11 @@ DialogVariables::DialogVariables(VContainer *data, VPattern *doc, QWidget *paren
 
     connect(this->doc, &VPattern::FullUpdateFromFile, this, &DialogVariables::FullUpdateFromFile);
 
+    connect(this->doc, &VPattern::patternClosed, [this]()
+    {
+        close();
+    });
+
     ui->tabWidget->setCurrentIndex(0);
     ui->name_LineEdit->setValidator( new QRegularExpressionValidator(QRegularExpression(
                                                                         QLatin1String("^$|")+NameRegExp()), this));

--- a/src/app/seamly2d/mainwindow.cpp
+++ b/src/app/seamly2d/mainwindow.cpp
@@ -4418,6 +4418,8 @@ void MainWindow::Clear()
 //---------------------------------------------------------------------------------------------------------------------
 void MainWindow::FileClosedCorrect()
 {
+    emit doc->patternClosed();
+    
     WriteSettings();
 
     //File was closed correct.

--- a/src/libs/ifc/xml/vabstractpattern.h
+++ b/src/libs/ifc/xml/vabstractpattern.h
@@ -477,6 +477,7 @@ signals:
      * @brief patternChanged emit if we have unsaved change.
      */
     void           patternChanged(bool saved);
+    void           patternClosed(); ///@brief emit patternClosed to clear variable table.
     void           updatePatternLabel();
     /**
      * @brief ShowTool highlight tool.

--- a/src/libs/vtools/undocommands/addtocalc.cpp
+++ b/src/libs/vtools/undocommands/addtocalc.cpp
@@ -100,6 +100,7 @@ void AddToCalc::undo()
         return;
     }
     emit NeedFullParsing();
+    emit doc->FullUpdateFromFile();
     VMainGraphicsView::NewSceneRect(qApp->getCurrentScene(), qApp->getSceneView());
     doc->setCurrentDraftBlock(activeBlockName);//Return current pattern piece after undo
 }
@@ -148,6 +149,7 @@ void AddToCalc::RedoFullParsing()
     if (redoFlag)
     {
         emit NeedFullParsing();
+        emit doc->FullUpdateFromFile();
         doc->setCurrentDraftBlock(activeBlockName);//Return current pattern piece after undo
     }
     else

--- a/src/libs/vtools/undocommands/deltool.cpp
+++ b/src/libs/vtools/undocommands/deltool.cpp
@@ -81,6 +81,7 @@ void DelTool::undo()
 
     UndoDeleteAfterSibling(parentNode, siblingId);
     emit NeedFullParsing();
+    emit doc->FullUpdateFromFile();
     //Keep last!
     doc->setCurrentDraftBlock(activeBlockName);//Without this user will not see this change
 }
@@ -95,4 +96,5 @@ void DelTool::redo()
     QDomElement domElement = doc->NodeById(nodeId);
     parentNode.removeChild(domElement);
     emit NeedFullParsing();
+    emit doc->FullUpdateFromFile();
 }

--- a/src/libs/vtools/undocommands/vundocommand.cpp
+++ b/src/libs/vtools/undocommands/vundocommand.cpp
@@ -80,6 +80,7 @@ void VUndoCommand::RedoFullParsing()
     if (redoFlag)
     {
         emit NeedFullParsing();
+        emit doc->FullUpdateFromFile();
     }
     else
     {


### PR DESCRIPTION
This fixes several cases where the Variables Table dialog does not refresh when tools are deleted, or as the case is close when the pattern is closed. 

- Adds emitting FullUpdateFromFile signals to Undo's for when either a tool is deleted, or Undo'ing a tool that was added... as well as Redo'ing a when a tool is undone. This signal is then handled by the DialogVariables to refresh the data in the tables. 

- Added new VAbstractPattern::patternClosed() signal which is emmited when a pattern is closed, which is then handled by DialogVariables  to close the dialog instead of leaving it open filled with invalid tables. 

closes issue #1398 