### PR TITLE
BUG: remove linetype nopen from internal paths

### DIFF
--- a/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.cpp
+++ b/src/libs/vtools/dialogs/tools/piece/internal_path_dialog.cpp
@@ -101,6 +101,9 @@ InternalPathDialog::InternalPathDialog(const VContainer *data, quint32 toolId, Q
     initializeSeamAllowanceTab();
     initializeNotchesTab();
 
+    //remove linetype "No Pen" item
+    ui->lineType_ComboBox->removeItem(ui->lineType_ComboBox->findData(LineTypeNone));
+
     flagName = true;//We have default name of piece.
     flagError = isValidPath();
     CheckState();


### PR DESCRIPTION
This removes the no pen linetype from the internal paths dialog so users can not set an invalid linetype for the "path" type. 

closes issue #1414 