### PR TITLE
feature: change search higtlight colors

### DIFF
--- a/src/libs/vmisc/vtablesearch.cpp
+++ b/src/libs/vmisc/vtablesearch.cpp
@@ -88,12 +88,12 @@ void VTableSearch::find(const QString &text)
         {
             for (QTableWidgetItem *item : m_searchList)
             {
-                item->setBackground(QColor("#FFDEDE"));
+                item->setBackground(QColor("#FAFAC8"));
             }
 
             m_searchIndex = 0;
             QTableWidgetItem *item = m_searchList.at(m_searchIndex);
-            item->setBackground(QColor("#FFBABA"));
+            item->setBackground(QColor("#FAFA5A"));
             m_table->scrollToItem(item);
 
             emit hasResult(true);
@@ -185,7 +185,7 @@ void VTableSearch::refreshList(const QString &text)
 
     for (QTableWidgetItem *item : m_searchList)
     {
-        item->setBackground(QColor("#FFDEDE"));
+        item->setBackground(QColor("#FAFAC8"));
     }
 
     if (!m_searchList.isEmpty())
@@ -200,7 +200,7 @@ void VTableSearch::refreshList(const QString &text)
         }
 
         QTableWidgetItem *item = m_searchList.at(m_searchIndex);
-        item->setBackground(QColor("#FFBABA"));
+        item->setBackground(QColor("#FAFA5A"));
         m_table->scrollToItem(item);
 
         emit hasResult(true);
@@ -266,10 +266,10 @@ void VTableSearch::showNext(int newIndex)
     if (!m_searchList.isEmpty())
     {
         QTableWidgetItem *item = m_searchList.at(m_searchIndex);
-        item->setBackground(QColor("#FFDEDE"));
+        item->setBackground(QColor("#FAFAC8"));
 
         item = m_searchList.at(newIndex);
-        item->setBackground(QColor("#FFBABA"));
+        item->setBackground(QColor("#FAFA5A"));
         m_table->scrollToItem(item);
         m_searchIndex = newIndex;
     }


### PR DESCRIPTION
To avoid user confusion - This changes the search hightlight colors in the History dialog and SeamlyMe from pink:

<img width="789" height="275" alt="image" src="https://github.com/user-attachments/assets/6ba1bcf6-7d0b-4b3a-bb38-f95320212b1d" />

to yellow:

<img width="791" height="264" alt="image" src="https://github.com/user-attachments/assets/214bf80b-e3aa-4d81-891f-94ff06bc2c3a" />

close issue #1410 